### PR TITLE
First cut at a more idiomatic scala fastq reader.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -92,9 +92,7 @@ lazy val commonSettings = Seq(
   // uncomment for full stack traces
   //testOptions in Test  += Tests.Argument("-oD"),
   fork in Test         := true,
-  resolvers            += Resolver.jcenterRepo,
-  // uncomment this to use the  local resolver
-  resolvers            += Resolver.mavenLocal,
+  resolvers            += Resolver.sonatypeRepo("public"),
   shellPrompt          := { state => "%s| %s> ".format(GitCommand.prompt.apply(state), version.value) },
   updateOptions        := updateOptions.value.withCachedResolution(true)
 ) ++ Defaults.coreDefaultSettings
@@ -120,7 +118,7 @@ lazy val root = Project(id="fgbio", base=file("."))
   .settings(
     libraryDependencies ++= Seq(
       "org.scala-lang"            %  "scala-reflect" %  scalaVersion.value,
-	    "com.fulcrumgenomics"       %% "dagr-commons"  % "0.1.0",
+	    "com.fulcrumgenomics"       %% "dagr-commons"  % "0.1.1-SNAPSHOT",
 	    "com.fulcrumgenomics"       %% "dagr-sopt"     % "0.1.0",
       "com.github.samtools"       %  "htsjdk"        % "2.1.0" excludeAll(htsjdkAndPicardExcludes: _*),
       "com.github.broadinstitute" %  "picard"        % "2.1.0" excludeAll(htsjdkAndPicardExcludes: _*),

--- a/src/main/scala/com/fulcrumgenomics/fastq/FastqRecord.scala
+++ b/src/main/scala/com/fulcrumgenomics/fastq/FastqRecord.scala
@@ -1,0 +1,29 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.fulcrumgenomics.fastq
+
+/**
+  * Represents a record that can be read from or written to a fastq file.
+  */
+case class FastqRecord(name: String, bases: String, quals: String, comment: Option[String], readNumber: Option[Int])

--- a/src/main/scala/com/fulcrumgenomics/fastq/FastqSource.scala
+++ b/src/main/scala/com/fulcrumgenomics/fastq/FastqSource.scala
@@ -1,0 +1,112 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.fulcrumgenomics.fastq
+
+import java.io._
+
+import com.fulcrumgenomics.util.Io
+import dagr.commons.CommonsDef.{PathToFastq, yieldAndThen}
+
+import scala.io.Source
+
+/**
+  * Provides factory methods for creating a `FastqSource` from multiple types.
+  */
+object FastqSource {
+  /** Creates a new fastq source from a sequence of lines. */
+  def apply(lines: Seq[String]): FastqSource = new FastqSource(lines.iterator)
+
+  /** Creates a new fastq source from an iterator of lines. */
+  def apply(lines: Iterator[String]): FastqSource = new FastqSource(lines)
+
+  /** Creates a new fastq source from an input stream. */
+  def apply(stream: InputStream): FastqSource = new FastqSource(Source.fromInputStream(stream).getLines(), Some(stream))
+
+  /** Creates a new fastq source from an input stream. */
+  def apply(source: Source): FastqSource = new FastqSource(source.getLines(), Some(source))
+
+  /** Creates a new fastq source from a File. */
+  def apply(file: File): FastqSource = apply(path=file.toPath)
+
+  /** Creates a new fastq source from a Path. */
+  def apply(path: PathToFastq): FastqSource = apply(Io.toInputStream(path))
+}
+
+
+/**
+  * Reads fastq records from any text based source via a reader. Ensures that lines come in
+  * the expected groupings of four lines with the correct headers, and that bases and qualities
+  * are of the same length.  The underlying reader is closed automatically when EOF is reached.
+  */
+class FastqSource private(val lines: Iterator[String],
+                          private[this] val source: Option[{ def close(): Unit }] = None)
+  extends Iterator[FastqRecord] with Closeable {
+  
+  private var nextRecord: Option[FastqRecord] = fetchNextRecord()
+
+  /** True if calling `next()` will yield another record, false otherwise. */
+  override def hasNext: Boolean = this.nextRecord.isDefined
+
+  /** Returns the next record if available, or throws an exception if none is available. */
+  override def next(): FastqRecord =  yieldAndThen(nextRecord.get) { this.nextRecord = fetchNextRecord() }
+
+  /** Short hand to throw an illegal state exception. */
+  private def illegal(msg: String): Nothing = throw new IllegalStateException(msg)
+
+  /** Sets the current record to None, and then attempts to read the next record from the input. */
+  private def fetchNextRecord() : Option[FastqRecord] = {
+    this.lines.take(4).toList match {
+      case Nil =>
+        None
+      case header :: seq :: qheader :: quals :: Nil =>
+        if (!header.startsWith("@"))    illegal(s"Fastq sequence header must start with @: ${header}")
+        if (!qheader.startsWith("+"))   illegal(s"Fastq quality header must start with +: ${qheader}")
+        if (seq.length != quals.length) illegal(s"Sequence and qualities not same length for record: ${header}")
+
+        // Destructure the header line into name, read number and comment
+        val (fullName, comment) = header.indexWhere(_.isWhitespace) match {
+          case -1 => (header.drop(1), None)
+          case i  => (header.substring(1, i), Some(header.substring(i+1)))
+        }
+
+        val (name, readNumber) = fullName.endsWith("/1") || fullName.endsWith("/2") match {
+          case true  => (fullName.dropRight(2), Some(fullName.last.asDigit))
+          case false => (fullName, None)
+        }
+
+        Some(FastqRecord(
+          name       = name,
+          bases      = seq,
+          quals      = quals,
+          comment    = comment,
+          readNumber = readNumber
+        ))
+      case header :: _ =>
+        illegal(s"Fastq source terminated mid-record at ${header}")
+    }
+  }
+
+  /** Closes the underlying reader; only necessary if EOF hasn't been reached. */
+  override def close(): Unit = this.source.foreach(_.close())
+}

--- a/src/main/scala/com/fulcrumgenomics/util/Io.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/Io.scala
@@ -1,0 +1,52 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */package com.fulcrumgenomics.util
+
+import java.io.{OutputStream, InputStream}
+import java.nio.file.{Files, Path}
+import java.util.zip.{GZIPOutputStream, GZIPInputStream}
+
+import dagr.commons.io.{PathUtil, IoUtil}
+
+/**
+  * Common IO Utility methods.
+  */
+object Io extends IoUtil {
+  val BufferSize = 16 * 1024
+
+  /** Adds the automatic handling of gzipped files when opening files for reading. */
+  override def toInputStream(path: Path): InputStream = {
+    PathUtil.extensionOf(path) match {
+      case Some(".gz") => new GZIPInputStream(Files.newInputStream(path), BufferSize)
+      case _           => super.toInputStream(path)
+    }
+  }
+
+  /** Adds the automatic handling of gzipped files when opening files for writing. */
+  override def toOutputStream(path: Path): OutputStream = {
+    PathUtil.extensionOf(path) match {
+      case Some(".gz") => new GZIPOutputStream(Files.newOutputStream(path), BufferSize)
+      case _           => super.toOutputStream(path)
+    }
+  }
+}

--- a/src/test/scala/com/fulcrumgenomics/fastq/FastqSourceTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/fastq/FastqSourceTest.scala
@@ -1,0 +1,73 @@
+package com.fulcrumgenomics.fastq
+
+import com.fulcrumgenomics.testing.UnitSpec
+import dagr.commons.io.Io
+
+object FastqSourceTest {
+  val someFastq =
+    """
+      |@Foo:279:000000000-ABCDE:1:1101:15033:1749 1:N:0:18
+      |ATGACTGCGTATATATGACGTCGTGCTA
+      |+
+      |-,86,,;:C,<;-,86,,;:C,<;-,86
+      |@Foo:279:000000000-ABCDE:1:1101:12430:1790 1:N:0:18
+      |ATAGCTATGAGCTGCTGCTGA
+      |+
+      |8,,8,++++8788,,8,++++
+      |@Foo:279:000000000-ABCDE:1:1101:9471:1291/1 1:N:0:18
+      |CCCCCCCTCCTTGGGGGGGAGAGGG
+      |+Foo:279:000000000-ABCDE:1:1101:9471:1291/1 1:N:0:18
+      |AAA,,++78,66AAA,,++78,666
+    """.stripMargin.trim().lines.toSeq.dropWhile(_.isEmpty)
+
+  val someFastqRecords = Seq(
+    FastqRecord("Foo:279:000000000-ABCDE:1:1101:15033:1749", "ATGACTGCGTATATATGACGTCGTGCTA", "-,86,,;:C,<;-,86,,;:C,<;-,86", Some("1:N:0:18"), None),
+    FastqRecord("Foo:279:000000000-ABCDE:1:1101:12430:1790", "ATAGCTATGAGCTGCTGCTGA",        "8,,8,++++8788,,8,++++",        Some("1:N:0:18"), None),
+    FastqRecord("Foo:279:000000000-ABCDE:1:1101:9471:1291",  "CCCCCCCTCCTTGGGGGGGAGAGGG",    "AAA,,++78,66AAA,,++78,666",    Some("1:N:0:18"), Some(1))
+  )
+}
+
+/**
+  * Tests for the FastqSource
+  */
+class FastqSourceTest extends UnitSpec {
+  "FastqSource" should "read valid fastq from various kinds of input resources" in {
+    val fq = makeTempFile("some", ".fq")
+    Io.writeLines(fq, FastqSourceTest.someFastq)
+
+    Seq(FastqSource(fq), FastqSource(fq.toFile), FastqSource(Io.toInputStream(fq)), FastqSource(FastqSourceTest.someFastq)).foreach(source => {
+      source.hasNext shouldBe true
+      source.next shouldBe FastqSourceTest.someFastqRecords(0)
+      source.hasNext shouldBe true
+      source.next shouldBe FastqSourceTest.someFastqRecords(1)
+      source.hasNext shouldBe true
+      source.next shouldBe FastqSourceTest.someFastqRecords(2)
+      source.hasNext shouldBe false
+      an[NoSuchElementException] shouldBe thrownBy { source.next() }
+    })
+  }
+
+  it should "throw an exception if a header line doesn't start with an @" in {
+    val fq = makeTempFile("some", ".fq")
+    Io.writeLines(fq, Seq("foo", "ACGT", "+", "7777"))
+    an[IllegalStateException] shouldBe thrownBy { FastqSource(fq) }
+  }
+
+  it should "throw an exception if a quality header line doesn't start with an +" in {
+    val fq = makeTempFile("some", ".fq")
+    Io.writeLines(fq, Seq("@foo", "ACGT", "@", "7777"))
+    an[IllegalStateException] shouldBe thrownBy { FastqSource(fq) }
+  }
+
+  it should "throw an exception if there are not n*4 lines" in {
+    val fq = makeTempFile("some", ".fq")
+    Io.writeLines(fq, Seq("@foo", "ACGT", "+foo"))
+    an[IllegalStateException] shouldBe thrownBy { FastqSource(fq) }
+  }
+
+  it should "throw an exception if seqs and quals are not the same length for a record" in {
+    val fq = makeTempFile("some", ".fq")
+    Io.writeLines(fq, Seq("@foo", "ACGT", "+foo", "12345"))
+    an[IllegalStateException] shouldBe thrownBy { FastqSource(fq) }
+  }
+}

--- a/src/test/scala/com/fulcrumgenomics/testing/UnitSpec.scala
+++ b/src/test/scala/com/fulcrumgenomics/testing/UnitSpec.scala
@@ -1,0 +1,38 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.fulcrumgenomics.testing
+
+import java.nio.file.{Path, Files}
+
+import org.scalatest.{FlatSpec, Matchers}
+
+/** Base class for unit and integration testing */
+trait UnitSpec extends FlatSpec with Matchers {
+  /** Creates a new temp file for use in testing that will be deleted when the VM exits. */
+  protected def makeTempFile(prefix: String, suffix: String) : Path = {
+    val path = Files.createTempFile(prefix, suffix)
+    path.toFile.deleteOnExit()
+    path
+  }
+}

--- a/src/test/scala/com/fulcrumgenomics/util/IoTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/util/IoTest.scala
@@ -1,0 +1,55 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */package com.fulcrumgenomics.util
+
+import java.io.{BufferedReader, FileInputStream, InputStreamReader}
+import java.util.zip.GZIPInputStream
+
+import com.fulcrumgenomics.testing.UnitSpec
+
+/**
+  * Tests for the Io utility class.
+  */
+class IoTest extends UnitSpec {
+
+  "Io" should "open a file for gzip writing if it ends with .gz" in {
+    val text = "This is a stupid little text fragment for compression. Yay compression!"
+    val in   = Seq(text, text, text)
+    val f = makeTempFile("test", ".gz")
+    Io.writeLines(f, in)
+
+    // Manually read it back as gzipped data
+    val reader = new BufferedReader(new InputStreamReader(new GZIPInputStream(new FileInputStream(f.toFile))))
+    val out = Seq(reader.readLine(), reader.readLine(), reader.readLine())
+    out shouldBe in
+  }
+
+  "Io" should "round trip data to a gzipped file if it ends with .gz" in {
+    val text = "This is a stupid little text fragment for compression. Yay compression!"
+    val in   = Seq(text, text, text)
+    val f = makeTempFile("test", ".gz")
+    Io.writeLines(f, in)
+    val out = Io.readLines(f).toSeq
+    out shouldBe in
+  }
+}


### PR DESCRIPTION
@nh13 This isn't quite read for prime time, because it won't automatically handle `.gz` fastq file which is obviously needed.  We either need to implement `.gz` auto-handling in dagr-commons `Io`, or do something different in fgbio.  Thoughts?