### PR TITLE
Adding a tool to update read groups.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/bam/UpdateReadGroups.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/UpdateReadGroups.scala
@@ -1,0 +1,149 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.fulcrumgenomics.bam
+
+import com.fulcrumgenomics.cmdline.{ClpGroups, FgBioTool}
+import com.fulcrumgenomics.util.ProgressLogger
+import dagr.commons.CommonsDef._
+import dagr.commons.io.Io
+import dagr.commons.util.LazyLogging
+import dagr.sopt._
+import htsjdk.samtools._
+
+import scala.collection.JavaConversions._
+
+/**
+  * Updates one or more read groups.
+  *
+  * @author Nils Homer
+  */
+@clp(description =
+  """
+      |Updates one or more read groups and their identifiers.
+      |
+      |This tool will replace each read group with a new read group, including a new read group identifier.  If the read
+      |group identifier is not to be changed, it is recommended to use `samtools reheader` or Picard's
+      |`ReplaceSamHeader` instead as in this case only the header needs modification. If all read groups are to be
+      |assigned to one read group, it is recommended to use Picard's `AddOrReplaceReadGroups`.  Nonetheless, if the read
+      |group identifier also needs to be changed, use this tool.
+      |
+      |Each read group in the input file will be mapped to one and only one new read group identifier, unless
+      |`ignoreMissingReadGroups` is set.  A SAM header file should be given with the new read groups and the ID field
+      |foreach read group containing the new read group identifier.  An additional attribute ("FR") should be provided
+      |that gives the original read group identifier ("ID") to which this new read group corresponds.
+      |
+      |If `keepReadGroupAttributes` is true, then any read group attribute not replaced will be kept in the new read
+      |group.  Otherwise, only the attributes in the provided SAM header file will be used.
+    """,
+  group = ClpGroups.SamOrBam)
+class UpdateReadGroups
+(@arg(flag = "i", doc = "Input BAM file.") val input: PathToBam,
+ @arg(flag = "o", doc = "Output BAM file.") val output: PathToBam,
+ @arg(flag = "r", doc = "A SAM header file with the replacement read groups (see detailed usage).") val readGroupsFile: PathToBam,
+ @arg(flag = "k", doc = "Keep all read group attributes that are not replaced.") val keepReadGroupAttributes: Boolean = false,
+ @arg(flag = "g", doc = "Keep all read groups not found in the replacement header, otherwise throw an error.") val ignoreMissingReadGroups: Boolean = false
+) extends FgBioTool with LazyLogging {
+
+  private val fromReadGroupKey = "FR"
+
+  Io.assertReadable(input)
+  Io.assertReadable(readGroupsFile)
+  Io.assertCanWriteFile(output)
+
+  override def execute(): Unit = {
+    val progress: ProgressLogger = new ProgressLogger(logger)
+
+    val in: SamReader = SamReaderFactory.make.open(input.toFile)
+    val toReadGroupsMap = getReadGroupMap(readGroupsFile, in.getFileHeader)
+    val outHeader = in.getFileHeader.clone()
+    outHeader.setReadGroups(toReadGroupsMap.values.toList.sortBy(_.getId))
+    val out: SAMFileWriter = new SAMFileWriterFactory().makeSAMOrBAMWriter(outHeader, true, output.toFile)
+
+    // main loop
+    in.foreach { record =>
+      updateRecord(record, outHeader, toReadGroupsMap)
+      out.addAlignment(record)
+      progress.record(record)
+    }
+    logger.info(s"Processed ${progress.getCount} in ${progress.getElapsedSeconds} seconds")
+
+    in.safelyClose()
+    out.close()
+  }
+
+  private def updateRecord(record: SAMRecord,
+                           header: SAMFileHeader,
+                           readGroupMap: Map[String, SAMReadGroupRecord]): SAMRecord = {
+    val fromReadGroup = record.getReadGroup match {
+      case null => fail(s"Record '${record.getReadName}' has no read group")
+      case rg => rg
+    }
+    readGroupMap.get(fromReadGroup.getId) match {
+      case None => unreachable(s"Read group id '${record.getReadGroup.getId}' from record '${record.getReadName}' not found in the SAM header.")
+      case Some(readGroup: SAMReadGroupRecord) =>
+        record.setAttribute(SAMTag.RG.name(), readGroup.getId)
+        record.setHeader(header)
+    }
+    record
+  }
+
+  private def getReadGroupMap(readGroupsFile: FilePath, samFileHeader: SAMFileHeader): Map[String, SAMReadGroupRecord] = {
+    val fromReadGroups = samFileHeader.getReadGroups.map { rg => rg.getId -> rg }.toMap
+
+    // get the header
+    val reader = SamReaderFactory.make.open(readGroupsFile)
+    val h = reader.getFileHeader
+    reader.safelyClose()
+
+    // map from the "FR" attribute value to the new read group
+    val readGroupMap = h.getReadGroups.map { rg =>
+      rg.getAttribute(fromReadGroupKey) match {
+        case null => fail(s"'$fromReadGroupKey' attribute not found in read group: " + rg.toString)
+        case fromId =>
+          // remove the "FR" attribute
+          rg.setAttribute(fromReadGroupKey, null)
+          // verify the `id` is found in `fromReadGroups`
+          if (!fromReadGroups.contains(fromId)) fail(s"Read group id '$fromId' not found in input BAM file.")
+          // keep the old attributes that are not being overwritten
+          if (keepReadGroupAttributes) {
+            // find all read group attributes that are not present in the new read group and add those attributes to the new read group
+            fromReadGroups(fromId).getAttributes.filter(attr => rg.getAttribute(attr.getKey) == null).foreach { attr => rg.setAttribute(attr.getKey, attr.getValue) }
+          }
+          fromId -> rg
+      }
+    }.toMap
+
+    // get the read groups in the original file that are not being updated
+    val missingReadGroups = samFileHeader.getReadGroups.filter(rg => !readGroupMap.contains(rg.getId)).map(rg => rg.getId -> rg).toMap
+    
+    if (ignoreMissingReadGroups) {
+      readGroupMap ++ missingReadGroups
+    }
+    else if (missingReadGroups.nonEmpty) fail("Read groups found that are not being replaced: " + missingReadGroups.keys.mkString(", "))
+    else {
+      readGroupMap
+    }
+  }
+}

--- a/src/test/scala/com/fulcrumgenomics/bam/UpdateReadGroupsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/UpdateReadGroupsTest.scala
@@ -1,0 +1,223 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 Fulcrum Genomics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package com.fulcrumgenomics.bam
+
+import java.nio.file.Files
+
+import com.fulcrumgenomics.testing.{SamRecordSetBuilder, UnitSpec}
+import dagr.commons.CommonsDef._
+import htsjdk.samtools.SAMFileHeader.SortOrder
+import htsjdk.samtools._
+
+import scala.collection.JavaConversions._
+
+/**
+  * Tests for UpdateReadGroups.
+  */
+class UpdateReadGroupsTest extends UnitSpec {
+  def newBam = makeTempFile("update_read_group_test.", ".bam")
+
+  private val builderOne   = new SamRecordSetBuilder(sortOrder=SortOrder.coordinate, readGroupId=Some("IDA"))
+  private val builderTwo   = new SamRecordSetBuilder(sortOrder=SortOrder.coordinate, readGroupId=Some("IDB"))
+
+  Stream(builderOne, builderTwo).foreach { builder =>
+    builder.addPair("ok_1" + builder.readGroupId.get, 0, 100, 300)
+    builder.addPair("ok_2" + builder.readGroupId.get, 0, 200, 400)
+    builder.header.getReadGroups.foreach { rg => rg.setDescription("Description") }
+  }
+
+  private val headerAtoB              = makeHeader(("IDA", "IDB"))
+  private val headerAandBtoCandD      = makeHeader(("IDA", "IDC"), ("IDB", "IDD"))
+  private val headerBtoC              = makeHeader(("IDB", "IDC"))
+  private val headerAtoBWithNewSample = makeHeaderWithNewSample(("IDA", "IDB", "NoName"))
+
+  /** toFr are tuples, where each triple is old read group ID ("FR"), the new read group ID, and new sample name ("SM"). */
+  def makeHeaderWithNewSample(fromAndTo: (String, String, String)*): SAMFileHeader = {
+    val header = makeHeader(fromAndTo.map(x => (x._1, x._2)):_*)
+    fromAndTo.foreach { case ((fr, to, sn)) => header.getReadGroup(to).setSample(sn) }
+    header
+  }
+
+  /** toFr are tuples, where each tuple is old read group ID ("FR") and the new read group ID. */
+  def makeHeader(fromAndTo: (String, String)*): SAMFileHeader = {
+    val header = new SAMFileHeader()
+    fromAndTo.foreach { case (fr, to) =>
+      val rg = new SAMReadGroupRecord(to)
+      rg.setSample("Sample")
+      rg.setAttribute("FR", fr)
+      header.addReadGroup(rg)
+    }
+    header
+  }
+
+  /** Writes the given SAM file header to a BAM file. */
+  def headerToTempFile(header: SAMFileHeader): PathToBam = {
+    val path = Files.createTempFile("SamRecordSet.", ".bam")
+    path.toFile.deleteOnExit()
+    val writer = new SAMFileWriterFactory()
+      .setCreateIndex(true)
+      .makeWriter(header, false, path.toFile, null)
+    writer.close()
+    path
+  }
+
+  /** Creates a temp SAM file after merging the header and records from multiple builders. */
+  def mergeToTempFile(builder: SamRecordSetBuilder*): PathToBam = {
+    val path = Files.createTempFile("SamRecordSet.", ".bam")
+    path.toFile.deleteOnExit()
+    val merger = new SamFileHeaderMerger(SortOrder.coordinate, builder.map(_.header), false)
+    val header = merger.getMergedHeader
+    merger.hasReadGroupCollisions shouldBe false
+    val writer = new SAMFileWriterFactory()
+      .setCreateIndex(true)
+      .makeWriter(header, false, path.toFile, null)
+    builder.foreach { b => b.iterator.foreach(writer.addAlignment) }
+    writer.close()
+    path
+  }
+
+  "UpdateReadGroups" should "change the read group ID from IDA to IDB with an extra read group in the input file" in {
+    val out = newBam
+    new UpdateReadGroups(input=builderOne.toTempFile(), output=out, readGroupsFile=headerToTempFile(headerAtoB), ignoreMissingReadGroups=true).execute()
+    val reader = SamReaderFactory.make.open(out.toFile)
+    reader.iterator().foreach { rec => rec.getReadGroup.getId shouldBe headerAtoB.getReadGroups.head.getId }
+    reader.close()
+  }
+
+  it should "change the read group ID from IDA to IDB" in {
+    // remove the read group with ID "1" from the builder :/
+    val builder = new SamRecordSetBuilder(sortOrder=SortOrder.coordinate, readGroupId=Some("IDA"))
+    builder.addPair("ok_1" + builder.readGroupId.get, 0, 100, 300)
+    builder.addPair("ok_2" + builder.readGroupId.get, 0, 200, 400)
+    builder.header.setReadGroups(builder.header.getReadGroups.filter { rg => rg.getId == "IDA" })
+    val out = newBam
+    new UpdateReadGroups(input=builder.toTempFile(), output=out, readGroupsFile=headerToTempFile(headerAtoB), ignoreMissingReadGroups=false).execute()
+    val reader = SamReaderFactory.make.open(out.toFile)
+    reader.iterator().foreach { rec => rec.getReadGroup.getId shouldBe headerAtoB.getReadGroups.head.getId }
+    reader.close()
+  }
+
+  it should "change two read groups (IDA, IDB) to (IDC, IDD)" in {
+    val in  = mergeToTempFile(builderOne, builderTwo)
+    val out = newBam
+    new UpdateReadGroups(input=in, output=out, readGroupsFile=headerToTempFile(headerAandBtoCandD), ignoreMissingReadGroups=true).execute()
+    val reader = SamReaderFactory.make.open(out.toFile)
+    val builderOneReadNames = builderOne.iterator.map(_.getReadName).toSet
+    reader.iterator().foreach { rec =>
+      if (builderOneReadNames.contains(rec.getReadName)) rec.getReadGroup.getId shouldBe "IDC"
+      else rec.getReadGroup.getId shouldBe "IDD"
+    }
+    reader.close()
+  }
+
+  it should "fail if missing read groups when ignoreMissingReadGroups is false" in {
+    val out = newBam
+    an[Exception] should be thrownBy new UpdateReadGroups(input=builderOne.toTempFile(), output=out, readGroupsFile=headerToTempFile(headerAtoB), ignoreMissingReadGroups=false).execute()
+  }
+
+  it should "allow missing read groups when ignoreMissingReadGroups is true" in {
+    val out = newBam
+    // headerAtoB is missing read group "ID:1".
+    val builder = new SamRecordSetBuilder(sortOrder=SortOrder.coordinate, readGroupId=Some("IDA"))
+    builder.addPair("ok_1", 0, 100, 300).foreach { rec => rec.setAttribute(SAMTag.RG.name, "IDA") }
+    builder.addPair("ok_2", 0, 200, 400).foreach { rec => rec.setAttribute(SAMTag.RG.name, "1") }
+    new UpdateReadGroups(input=builder.toTempFile(), output=out, readGroupsFile=headerToTempFile(headerAtoB), ignoreMissingReadGroups=true).execute()
+    val reader = SamReaderFactory.make.open(out.toFile)
+    reader.iterator().foreach { rec =>
+      if (rec.getReadName == "ok_1") rec.getReadGroup.getId shouldBe "IDB"
+      else rec.getReadGroup.getId shouldBe "1"
+    }
+    reader.close()
+  }
+
+  it should "not keep any read group attributes if keepReadGroupAttributes is false" in {
+    val out = newBam
+    new UpdateReadGroups(
+      input                   = builderOne.toTempFile(),
+      output                  = out,
+      readGroupsFile          = headerToTempFile(headerAtoBWithNewSample),
+      ignoreMissingReadGroups = true,
+      keepReadGroupAttributes = false
+    ).execute()
+    val reader = SamReaderFactory.make.open(out.toFile)
+    reader.iterator().foreach { rec =>
+      rec.getReadGroup.getId shouldBe headerAtoBWithNewSample.getReadGroups.head.getId
+      rec.getReadGroup.getSample shouldBe "NoName"
+      rec.getReadGroup.getDescription shouldBe null
+    }
+    reader.close()
+  }
+
+  it should "keep read group attributes if keepReadGroupAttributes is true" in {
+    val out = newBam
+    new UpdateReadGroups(
+      input                   = builderOne.toTempFile(),
+      output                  = out,
+      readGroupsFile          = headerToTempFile(headerAtoBWithNewSample),
+      ignoreMissingReadGroups = true,
+      keepReadGroupAttributes = true
+    ).execute()
+    val reader = SamReaderFactory.make.open(out.toFile)
+    reader.iterator().foreach { rec =>
+      rec.getReadGroup.getId shouldBe headerAtoBWithNewSample.getReadGroups.head.getId
+      rec.getReadGroup.getSample shouldBe "NoName" // overwritten
+      rec.getReadGroup.getDescription shouldBe "Description" // kept!
+    }
+    reader.close()
+  }
+
+  it should "fail if the new SAM header file has a read group without a \"FR\" attribute" in {
+    val out = newBam
+    an[Exception] should be thrownBy new UpdateReadGroups(
+      input                   = builderOne.toTempFile(),
+      output                  = out,
+      readGroupsFile          = headerToTempFile(builderOne.header),
+      ignoreMissingReadGroups = true
+    ).execute()
+  }
+
+  it should "fail if the new SAM header file has a \"FR\" attribute that is not found in the input SAM file" in {
+    val out = newBam
+    an[Exception] should be thrownBy new UpdateReadGroups(
+      input                   = builderOne.toTempFile(),
+      output                  = out,
+      readGroupsFile          = headerToTempFile(headerBtoC),
+      ignoreMissingReadGroups = true
+    ).execute()
+  }
+
+  it should "fail if a record in the input file has no read group" in {
+    val out = newBam
+    val builder = new SamRecordSetBuilder(sortOrder=SortOrder.coordinate, readGroupId=Some("IDA"))
+    builder.addPair("ok_1" + builder.readGroupId.get, 0, 100, 300).foreach { rec => rec.setAttribute("RG", null); }
+    an[Exception] should be thrownBy new UpdateReadGroups(
+      input                   = builder.toTempFile(),
+      output                  = out,
+      readGroupsFile          = headerToTempFile(headerAtoB),
+      ignoreMissingReadGroups = true
+    ).execute()
+  }
+}


### PR DESCRIPTION
This differs from Picard's AddOrReplaceReadGroups since we do not add
any read groups but merely update them.  We also can also update more
than one read group.