### PR TITLE
Bug fix an ArrayIndexOutOfBoundsException in PickIlluminaIndices.

### DIFF
--- a/src/main/java/com/fulcrumgenomics/util/PickIlluminaIndicesCommand.java
+++ b/src/main/java/com/fulcrumgenomics/util/PickIlluminaIndicesCommand.java
@@ -134,7 +134,7 @@ class PickIlluminaIndicesCommand {
             for (final Index that : this.related) {
                 final byte distance = calculateEditDistance(that);
 
-                _score += SCORE_BY_DISTANCE[distance];
+                if (distance < SCORE_BY_DISTANCE.length) _score += SCORE_BY_DISTANCE[distance];
                 if (distance < _minEditDistance) _minEditDistance = distance;
             }
         }


### PR DESCRIPTION
This occurs when you set the edit distance `> 3` since `SCORE_BY_DISTANCE` is static and has length 4.  Full stack trace is:
```
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: 4
        at com.fulcrumgenomics.util.PickIlluminaIndicesCommand$Index.recalculate(PickIlluminaIndicesCommand.java:137)
        at com.fulcrumgenomics.util.PickIlluminaIndicesCommand$Index.score(PickIlluminaIndicesCommand.java:111)
        at com.fulcrumgenomics.util.PickIlluminaIndicesCommand.lambda$rankBarcodes$1(PickIlluminaIndicesCommand.java:443)
        at com.fulcrumgenomics.util.PickIlluminaIndicesCommand$$Lambda$11/292958927.compare(Unknown Source)
        at java.util.concurrent.ConcurrentSkipListMap.cpr(ConcurrentSkipListMap.java:655)
        at java.util.concurrent.ConcurrentSkipListMap.doPut(ConcurrentSkipListMap.java:835)
        at java.util.concurrent.ConcurrentSkipListMap.putIfAbsent(ConcurrentSkipListMap.java:1962)
        at java.util.concurrent.ConcurrentSkipListSet.add(ConcurrentSkipListSet.java:241)
        at java.util.AbstractCollection.addAll(AbstractCollection.java:344)
        at com.fulcrumgenomics.util.PickIlluminaIndicesCommand.rankBarcodes(PickIlluminaIndicesCommand.java:452)
        at com.fulcrumgenomics.util.PickIlluminaIndicesCommand.execute(PickIlluminaIndicesCommand.java:299)
        at com.fulcrumgenomics.util.PickIlluminaIndices.execute(PickIlluminaIndices.scala:57)
        at com.fulcrumgenomics.cmdline.FgBioMain.makeItSo(FgBioMain.scala:54)
        at com.fulcrumgenomics.cmdline.FgBioMain$.main(FgBioMain.scala:36)
        at com.fulcrumgenomics.cmdline.FgBioMain.main(FgBioMain.scala)
```