### PR TITLE
Removed usage of PicardException, replace with fail()

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,7 @@ lazy val commonSettings = Seq(
 ////////////////////////////////////////////////////////////////////////////////////////////////
 // root project
 ////////////////////////////////////////////////////////////////////////////////////////////////
-lazy val htsjdkAndPicardExcludes = Seq(
+lazy val htsjdkExcludes = Seq(
   ExclusionRule(organization="org.apache.ant"),
   ExclusionRule(organization="gov.nih.nlm.ncbi"),
   ExclusionRule(organization="org.testng"),
@@ -121,8 +121,7 @@ lazy val root = Project(id="fgbio", base=file("."))
       "org.scala-lang"            %  "scala-reflect" %  scalaVersion.value,
 	    "com.fulcrumgenomics"       %% "dagr-commons"  % "0.1.1-SNAPSHOT",
 	    "com.fulcrumgenomics"       %% "dagr-sopt"     % "0.1.1-SNAPSHOT",
-      "com.github.samtools"       %  "htsjdk"        % "2.1.0" excludeAll(htsjdkAndPicardExcludes: _*),
-      "com.github.broadinstitute" %  "picard"        % "2.1.0" excludeAll(htsjdkAndPicardExcludes: _*),
+      "com.github.samtools"       %  "htsjdk"        % "2.1.0" excludeAll(htsjdkExcludes: _*),
       //---------- Test libraries -------------------//
       "org.scalatest"             %%  "scalatest"    %  "2.2.4" % "test->*" excludeAll ExclusionRule(organization="org.junit", name="junit")
     )

--- a/src/main/scala/com/fulcrumgenomics/personal/nhomer/HasSequence.scala
+++ b/src/main/scala/com/fulcrumgenomics/personal/nhomer/HasSequence.scala
@@ -37,7 +37,6 @@ import dagr.sopt._
 import htsjdk.samtools._
 import htsjdk.samtools.metrics.{MetricBase, MetricsFile}
 import htsjdk.samtools.util._
-import picard.PicardException
 
 import scala.io.Source
 
@@ -67,7 +66,7 @@ class HasSequence
     val reader = SamReaderFactory.makeDefault.open(input.toFile)
     val header = reader.getFileHeader
     if (header.getSortOrder ne SAMFileHeader.SortOrder.queryname) {
-      throw new PicardException("Expects a queryname sorted input file, was: " + header.getSortOrder.name)
+      fail("Expects a queryname sorted input file, was: " + header.getSortOrder.name)
     }
     val writer = new SAMFileWriterFactory().makeSAMOrBAMWriter(header, false, output.toFile)
     val histogram = new Histogram[String]

--- a/src/main/scala/com/fulcrumgenomics/personal/nhomer/SplitTag.scala
+++ b/src/main/scala/com/fulcrumgenomics/personal/nhomer/SplitTag.scala
@@ -31,7 +31,6 @@ import dagr.sopt._
 import dagr.sopt.cmdline.ValidationException
 import htsjdk.samtools.util.CloserUtil
 import htsjdk.samtools.{SAMFileWriter, SAMFileWriterFactory, SamReader, SamReaderFactory}
-import picard.PicardException
 import picard.util.IlluminaUtil
 
 import scala.collection.JavaConversions._
@@ -60,9 +59,9 @@ class SplitTag
     val writer: SAMFileWriter = new SAMFileWriterFactory().makeSAMOrBAMWriter(reader.getFileHeader, true, output.toFile)
     reader.foreach { record =>
       val value: String = record.getStringAttribute(tagToSplit)
-      if (value == null) throw new PicardException(String.format("Record '%s' was missing the tag '%s'", record.getReadName, tagToSplit))
+      if (value == null) fail(String.format("Record '%s' was missing the tag '%s'", record.getReadName, tagToSplit))
       val tokens: Array[String] = value.split(delimiter)
-      if (tokens.length != tagsToOutput.size) throw new PicardException(s"Record '${record.getReadName}' did not have '${tagsToOutput.size}' tokens")
+      if (tokens.length != tagsToOutput.size) fail(s"Record '${record.getReadName}' did not have '${tagsToOutput.size}' tokens")
       tagsToOutput.zip(tokens).foreach { case (tagToOutput, token) => record.setAttribute(tagToOutput, token) }
       writer.addAlignment(record)
     }

--- a/src/main/scala/com/fulcrumgenomics/personal/nhomer/SplitTag.scala
+++ b/src/main/scala/com/fulcrumgenomics/personal/nhomer/SplitTag.scala
@@ -31,7 +31,6 @@ import dagr.sopt._
 import dagr.sopt.cmdline.ValidationException
 import htsjdk.samtools.util.CloserUtil
 import htsjdk.samtools.{SAMFileWriter, SAMFileWriterFactory, SamReader, SamReaderFactory}
-import picard.util.IlluminaUtil
 
 import scala.collection.JavaConversions._
 
@@ -44,7 +43,7 @@ class SplitTag
   @arg(doc = "Output SAM or BAM.") val output: PathToBam,
   @arg(doc = "Tag to split.") val tagToSplit: String,
   @arg(doc = "Tag(s) to output.  There should be one per produced token.", minElements = 1) val tagsToOutput: List[String],
-  @arg(doc = "The delimiter used to split the string.") val delimiter: String = IlluminaUtil.BARCODE_DELIMITER
+  @arg(doc = "The delimiter used to split the string.") val delimiter: String = "-"
 ) extends FgBioTool {
 
   Io.assertReadable(input)

--- a/src/main/scala/com/fulcrumgenomics/util/IlluminaAdapters.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/IlluminaAdapters.scala
@@ -1,0 +1,56 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.fulcrumgenomics.util
+
+import htsjdk.samtools.util.SequenceUtil
+
+/** An object providing access to various Illumina adapter sequences. */
+object IlluminaAdapters {
+  sealed abstract class AdapterPair(fivePrime: String, threePrime: String) {
+    val      both = Seq(fivePrime, threePrime)
+    val      threePrimeReadOrder = threePrime
+    lazy val fivePrimeReadOrder  = SequenceUtil.reverseComplement(fivePrime)
+  }
+
+  case object PairedEnd extends AdapterPair("AATGATACGGCGACCACCGAGATCTACACTCTTTCCCTACACGACGCTCTTCCGATCT",
+                                            "AGATCGGAAGAGCGGTTCAGCAGGAATGCCGAGACCGATCTCGTATGCCGTCTTCTGCTTG")
+
+  case object Indexed extends AdapterPair("AATGATACGGCGACCACCGAGATCTACACTCTTTCCCTACACGACGCTCTTCCGATCT",
+                                          "AGATCGGAAGAGCACACGTCTGAACTCCAGTCACNNNNNNNNATCTCGTATGCCGTCTTCTGCTTG")
+
+  case object SingleEnd extends AdapterPair("AATGATACGGCGACCACCGAGATCTACACTCTTTCCCTACACGACGCTCTTCCGATCT",
+                                            "AGATCGGAAGAGCTCGTATGCCGTCTTCTGCTTG")
+
+  case object NexteraV1 extends AdapterPair("AATGATACGGCGACCACCGAGATCTACACGCCTCCCTCGCGCCATCAGAGATGTGTATAAGAGACAG",
+                                            "CTGTCTCTTATACACATCTCTGAGCGGGCTGGCAAGGCAGACCGNNNNNNNNATCTCGTATGCCGTCTTCTGCTTG")
+
+  case object NexteraV2 extends AdapterPair("AATGATACGGCGACCACCGAGATCTACACNNNNNNNNTCGTCGGCAGCGTCAGATGTGTATAAGAGACAG",
+                                            "CTGTCTCTTATACACATCTCCGAGCCCACGAGACNNNNNNNNATCTCGTATGCCGTCTTCTGCTTG")
+
+  case object DualIndexed extends AdapterPair("AATGATACGGCGACCACCGAGATCTNNNNNNNNACACTCTTTCCCTACACGACGCTCTTCCGATCT",
+                                              "AGATCGGAAGAGCACACGTCTGAACTCCAGTCACNNNNNNNNATCTCGTATGCCGTCTTCTGCTTG")
+
+  val all = Seq(PairedEnd, Indexed, SingleEnd, NexteraV1, NexteraV2, DualIndexed)
+}

--- a/src/main/scala/com/fulcrumgenomics/util/PickIlluminaIndices.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/PickIlluminaIndices.scala
@@ -5,7 +5,6 @@ import scala.collection.JavaConversions._
 import com.fulcrumgenomics.cmdline.{ClpGroups, FgBioTool}
 import dagr.commons.CommonsDef.{DirPath, FilePath}
 import dagr.sopt.{arg, clp}
-import picard.util.IlluminaUtil.IlluminaAdapterPair
 
 /**
   * Program for picking sets of indices of arbitrary length that meet certain constraints
@@ -32,9 +31,9 @@ class PickIlluminaIndices
   @arg(          doc="The installation directory for ViennaRNA.")                      val viennaRnaDir: DirPath,
   @arg(          doc="The lowest acceptable secondary structure deltaG.")              val minDeltaG: Double = -10,
   @arg(          doc="The indexed adapter sequence into which the indices will be integrated.")
-  val adapters: Seq[String] = Seq(IlluminaAdapterPair.DUAL_INDEXED.get5PrimeAdapter, IlluminaAdapterPair.DUAL_INDEXED.get3PrimeAdapter),
+  val adapters: Seq[String] = IlluminaAdapters.DualIndexed.both,
   @arg(          doc="Sequences that should be avoided.  Any kmer of 'length' that appears in these sequences and their " + "reverse complements will be thrown out.")
-  val avoidSequence: Seq[String] = IlluminaAdapterPair.values().flatMap(p => Seq(p.get5PrimeAdapter(), p.get3PrimeAdapter()))
+  val avoidSequence: Seq[String] = IlluminaAdapters.all.flatMap(_.both)
 ) extends FgBioTool{
 
   override def execute(): Unit = {


### PR DESCRIPTION
@nh13 I was thinking that since we have minimal dependencies on Picard it would be nice to be able to drop that dependency, and just depend on htsjdk.  What do you think?

The only remaining usages of Picard are:

1. `PickIlluminaIndices` references `IlluminaUtil.IlluminaAdapterPair`
1. `SplitTag` references `IlluminaUtil.BARCODE_DELIMITER` aka `-`.

The options as I see it are: 1) make a PR to push IlluminaUtil down into HTSJDK (it is standalone as far as I can tell) or 2) copy just the adapters and constants we need into a class in fgbio.