### PR TITLE
Extracting re-usable parts of the consensus caller.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReads.scala
@@ -26,7 +26,7 @@
 package com.fulcrumgenomics.umi
 
 import com.fulcrumgenomics.cmdline.{ClpGroups, FgBioTool}
-import com.fulcrumgenomics.umi.ConsensusCallerOptions._
+import com.fulcrumgenomics.umi.VanillaUmiConsensusCallerOptions._
 import com.fulcrumgenomics.util.ProgressLogger
 import dagr.commons.CommonsDef.PathToBam
 import dagr.commons.io.Io
@@ -105,12 +105,12 @@ class CallMolecularConsensusReads
     // The output file is unmapped, so for now let's clear out the sequence dictionary & PGs
     val out = new SAMFileWriterFactory().makeWriter(outputHeader(in.getFileHeader), true, output.toFile, null)
 
-    val options = new ConsensusCallerOptions(
+    val options = new VanillaUmiConsensusCallerOptions(
       tag                          = tag,
       errorRatePreUmi              = errorRatePreUmi,
       errorRatePostUmi             = errorRatePostUmi,
-      maxBaseQuality               = maxBaseQuality,
-      baseQualityShift             = baseQualityShift,
+      maxRawBaseQuality               = maxBaseQuality,
+      rawBaseQualityShift             = baseQualityShift,
       minConsensusBaseQuality      = minConsensusBaseQuality,
       minReads                     = minReads,
       minMeanConsensusBaseQuality  = minMeanConsensusBaseQuality,
@@ -118,7 +118,7 @@ class CallMolecularConsensusReads
     )
 
     val progress = new ProgressLogger(logger, unit=1e5.toInt)
-    val consensusCaller = new ConsensusCaller(
+    val consensusCaller = new VanillaUmiConsensusCaller(
       input          = in.iterator().asScala,
       header         = in.getFileHeader,
       readNamePrefix = readNamePrefix,

--- a/src/main/scala/com/fulcrumgenomics/umi/ConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/ConsensusCaller.scala
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016 Fulcrum Genomics
+ * Copyright (c) 2016 Fulcrum Genomics LLC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,448 +20,165 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
- *
  */
 
 package com.fulcrumgenomics.umi
 
-import com.fulcrumgenomics.umi.ConsensusCallerOptions._
+import java.util
+
+import com.fulcrumgenomics.umi.ConsensusCaller.Base
+import com.fulcrumgenomics.util.MathUtil
 import com.fulcrumgenomics.util.NumericTypes._
-import com.fulcrumgenomics.util.{MathUtil, ProgressLogger}
-import htsjdk.samtools._
 import htsjdk.samtools.util.SequenceUtil
 
-import scala.collection.mutable
-import scala.collection.mutable.ListBuffer
+import scala.math.{max, min}
 
-object ConsensusCallerOptions {
-  type PhredScore = Byte
-
-  /** Various default values for the consensus caller. */
-  val DefaultTag: String                             = "MI"
-  val DefaultErrorRatePreUmi: PhredScore             = 45.toByte
-  val DefaultErrorRatePostUmi: PhredScore            = 40.toByte
-  val DefaultMaxBaseQuality: PhredScore              = 40.toByte
-  val DefaultBaseQualityShift: PhredScore            = 10.toByte
-  val DefaultMinConsensusBaseQuality: PhredScore     = 13.toByte
-  val DefaultMinReads: Int                           = 1
-  val DefaultMinMeanConsensusBaseQuality: PhredScore = 13.toByte
-  val DefaultRequireConsensusForBothPairs: Boolean   = true
+object ConsensusCaller {
+  type Base = Byte
 }
 
-/** Holds the parameters/options for consensus calling. */
-case class ConsensusCallerOptions(tag: String                             = DefaultTag,
-                                  errorRatePreUmi: PhredScore             = DefaultErrorRatePreUmi,
-                                  errorRatePostUmi: PhredScore            = DefaultErrorRatePostUmi,
-                                  maxBaseQuality: PhredScore              = DefaultMaxBaseQuality,
-                                  baseQualityShift: PhredScore            = DefaultBaseQualityShift,
-                                  minConsensusBaseQuality: PhredScore     = DefaultMinConsensusBaseQuality,
-                                  minReads: Int                           = DefaultMinReads,
-                                  minMeanConsensusBaseQuality: PhredScore = DefaultMinMeanConsensusBaseQuality,
-                                  requireConsensusForBothPairs: Boolean   = DefaultRequireConsensusForBothPairs
-                                 ) {
-
-  val errorRatePreUmiLn  = LogProbability.fromPhredScore(errorRatePreUmi)
-  val errorRatePostUmiLn = LogProbability.fromPhredScore(errorRatePostUmi)
-}
-
-/** Stores all the information about a read going into a consensus. */
-private[umi] case class AdjustedRead(bases: Array[Byte], pError: Array[LogProbability], pCorrect: Array[LogProbability]) {
-  assert(bases.length == pError.length,   "Bases and qualities not the same length.")
-  assert(bases.length == pCorrect.length, "Bases and qualities not the same length.")
-
-  def length: Int = bases.length
-}
-
-/** Stores information about a read to be fed into a consensus. */
-case class SourceRead(bases: Array[Byte], quals: Array[Byte]) {
-  assert(bases.length == quals.length,   "Bases and qualities not the same length.")
-  def length = bases.length
-}
-
-/** Stores information about a consensus read. */
-case class ConsensusRead(bases: Array[Byte], quals: Array[Byte]) {
-  val meanQuality: Byte = MathUtil.mean(quals)
-
-  /** Returns the consensus read a String - mostly useful for testing. */
-  def baseString = new String(bases)
-}
-
-/** Calls consensus reads by grouping consecutive reads with the same SAM tag.
+/**
+  * Generic consensus caller class that can be used to produce consensus base calls and qualities from
+  * a pileup of raw base calls and qualities.
   *
-  * Consecutive reads with the SAM tag are partitioned into fragments, first of pair, and
-  * second of pair reads, and a consensus read is created for each partition.  A consensus read
-  * for a given partition may not be returned if any of the conditions are not met (ex. minimum
-  * number of reads, minimum mean consensus base quality, ...).
-  * */
-class ConsensusCaller
-( input: Iterator[SAMRecord],
-  val header: SAMFileHeader,
-  val readNamePrefix: Option[String]   = None,
-  val readGroupId: String              = "A",
-  val options: ConsensusCallerOptions  = new ConsensusCallerOptions(),
-  val rejects: Option[SAMFileWriter]   = None,
-  val progress: Option[ProgressLogger] = None
-) extends Iterator[SAMRecord] {
-  /** The type of consensus read to output. */
-  private object ReadType extends Enumeration {
-    val Fragment, FirstOfPair, SecondOfPair = Value
+  * The consensus caller sees the process of going from a DNA source molecule in its original, pristine, state
+  * to a sequenced base as having three phases each with their own distinct error profiles:
+  *   1) The phase whereby the source molecule is harvested (e.g. cells extracted and lysed) to the point where
+  *   some kind of molecular identifier has been attached that will allow for identification of replicates that
+  *   are generated from the same original source molecule.  Errors in this phase will be present in all copies
+  *   of the molecule that are prepared for sequencing (except where a second error reverts the change).
+  *
+  *   2) Everything between phases 1 & 3! Generally including any sample preparation activities after a molecular
+  *   identifier has been attached but prior to sequencing.  Errors introduced in this phase will be present in
+  *   some fraction of the molecules available at sequencing.
+  *
+  *   3) Sequencing of the molecule (or clonal cluster of molecules) on a sequencer.  E.g. the process of base-by-base
+  *   resynthesis and sequencing on an Illumina sequencer _after_ cluster amplification.  Errors in this phase are
+  *   captured by the raw base quality scores from the sequencer.
+  *
+  * @param errorRatePreLabeling an estimate of the error rate (i.e. rate of base substitutions) caused by DNA damage
+  *                             prior to any labeling of source molecules. Estimates the rate at which errors from
+  *                             Phase 1 described above would be observed if the rest of the process were error-free.
+  * @param errorRatePostLabeling an estimate of the error rate (i.e. rate of base substitutions) caused by DNA damage
+  *                              post-labeling. Estimates the errors from Phase 2 which would be non-uniform across
+  *                              replicates of the same source molecule.
+  * @param rawBaseQualityShift shift the incoming raw base quality by this amount before use. Useful if the
+  *                            raw base qualities are believed to be uniformly over-estimated. E.g. a value of 5
+  *                            would cause an incoming base quality of 30 to be shifted to 25.
+  * @param maxRawBaseQuality the maximum raw base quality to allow after any shift has been applied. Base qualities
+  *                          higher than this value are capped at this value.
+  */
+class ConsensusCaller(errorRatePreLabeling:  PhredScore,
+                      errorRatePostLabeling: PhredScore,
+                      rawBaseQualityShift:   PhredScore = 0.toByte,
+                      maxRawBaseQuality:     PhredScore = PhredScore.MaxValue
+                      ) {
+
+  assert(maxRawBaseQuality >= PhredScore.MinValue, s"maxBaseQuality must be >= ${PhredScore.MinValue}")
+  assert(maxRawBaseQuality <= PhredScore.MaxValue, s"maxBaseQuality must be <= ${PhredScore.MaxValue}")
+
+  private val LnErrorRatePreLabeling  = LogProbability.fromPhredScore(errorRatePreLabeling)
+  private val LnErrorRatePostLabeling = LogProbability.fromPhredScore(errorRatePostLabeling)
+  private val DnaBasesUpperCase: Array[Base] = Array('A', 'C', 'G', 'T').map(_.toByte)
+  private val DnaBaseCount  = DnaBasesUpperCase.length
+
+  /**
+    * An inner class for tracking the likelihoods for the consensus for a single base.
+    */
+  class ConsensusBaseBuilder {
+    private var contributors: Int = 0
+    private val likelihoods = new Array[LogProbability](DnaBaseCount)
+
+    /** Resets the likelihoods to p=1 so that the builder can be re-used. */
+    def reset(): Unit = {
+      this.contributors = 0
+      util.Arrays.fill(this.likelihoods, LnOne)
+    }
+
+    /** Adds a base and un-adjusted base quality to the consensus likelihoods. */
+    def add(base: Base, qual: PhredScore): Unit = add(base, pError=phredToAdjustedLogProbError(qual), pTruth=phredToAdjustedLogProbCorrect(qual))
+
+    /** Adds a base with adjusted error and truth probabilities to the consensus likelihoods. */
+    def add(base: Base, pError: LogProbability, pTruth: LogProbability) = {
+      val b = SequenceUtil.upperCase(base)
+      if (b != 'N') {
+        this.contributors += 1
+
+        var i = 0
+        while (i < DnaBaseCount) {
+          val candidateBase = DnaBasesUpperCase(i)
+
+          //  Pr(Error) for this specific base, assuming the error distributes uniformly across the other three bases
+          likelihoods(i) += ( if (base == candidateBase) pTruth else LogProbability.normalizeByScalar(pError, 3) )
+          i += 1
+        }
+      }
+    }
+
+    /**
+      * Returns the number of reads that contributed evidence to the consensus. The value is equal
+      * to the number of times add() was called with non-ambiguous bases.
+      */
+    def contributions: Int = this.contributors
+
+    /** Call the consensus base and quality score given the current set of likelihoods. */
+    def call() : (Base, PhredScore) = {
+      // get the sum of the likelihoods
+      // pick the base with the maximum posterior
+      val lls  = likelihoods
+      val likelihoodSum   = LogProbability.or(lls)
+      val (maxLikelihood, maxLlIndex) = MathUtil.maxWithIndex(lls)
+      val maxPosterior    = LogProbability.normalizeByLogProbability(maxLikelihood, likelihoodSum)
+      val pConsensusError = LogProbability.not(maxPosterior) // convert to probability of the called consensus being wrong
+
+      // Factor in the pre-UMI error rate.
+      // Pr(error) = Pr(any pre-UMI error AND correct consensus) + Pr(no pre-UMI error AND any error in consensus)
+      //               + Pr(pre-UMI error AND error in consensus, that do not give us the correct bases)
+      // The last term tries to capture the case where a pre-UMI error modifies the base (ex. A->C) but a sequencing
+      // error calls it the correct base (C->A).  Only 2/3 times will the two errors result in the incorrect base.
+      val p = LogProbability.probabilityOfErrorTwoTrials(LnErrorRatePreLabeling, pConsensusError)
+      val q = PhredScore.cap(PhredScore.fromLogProbability(p))
+      val base = DnaBasesUpperCase(maxLlIndex)
+      (base, q)
+    }
   }
-  import ReadType._
 
-  private val DnaBasesUpperCase: Array[Byte] = Array('A', 'C', 'G', 'T').map(_.toByte)
-  private val LogThree      = LogProbability.toLogProbability(3.0)
-  private val LogFourThirds = LogProbability.toLogProbability(4.0) - LogThree
 
-  /** Pre-computes the the log-scale probabilities of an error for each a phred-scaled base quality from 0-100. */
-  private val phredToLogProbError: Array[Double] = Range(0, 100).toArray.map(p => {
-    val e1 = LogProbability.fromPhredScore(options.errorRatePostUmi)
-    val e2 = LogProbability.fromPhredScore(p.toByte)
-    probabilityOfErrorTwoTrials(e1, e2)
+  /** Pre-computes the the log-scale probabilities of an error for each a phred-scaled base quality from 0-127. */
+  private val phredToAdjustedLogProbError: Array[LogProbability] = Range(0, Byte.MaxValue).toArray.map(q => {
+    val aq = min(this.maxRawBaseQuality, max(PhredScore.MinValue, q - this.rawBaseQualityShift)).toByte
+    val e1 = LogProbability.fromPhredScore(this.errorRatePostLabeling)
+    val e2 = LogProbability.fromPhredScore(aq)
+    LogProbability.probabilityOfErrorTwoTrials(e1, e2)
   })
 
-  /** Pre-computes the the log-scale probabilities of an not an error for each a phred-scaled base quality from 0-100. */
-  private val phredToLogProbCorrect: Array[Double] = phredToLogProbError.map(LogProbability.not)
+  /** Pre-computes the the log-scale probabilities of an not an error for each a phred-scaled base quality from 0-127. */
+  private val phredToAdjustedLogProbCorrect: Array[Double] = phredToAdjustedLogProbError.map(LogProbability.not)
 
-  private val iter = input.buffered
-  private val nextConsensusRecords: mutable.Queue[SAMRecord] = mutable.Queue[SAMRecord]() // one per UMI group
-  private var readIdx = 1
-
-  /** Creates a consensus read from the given records.  If no consensus read was created, None is returned. */
-  def consensusFromSamRecords(records: Seq[SAMRecord]): Option[ConsensusRead] = {
-    val sourceReads = records.map { rec =>
-      if (rec.getReadNegativeStrandFlag) {
-        val newBases = rec.getReadBases.clone()
-        val newQuals = rec.getBaseQualities.clone()
-        SequenceUtil.reverseComplement(newBases)
-        SequenceUtil.reverse(newQuals, 0, newQuals.length)
-        SourceRead(newBases, newQuals)
-      }
-      else {
-        SourceRead(rec.getReadBases.array, rec.getBaseQualities.array)
-      }
-    }
-
-    consensusCall(sourceReads)
-  }
-
-  /** Creates a consensus read from the given read and qualities sequences.  If no consensus read was created, None
-    * is returned.
+  /**
+    * Returns the adjusted probability of error given a base quality. This is the probability that the base was
+    * sequenced incorrectly or that the template had the wrong base due to an error during sample-preparation
+    * post-labeling (phase 2 described above).
     *
-    * The same number of base sequences and quality sequences should be given.
-    * */
-  private[umi] def consensusCall(reads: Seq[SourceRead]): Option[ConsensusRead] = {
-    // check to see if we have enough reads.
-    if (reads.length < options.minReads) return None
-
-    // extract the bases and qualities, and adjust the qualities based on the given options.s
-    val adjustedReads = reads.map(adjustBaseQualities)
-
-    // get the most likely consensus bases and qualities
-    val consensusRead = consensusCallAdjustedReads(reads=adjustedReads)
-
-    // check that the mean base quality is high enough
-    if (consensusRead.meanQuality < options.minMeanConsensusBaseQuality) None
-    else Some(consensusRead)
-  }
-
-  /** Get the most likely consensus bases and qualities. */
-  private[umi] def consensusCallAdjustedReads(reads: Seq[AdjustedRead]): ConsensusRead = {
-    type Base = Byte
-    val maxReadLength = reads.map(_.length).max
-
-    // Array
-    // by cycle, by candidate base
-    val likelihoods = Array.ofDim[LogProbability](maxReadLength, DnaBasesUpperCase.length) // NB: array is initialized to zero, which is toLogProbability(1.0)
-    val numReads = new Array[Int](maxReadLength)
-
-    // Calculate the likelihoods
-    {
-      val readCount = reads.length
-      val DnaBasesUpperCaseCount = DnaBasesUpperCase.length
-
-      var readIdx = 0
-      while (readIdx < readCount) {
-        // for each read
-        val read = reads(readIdx)
-        val bases = read.bases
-        val baseCount = bases.length
-
-        var baseIdx = 0
-        while (baseIdx < baseCount) {
-          // for each base in the read
-          val base = bases(baseIdx)
-          if (base != 'N') {
-
-            var i = 0
-            while (i < DnaBasesUpperCaseCount) {
-              val candidateBase = DnaBasesUpperCase(i)
-              val likelihood = {
-                if (base == candidateBase) read.pCorrect(baseIdx)
-                else LogProbability.normalizeByScalar(read.pError(baseIdx), 3) //  Pr(Error) for this specific base, assuming the error distributes uniformly across the other three bases
-              }
-              likelihoods(baseIdx)(i) = LogProbability.and( likelihoods(baseIdx)(i), likelihood)
-              i += 1
-            }
-            numReads(baseIdx) += 1
-          }
-
-          baseIdx +=1
-        }
-        readIdx += 1
-      }
-    }
-
-    // Calculate the posteriors
-    val consensusBases     = new Array[Base](maxReadLength)
-    val consensusQualities = new Array[PhredScore](maxReadLength)
-    for (baseIdx <- likelihoods.indices) { // for each base in the read
-      if (numReads(baseIdx) < this.options.minReads) {
-        consensusBases(baseIdx) = SequenceUtil.N
-        consensusQualities(baseIdx) = PhredScore.MinValue
-      }
-      else {
-        // get the sum of the likelihoods
-        // pick the base with the maximum posterior
-        val lls  = likelihoods(baseIdx)
-        val likelihoodSum   = LogProbability.or(lls)
-        val (maxLikelihood, maxLlIndex) = MathUtil.maxWithIndex(lls)
-        val maxPosterior    = LogProbability.normalizeByLogProbability(maxLikelihood, likelihoodSum)
-        val pConsensusError = LogProbability.not(maxPosterior) // convert to probability of the called consensus being wrong
-
-        // Masks a base if the phred score would be too low
-        consensusBases(baseIdx) = {
-          if (PhredScore.fromLogProbability(pConsensusError) < this.options.minConsensusBaseQuality) SequenceUtil.N
-          else DnaBasesUpperCase(maxLlIndex)
-        }
-
-        // Factor in the pre-UMI error rate.
-        // Pr(error) = Pr(any pre-UMI error AND correct consensus) + Pr(no pre-UMI error AND any error in consensus)
-        //               + Pr(pre-UMI error AND error in consensus, that do not give us the correct bases)
-        // The last term tries to capture the case where a pre-UMI error modifies the base (ex. A->C) but a sequencing
-        // error calls it the correct base (C->A).  Only 2/3 times will the two errors result in the incorrect base.
-        val p = probabilityOfErrorTwoTrials(this.options.errorRatePreUmiLn, pConsensusError)
-
-        // Cap the quality
-        consensusQualities(baseIdx) = PhredScore.cap(PhredScore.fromLogProbability(p))
-      }
-    }
-
-    ConsensusRead(consensusBases, consensusQualities)
+    * @param qual the raw base quality as a Phred scaled number
+    * @return the LogProbability that the base is incorrect
+    */
+  def adjustedErrorProbability(qual: PhredScore): LogProbability = {
+    if (qual < PhredScore.MinValue) throw new IllegalArgumentException(s"Cannot adjust score lower than ${PhredScore.MinValue}")
+    else this.phredToAdjustedLogProbError(qual)
   }
 
   /**
-    * Adjusts the given base qualities.  The base qualities are first shifted by `baseQualityShift`, then capped using
-    *`maxBaseQuality`, and finally the `errorRatePostUmi` is incorporated.
+    * Returns 1 - #adjustedErrorProbability
     *
-    * Implemented as a while loop with assignment into pre-created arrays as this function is called on every
-    * single input read and unfortunately Array[Double].map() causes boxing on all the values which is a
-    * significant performance drain.
+    * @param qual the raw base quality as a Phred scaled number
+    * @return the LogProbability that the base is incorrect
     */
-  private[umi] def adjustBaseQualities(read: SourceRead): AdjustedRead = {
-    val len = read.length
-    val pErrors   = new Array[LogProbability](len)
-    val pCorrects = new Array[LogProbability](len)
-
-    val qs = read.quals
-    var i = 0
-    while (i < len) {
-      val q = qs(i)
-      val newQ = Math.min(this.options.maxBaseQuality, Math.max(PhredScore.MinValue, q - this.options.baseQualityShift))
-      pErrors(i)   = this.phredToLogProbError(newQ)
-      pCorrects(i) = this.phredToLogProbCorrect(newQ)
-      i += 1
-    }
-
-    new AdjustedRead(read.bases, pErrors, pCorrects)
+  def adjustedTruthProbability(qual: PhredScore): LogProbability = {
+    if (qual < PhredScore.MinValue) throw new IllegalArgumentException(s"Cannot adjust score lower than ${PhredScore.MinValue}")
+    else this.phredToAdjustedLogProbCorrect(qual)
   }
 
-  /** Computes the probability of seeing an error in the base sequence if there are two independent error processes.
-    * We sum three terms:
-    * 1. the probability of an error in trial one and no error in trial two: Pr(A=Error, B=NoError).
-    * 2. the probability of no error in trial one and an error in trial two: Pr(A=NoError, B=Error).
-    * 3. the probability of an error in both trials, but when the second trial does not reverse the error in first one, which
-    *    for DNA (4 bases) would only occur 2/3 times: Pr(A=x->y, B=y->z) * Pr(x!=z | x!=y, y!=z, x,y,z \in {A,C,G,T})
-    */
-  private[umi] def probabilityOfErrorTwoTrials(prErrorTrialOne: LogProbability, prErrorTrialTwo: LogProbability): LogProbability = {
-    if (prErrorTrialOne < prErrorTrialTwo) probabilityOfErrorTwoTrials(prErrorTrialTwo, prErrorTrialOne)
-    else if (prErrorTrialOne - prErrorTrialTwo >= 6) prErrorTrialOne // a simple approximation since prErrorTrialOne will dominate
-    else {
-      // f(X, Y) = X(1-Y) + (1-X)Y + 2/3*XY
-      //         = X - XY + Y - XY + 2/3*XY
-      //         = X + Y - 2XY + 2/3*XY
-      //         = X + Y + XY*(2/3 - 6/3)
-      //         = X + Y - 4/3*XY
-      val term1 = LogProbability.or(prErrorTrialOne, prErrorTrialTwo) // X + Y
-      val term2 = LogFourThirds + prErrorTrialOne + prErrorTrialTwo // 4/3*XY
-      LogProbability.aOrNotB(term1, term2)
-    }
-  }
-
-  /** Gets the longest common prefix of the given strings, None if there is only one string or if there is an empty string. */
-  @annotation.tailrec
-  private def longestCommonPrefix(strs: Iterable[String], accu: Option[String] = None): Option[String] = {
-    if (strs.exists(_.isEmpty) || strs.size <= 1) accu
-    else {
-      val first = strs.head.head
-      if (strs.tail.exists(_.head != first)) accu
-      else longestCommonPrefix(strs.map(_.tail), Some(accu.getOrElse("") + first))
-    }
-  }
-
-  /** True if there are more consensus reads, false otherwise. */
-  def hasNext(): Boolean = this.nextConsensusRecords.nonEmpty || (this.iter.nonEmpty && advance())
-
-  /** Returns the next consensus read. */
-  def next(): SAMRecord = {
-    if (!this.hasNext()) throw new NoSuchElementException("Calling next() when hasNext() is false.")
-    this.nextConsensusRecords.dequeue()
-  }
-
-  /** Consumes records until a consensus read can be created, or no more input records are available. Returns
-    * true if a consensus read was created, false otherwise. */
-  @annotation.tailrec
-  private def advance(): Boolean = {
-    // get the records to create the consensus read
-    val buffer = nextGroupOfRecords()
-
-    // partition the records to which end of a pair it belongs, or if it is a fragment read.
-    val (fragments, firstOfPair, secondOfPair) = subGroupRecords(records = buffer)
-
-    // track if we are successful creating any consensus reads
-    var success = false
-
-    // fragment
-    consensusFromSamRecords(records=fragments) match {
-      case None       => // reject
-        rejectRecords(records=fragments);
-      case Some(frag) => // output
-        this.createAndEnqueueSamRecord(records=fragments, read=frag, readName=nextReadName(fragments), readType=Fragment)
-        success = true
-    }
-
-    // pairs
-    val needBothPairs = options.requireConsensusForBothPairs // for readability later
-    val firstOfPairConsensus  = consensusFromSamRecords(records=firstOfPair)
-    val secondOfPairConsensus = consensusFromSamRecords(records=secondOfPair)
-    (firstOfPairConsensus, secondOfPairConsensus) match {
-      case (None, None)                                       => // reject
-        rejectRecords(records=firstOfPair ++ secondOfPair)
-      case (Some(_), None) | (None, Some(_)) if needBothPairs => // reject
-        rejectRecords(records=firstOfPair ++ secondOfPair)
-      case (firstRead, secondRead)                            => // output
-        this.createAndEnqueueSamRecordPair(firstRecords=firstOfPair, firstRead=firstRead, secondRecords=secondOfPair, secondRead=secondRead)
-        success = true
-    }
-
-    if (success) true // consensus created
-    else if (this.iter.isEmpty) false // no more records, don't try again
-    else this.advance() // no consensus, but more records, try again
-  }
-
-  private def rejectRecords(records: Seq[SAMRecord]): Unit = this.rejects.foreach(rej => records.foreach(rej.addAlignment))
-
-  /** Adds a SAM record from the underlying iterator to the buffer if either the buffer is empty or the SAM tag is
-    * the same for the records in the buffer as the next record in the input iterator.  Returns true if a record was
-    * added, false otherwise.
-    */
-  private def nextGroupOfRecords(): List[SAMRecord] = {
-    if (this.iter.isEmpty) Nil
-    else {
-      val tagToMatch = this.iter.head.getStringAttribute(options.tag)
-      val buffer = ListBuffer[SAMRecord]()
-      while (this.iter.hasNext && this.iter.head.getStringAttribute(options.tag) == tagToMatch) {
-        val rec = this.iter.next()
-        buffer += rec
-      }
-      progress.map(_.record(buffer:_*))
-      buffer.toList
-    }
-  }
-
-  /** Split records into those that should make a single-end consensus read, first of pair consensus read,
-    * and second of pair consensus read, respectively.  The default method is to use the SAM flag to find
-    * unpaired reads, first of pair reads, and second of pair reads.
-    */
-  protected def subGroupRecords(records: Seq[SAMRecord]): (Seq[SAMRecord], Seq[SAMRecord],Seq[SAMRecord]) = {
-    val fragments    = records.filter { rec => !rec.getReadPairedFlag }
-    val firstOfPair  = records.filter { rec => rec.getReadPairedFlag && rec.getFirstOfPairFlag }
-    val secondOfPair = records.filter { rec => rec.getReadPairedFlag && rec.getSecondOfPairFlag }
-    (fragments, firstOfPair, secondOfPair)
-  }
-
-  /** Returns the next read name with format "<prefix>:<idx>", where "<prefix>" is either the supplied prefix or the
-    * longest common prefix of all read names, and "<idx>" is the 1-based consensus read index.  If no prefix was found,
-    * "CONSENSUS" is used.  If no records are given, the empty string is returned.
-    */
-  private def nextReadName(records: Seq[SAMRecord]): String = {
-    if (records.isEmpty) ""
-    else this.options.tag + ":" + records.head.getStringAttribute(this.options.tag)
-//    val curIdx = readIdx
-//    readIdx += 1
-//    val prefix = readNamePrefix.getOrElse(longestCommonPrefix(records.map(_.getReadName)).getOrElse("CONSENSUS"))
-//    s"$prefix:$curIdx"
-  }
-
-  /** Creates a `SAMRecord` for both ends of a pair.  If a consensus read is not given for one end of a pair, a dummy
-    * record is created.  At least one consensus read must be given.
-    */
-  private def createAndEnqueueSamRecordPair(firstRecords: Seq[SAMRecord],
-                                            firstRead: Option[ConsensusRead],
-                                            secondRecords: Seq[SAMRecord],
-                                            secondRead: Option[ConsensusRead]): Unit = {
-    if (firstRead.isEmpty && secondRead.isEmpty) throw new IllegalArgumentException("Both consenus reads were empty.")
-    val readName = nextReadName(firstRecords++secondRecords)
-    // first end
-    createAndEnqueueSamRecord(
-      records  = firstRecords,
-      read     = firstRead.getOrElse(dummyConsensusRead(secondRead.get)),
-      readName = readName,
-      readType = FirstOfPair
-    )
-    // second end
-    createAndEnqueueSamRecord(
-      records  = secondRecords,
-      read     = secondRead.getOrElse(dummyConsensusRead(firstRead.get)),
-      readName = readName,
-      readType = SecondOfPair
-    )
-  }
-
-  /** Creates a `SAMRecord` from the called consensus base and qualities. */
-  private def createAndEnqueueSamRecord(records: Seq[SAMRecord],
-                                        read: ConsensusRead,
-                                        readName: String,
-                                        readType: ReadType.Value): Unit = {
-    if (records.isEmpty) return
-    val rec = new SAMRecord(header)
-    rec.setReadName(readName)
-    rec.setReadUnmappedFlag(true)
-    readType match {
-      case Fragment     => // do nothing
-      case FirstOfPair  =>
-        rec.setReadPairedFlag(true)
-        rec.setFirstOfPairFlag(true)
-        rec.setMateUnmappedFlag(true)
-      case SecondOfPair =>
-        rec.setReadPairedFlag(true)
-        rec.setSecondOfPairFlag(true)
-        rec.setMateUnmappedFlag(true)
-    }
-    rec.setReadBases(read.bases)
-    rec.setBaseQualities(read.quals)
-    rec.setAttribute(SAMTag.RG.name(), readGroupId)
-    rec.setAttribute(options.tag, records.head.getStringAttribute(options.tag))
-    // TODO: set custom SAM tags:
-    // - # of reads contributing to this consensus
-
-    // enqueue the record
-    this.nextConsensusRecords.enqueue(rec)
-  }
-
-  /** Creates a dummy consensus read.  The read and quality strings will have the same length as the source, with
-    * the read string being all Ns, and the quality string having zero base qualities. */
-  private def dummyConsensusRead(source: ConsensusRead): ConsensusRead = {
-    ConsensusRead(bases=source.bases.map(_ => 'N'.toByte), quals=source.quals.map(_ => PhredScore.MinValue))
-  }
+  /** Returns a new builder that can be used to call the consensus at one or more sites serially. */
+  def builder(): ConsensusBaseBuilder = new ConsensusBaseBuilder
 }

--- a/src/main/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCaller.scala
@@ -1,0 +1,358 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package com.fulcrumgenomics.umi
+
+import com.fulcrumgenomics.FgBioDef._
+import com.fulcrumgenomics.umi.ConsensusCaller.Base
+import com.fulcrumgenomics.umi.VanillaUmiConsensusCallerOptions._
+import com.fulcrumgenomics.util.NumericTypes._
+import com.fulcrumgenomics.util.{MathUtil, ProgressLogger}
+import htsjdk.samtools._
+import htsjdk.samtools.util.SequenceUtil
+
+import scala.collection.JavaConversions.collectionAsScalaIterable
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+
+object VanillaUmiConsensusCallerOptions {
+  type PhredScore = Byte
+
+  /** Various default values for the consensus caller. */
+  val DefaultTag: String                             = "MI"
+  val DefaultErrorRatePreUmi: PhredScore             = 45.toByte
+  val DefaultErrorRatePostUmi: PhredScore            = 40.toByte
+  val DefaultMaxBaseQuality: PhredScore              = 40.toByte
+  val DefaultBaseQualityShift: PhredScore            = 10.toByte
+  val DefaultMinConsensusBaseQuality: PhredScore     = 13.toByte
+  val DefaultMinReads: Int                           = 1
+  val DefaultMinMeanConsensusBaseQuality: PhredScore = 13.toByte
+  val DefaultRequireConsensusForBothPairs: Boolean   = true
+}
+
+/** Holds the parameters/options for consensus calling. */
+case class VanillaUmiConsensusCallerOptions(tag: String                             = DefaultTag,
+                                            errorRatePreUmi: PhredScore             = DefaultErrorRatePreUmi,
+                                            errorRatePostUmi: PhredScore            = DefaultErrorRatePostUmi,
+                                            maxRawBaseQuality: PhredScore           = DefaultMaxBaseQuality,
+                                            rawBaseQualityShift: PhredScore         = DefaultBaseQualityShift,
+                                            minConsensusBaseQuality: PhredScore     = DefaultMinConsensusBaseQuality,
+                                            minReads: Int                           = DefaultMinReads,
+                                            minMeanConsensusBaseQuality: PhredScore = DefaultMinMeanConsensusBaseQuality,
+                                            requireConsensusForBothPairs: Boolean   = DefaultRequireConsensusForBothPairs)
+
+/** Stores information about a read to be fed into a consensus. */
+case class SourceRead(bases: Array[Byte], quals: Array[Byte]) {
+  assert(bases.length == quals.length,   "Bases and qualities not the same length.")
+  def length = bases.length
+}
+
+/** Stores information about a consensus read. */
+case class ConsensusRead(bases: Array[Byte], quals: Array[Byte]) {
+  val meanQuality: Byte = MathUtil.mean(quals)
+
+  /** Returns the consensus read a String - mostly useful for testing. */
+  def baseString = new String(bases)
+}
+
+
+/** Calls consensus reads by grouping consecutive reads with the same SAM tag.
+  *
+  * Consecutive reads with the SAM tag are partitioned into fragments, first of pair, and
+  * second of pair reads, and a consensus read is created for each partition.  A consensus read
+  * for a given partition may not be returned if any of the conditions are not met (ex. minimum
+  * number of reads, minimum mean consensus base quality, ...).
+  * */
+class VanillaUmiConsensusCaller
+(input: Iterator[SAMRecord],
+ val header: SAMFileHeader,
+ val readNamePrefix: Option[String]   = None,
+ val readGroupId: String              = "A",
+ val options: VanillaUmiConsensusCallerOptions  = new VanillaUmiConsensusCallerOptions(),
+ val rejects: Option[SAMFileWriter]   = None,
+ val progress: Option[ProgressLogger] = None
+) extends Iterator[SAMRecord] {
+  /** The type of consensus read to output. */
+  private object ReadType extends Enumeration {
+    val Fragment, FirstOfPair, SecondOfPair = Value
+  }
+  import ReadType._
+
+  private val DnaBasesUpperCase: Array[Byte] = Array('A', 'C', 'G', 'T').map(_.toByte)
+  private val LogThree = LogProbability.toLogProbability(3.0)
+  private val caller = new ConsensusCaller(errorRatePreLabeling  = options.errorRatePreUmi,
+                                           errorRatePostLabeling = options.errorRatePostUmi,
+                                           maxRawBaseQuality     = options.maxRawBaseQuality,
+                                           rawBaseQualityShift   = options.rawBaseQualityShift)
+
+  private val iter = input.buffered
+  private val nextConsensusRecords: mutable.Queue[SAMRecord] = mutable.Queue[SAMRecord]() // one per UMI group
+  private var readIdx = 1
+
+  private val NoCall: Base = 'N'.toByte
+  private val NotEnoughReadsQual: PhredScore = 0.toByte // Score output when masking to N due to insufficient input reads
+  private val TooLowQualityQual: PhredScore = 2.toByte  // Score output when masking to N due to too low consensus quality
+
+  // Initializes the prefix that will be used to make sure read names are (hopefully) unique
+  private val actualReadNamePrefix = readNamePrefix.getOrElse {
+    header.getReadGroups.map(rg => Option(rg.getLibrary).getOrElse(rg.getReadGroupId)).toSet.toList.sorted.mkString("|")
+  }
+
+  /** Creates a consensus read from the given records.  If no consensus read was created, None is returned. */
+  def consensusFromSamRecords(records: Seq[SAMRecord]): Option[ConsensusRead] = {
+    val sourceReads = records.map { rec =>
+      if (rec.getReadNegativeStrandFlag) {
+        val newBases = rec.getReadBases.clone()
+        val newQuals = rec.getBaseQualities.clone()
+        SequenceUtil.reverseComplement(newBases)
+        SequenceUtil.reverse(newQuals, 0, newQuals.length)
+        SourceRead(newBases, newQuals)
+      }
+      else {
+        SourceRead(rec.getReadBases.array, rec.getBaseQualities.array)
+      }
+    }
+
+    consensusCall(sourceReads)
+  }
+
+  /** Creates a consensus read from the given read and qualities sequences.  If no consensus read was created, None
+    * is returned.
+    *
+    * The same number of base sequences and quality sequences should be given.
+    * */
+  private[umi] def consensusCall(reads: Seq[SourceRead]): Option[ConsensusRead] = {
+    // check to see if we have enough reads.
+    if (reads.size < this.options.minReads) {
+      None
+    }
+    else {
+      // get the most likely consensus bases and qualities
+      val consensusLength = consensusReadLength(reads)
+      val consensusBases  = new Array[Base](consensusLength)
+      val consensusQuals  = new Array[PhredScore](consensusLength)
+
+      var positionInRead = 0
+      val builder = this.caller.builder()
+      while (positionInRead < consensusLength) {
+        // Add the evidence from all reads that are long enough to cover this base
+        reads.foreach { read =>
+          if (read.length > positionInRead) {
+            builder.add(base=read.bases(positionInRead), qual=read.quals(positionInRead))
+          }
+        }
+
+        // Call the consensus and do any additional filtering
+        val (base, qual) = {
+          if (builder.contributions < this.options.minReads) {
+            (NoCall, NotEnoughReadsQual)
+          }
+          else {
+            val (b,q) = builder.call()
+            if (q < this.options.minConsensusBaseQuality) (NoCall, TooLowQualityQual) else (b,q)
+
+          }
+        }
+        consensusBases(positionInRead) = base
+        consensusQuals(positionInRead) = qual
+
+        // Get ready for the next pass
+        builder.reset()
+        positionInRead += 1
+      }
+
+      // check that the mean base quality is high enough
+      if (MathUtil.mean(consensusQuals) >= options.minMeanConsensusBaseQuality)
+        Some(ConsensusRead(consensusBases, consensusQuals))
+      else
+        None
+    }
+  }
+
+  /**
+    * Calculates the length of the consensus read that should be produced. The length is calculated
+    * as the maximum length at which #options.minReads reads still have bases.
+    *
+    * @param reads the set of reads being fed into the consensus
+    * @return the length of consensus read that should be created
+    */
+  private def consensusReadLength(reads: Seq[SourceRead]): Int = {
+    val n = this.options.minReads
+    if (reads.length < n) throw new IllegalArgumentException("Too few reads to create a consensus.")
+
+    reads.map(_.length).sortBy(len => -len).drop(n-1).head
+  }
+
+  /** True if there are more consensus reads, false otherwise. */
+  def hasNext(): Boolean = this.nextConsensusRecords.nonEmpty || (this.iter.nonEmpty && advance())
+
+  /** Returns the next consensus read. */
+  def next(): SAMRecord = {
+    if (!this.hasNext()) throw new NoSuchElementException("Calling next() when hasNext() is false.")
+    this.nextConsensusRecords.dequeue()
+  }
+
+  /** Consumes records until a consensus read can be created, or no more input records are available. Returns
+    * true if a consensus read was created, false otherwise. */
+  @annotation.tailrec
+  private def advance(): Boolean = {
+    // get the records to create the consensus read
+    val buffer = nextGroupOfRecords()
+
+    // partition the records to which end of a pair it belongs, or if it is a fragment read.
+    val (fragments, firstOfPair, secondOfPair) = subGroupRecords(records = buffer)
+
+    // track if we are successful creating any consensus reads
+    var success = false
+
+    // fragment
+    consensusFromSamRecords(records=fragments) match {
+      case None       => // reject
+        rejectRecords(records=fragments);
+      case Some(frag) => // output
+        this.createAndEnqueueSamRecord(records=fragments, read=frag, readName=nextReadName(fragments), readType=Fragment)
+        success = true
+    }
+
+    // pairs
+    val needBothPairs = options.requireConsensusForBothPairs // for readability later
+    val firstOfPairConsensus  = consensusFromSamRecords(records=firstOfPair)
+    val secondOfPairConsensus = consensusFromSamRecords(records=secondOfPair)
+    (firstOfPairConsensus, secondOfPairConsensus) match {
+      case (None, None)                                       => // reject
+        rejectRecords(records=firstOfPair ++ secondOfPair)
+      case (Some(_), None) | (None, Some(_)) if needBothPairs => // reject
+        rejectRecords(records=firstOfPair ++ secondOfPair)
+      case (firstRead, secondRead)                            => // output
+        this.createAndEnqueueSamRecordPair(firstRecords=firstOfPair, firstRead=firstRead, secondRecords=secondOfPair, secondRead=secondRead)
+        success = true
+    }
+
+    if (success) true // consensus created
+    else if (this.iter.isEmpty) false // no more records, don't try again
+    else this.advance() // no consensus, but more records, try again
+  }
+
+  private def rejectRecords(records: Seq[SAMRecord]): Unit = this.rejects.foreach(rej => records.foreach(rej.addAlignment))
+
+  /** Adds a SAM record from the underlying iterator to the buffer if either the buffer is empty or the SAM tag is
+    * the same for the records in the buffer as the next record in the input iterator.  Returns true if a record was
+    * added, false otherwise.
+    */
+  private def nextGroupOfRecords(): List[SAMRecord] = {
+    if (this.iter.isEmpty) Nil
+    else {
+      val tagToMatch = this.iter.head.getStringAttribute(options.tag)
+      val buffer = ListBuffer[SAMRecord]()
+      while (this.iter.hasNext && this.iter.head.getStringAttribute(options.tag) == tagToMatch) {
+        val rec = this.iter.next()
+        buffer += rec
+      }
+      progress.map(_.record(buffer:_*))
+      buffer.toList
+    }
+  }
+
+  /** Split records into those that should make a single-end consensus read, first of pair consensus read,
+    * and second of pair consensus read, respectively.  The default method is to use the SAM flag to find
+    * unpaired reads, first of pair reads, and second of pair reads.
+    */
+  protected def subGroupRecords(records: Seq[SAMRecord]): (Seq[SAMRecord], Seq[SAMRecord],Seq[SAMRecord]) = {
+    val fragments    = records.filter { rec => !rec.getReadPairedFlag }
+    val firstOfPair  = records.filter { rec => rec.getReadPairedFlag && rec.getFirstOfPairFlag }
+    val secondOfPair = records.filter { rec => rec.getReadPairedFlag && rec.getSecondOfPairFlag }
+    (fragments, firstOfPair, secondOfPair)
+  }
+
+  /** Returns the next read name with format "<prefix>:<idx>", where "<prefix>" is either the supplied prefix or a
+    * prefix composed by concatenating information from the input read groups.
+    */
+  private def nextReadName(records: Seq[SAMRecord]): String = {
+    if (records.isEmpty) unreachable("Can't generate a consensus read name for zero input reads.")
+    else this.actualReadNamePrefix + ":" + records.head.getStringAttribute(this.options.tag)
+  }
+
+  /** Creates a `SAMRecord` for both ends of a pair.  If a consensus read is not given for one end of a pair, a dummy
+    * record is created.  At least one consensus read must be given.
+    */
+  private def createAndEnqueueSamRecordPair(firstRecords: Seq[SAMRecord],
+                                            firstRead: Option[ConsensusRead],
+                                            secondRecords: Seq[SAMRecord],
+                                            secondRead: Option[ConsensusRead]): Unit = {
+    if (firstRead.isEmpty && secondRead.isEmpty) throw new IllegalArgumentException("Both consenus reads were empty.")
+    val readName = nextReadName(firstRecords++secondRecords)
+    // first end
+    createAndEnqueueSamRecord(
+      records  = firstRecords,
+      read     = firstRead.getOrElse(dummyConsensusRead(secondRead.get)),
+      readName = readName,
+      readType = FirstOfPair
+    )
+    // second end
+    createAndEnqueueSamRecord(
+      records  = secondRecords,
+      read     = secondRead.getOrElse(dummyConsensusRead(firstRead.get)),
+      readName = readName,
+      readType = SecondOfPair
+    )
+  }
+
+  /** Creates a `SAMRecord` from the called consensus base and qualities. */
+  private def createAndEnqueueSamRecord(records: Seq[SAMRecord],
+                                        read: ConsensusRead,
+                                        readName: String,
+                                        readType: ReadType.Value): Unit = {
+    if (records.isEmpty) return
+    val rec = new SAMRecord(header)
+    rec.setReadName(readName)
+    rec.setReadUnmappedFlag(true)
+    readType match {
+      case Fragment     => // do nothing
+      case FirstOfPair  =>
+        rec.setReadPairedFlag(true)
+        rec.setFirstOfPairFlag(true)
+        rec.setMateUnmappedFlag(true)
+      case SecondOfPair =>
+        rec.setReadPairedFlag(true)
+        rec.setSecondOfPairFlag(true)
+        rec.setMateUnmappedFlag(true)
+    }
+    rec.setReadBases(read.bases)
+    rec.setBaseQualities(read.quals)
+    rec.setAttribute(SAMTag.RG.name(), readGroupId)
+    rec.setAttribute(options.tag, records.head.getStringAttribute(options.tag))
+    // TODO: set custom SAM tags:
+    // - # of reads contributing to this consensus
+
+    // enqueue the record
+    this.nextConsensusRecords.enqueue(rec)
+  }
+
+  /** Creates a dummy consensus read.  The read and quality strings will have the same length as the source, with
+    * the read string being all Ns, and the quality string having zero base qualities. */
+  private def dummyConsensusRead(source: ConsensusRead): ConsensusRead = {
+    ConsensusRead(bases=source.bases.map(_ => 'N'.toByte), quals=source.quals.map(_ => PhredScore.MinValue))
+  }
+}

--- a/src/test/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReadsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReadsTest.scala
@@ -26,14 +26,14 @@
 package com.fulcrumgenomics.umi
 
 import com.fulcrumgenomics.testing.{SamRecordSetBuilder, UnitSpec}
-import com.fulcrumgenomics.umi.ConsensusCallerOptions._
+import com.fulcrumgenomics.umi.VanillaUmiConsensusCallerOptions._
 import htsjdk.samtools.SAMFileHeader.SortOrder
 
 /**
   * Tests for CallMolecularConsensusReads.
   *
   * This makes sure the tool runs end-to-end, and the majority of the tests that cover various options are covered
-  * in [[ConsensusCallerTest]].
+  * in [[VanillaUmiConsensusCallerTest]].
   */
 class CallMolecularConsensusReadsTest extends UnitSpec {
 

--- a/src/test/scala/com/fulcrumgenomics/umi/ConsensusCallerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/ConsensusCallerTest.scala
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016 Fulcrum Genomics
+ * Copyright (c) 2016 Fulcrum Genomics LLC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,352 +20,79 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
- *
  */
 
 package com.fulcrumgenomics.umi
 
 import com.fulcrumgenomics.testing.UnitSpec
-import com.fulcrumgenomics.umi.ConsensusCallerOptions._
-import com.fulcrumgenomics.util.NumericTypes._
-import com.fulcrumgenomics.util.NumericTypes.LogProbability._
-import htsjdk.samtools.util.CloserUtil
-import htsjdk.samtools.{SAMFileHeader, SAMRecordSetBuilder, SAMUtils}
-import net.jafama.FastMath._
+import com.fulcrumgenomics.util.NumericTypes.PhredScore
 
-import scala.collection.JavaConversions._
-import scala.collection.JavaConverters._
-
-/**
-  * Tests for ConsensusCaller.
-  */
 class ConsensusCallerTest extends UnitSpec {
-  /** Helper function to make a set of consensus caller options. */
-  def cco = ConsensusCallerOptions
-
-  /** Helper function to make a consensus caller. */
-  def cc(options: ConsensusCallerOptions = new ConsensusCallerOptions()) = {
-    new ConsensusCaller(Iterator.empty, new SAMFileHeader, options=options)
-  }
-
-  /** Helper function to make a SourceRead. */
-  def src(bases: String, quals: TraversableOnce[Int]) = SourceRead(bases.getBytes(), quals.toArray.map(_.toByte))
-
-  /** Helper function to make a SourceRead from bases and Phred-33 ascii quals. */
-  def src(bases: String, quals: String) = SourceRead(bases.getBytes(), SAMUtils.fastqToPhred(quals))
-
-  /**
-    * Function to calculated the expected quality of a consensus base in non-log math, that should work for
-    * modest values of Q and N.
-    *
-    * @param q The quality score of the correct bases (assumed all the same)
-    * @param n The number of observations at that quality
-    * @return the phred-scaled number (byte) of the consensus base
-    */
-  def expectedConsensusQuality(q: Int, n: Int): Byte = {
-    val p   = BigDecimal(pow(10.0, q  / -10.0))
-    val ok  = BigDecimal(1) - p
-    val err = p / 3 // error could be one of three bases
-
-    val numerator   = ok.pow(n)
-    val denomenator = numerator + (err.pow(2) * 3)
-    val pError = 1 - (numerator / denomenator)
-    val phred = -10 * log10(pError.toDouble)
-    phred.toByte
-  }
-
   "ConsensusCaller.adjustBaseQualities" should "cap base qualities" in {
-    val caller   = cc(cco(maxBaseQuality=10.toByte, baseQualityShift=0.toByte, errorRatePostUmi=Byte.MaxValue))
-    val adjusted = caller.adjustBaseQualities(SourceRead("ACGT".getBytes(), Array(20, 15, 10, 5).map(_.toByte)))
-    val actuals  = adjusted.pError.map(p => -10 * log10(exp(p))).map(_.toByte).toSeq
-    actuals shouldBe Seq(10, 10, 10, 5)
+    val caller   = new ConsensusCaller(maxRawBaseQuality=10.toByte, rawBaseQualityShift=0.toByte, errorRatePostLabeling=PhredScore.MaxValue, errorRatePreLabeling=PhredScore.MaxValue)
+    val adjusted = Array[Byte](20, 15, 10, 5).map(caller.adjustedErrorProbability).map(PhredScore.fromLogProbability).toSeq
+    adjusted shouldBe Seq(10, 10, 10, 5)
   }
 
   it should "shift base qualities" in {
-    val caller   = cc(cco(maxBaseQuality=Byte.MaxValue, baseQualityShift=10.toByte, errorRatePostUmi=Byte.MaxValue))
-    val adjusted = caller.adjustBaseQualities(SourceRead("ACGT".getBytes(), Array(20, 15, 10, 5).map(_.toByte)))
-    val actuals  = adjusted.pError.map(p => -10 * log10(exp(p))).map(_.toByte).toSeq
-    actuals shouldBe Seq(10, 5, 2, 2)
+    val caller   = new ConsensusCaller(maxRawBaseQuality=PhredScore.MaxValue, rawBaseQualityShift=10.toByte, errorRatePostLabeling=PhredScore.MaxValue, errorRatePreLabeling=PhredScore.MaxValue)
+    val adjusted = Array[Byte](20, 15, 10, 5).map(caller.adjustedErrorProbability).map(PhredScore.fromLogProbability).toSeq
+    adjusted shouldBe Seq(10, 5, 2, 2)
   }
 
   it should "scale base qualities using the post-umi error rate" in {
-    val caller   = cc(cco(maxBaseQuality=Byte.MaxValue, baseQualityShift=0.toByte, errorRatePostUmi=10.toByte))
-    val adjusted = caller.adjustBaseQualities(SourceRead("ACGT".getBytes(), Array(20, 15, 10, 5).map(_.toByte)))
-    val actuals  = adjusted.pError.map(p => -10 * log10(exp(p))).map(_.toByte).toSeq
-    actuals shouldBe Seq(9, 8, 7, 4)
+    val caller   = new ConsensusCaller(maxRawBaseQuality=PhredScore.MaxValue, rawBaseQualityShift=0.toByte, errorRatePostLabeling=10.toByte, errorRatePreLabeling=PhredScore.MaxValue)
+    val adjusted = Array[Byte](20, 15, 10, 5).map(caller.adjustedErrorProbability).map(PhredScore.fromLogProbability).toSeq
+    adjusted shouldBe Seq(9, 8, 7, 4)
   }
 
   it should "cap, shift, and scale base qualities" in {
-    val caller   = cc(cco(maxBaseQuality=10.toByte, baseQualityShift=5.toByte, errorRatePostUmi=10.toByte))
-    val adjusted = caller.adjustBaseQualities(SourceRead("ACGT".getBytes(), Array(20, 15, 10, 5).map(_.toByte)))
-    val actuals  = adjusted.pError.map(p => -10 * log10(exp(p))).map(_.toByte).toSeq
-    actuals shouldBe Seq(7, 7, 4, 1)
+    val caller   = new ConsensusCaller(maxRawBaseQuality=10.toByte, rawBaseQualityShift=5.toByte, errorRatePostLabeling=10.toByte, errorRatePreLabeling=PhredScore.MaxValue)
+    val adjusted = Array[Byte](20, 15, 10, 5).map(caller.adjustedErrorProbability).map(PhredScore.fromLogProbability).toSeq
+    adjusted shouldBe Seq(7, 7, 4, 1)
   }
 
-  "ConsensusCaller.consensusCalls" should "produce a consensus from one read" in {
-    val source = src("GATTACA", Seq(10, 10, 10, 10, 10, 10, 10))
-    val caller = cc(cco(errorRatePreUmi=PhredScore.MaxValue, minReads=1, baseQualityShift=0.toByte, minConsensusBaseQuality=0.toByte, minMeanConsensusBaseQuality=0.toByte))
-    val consensus = caller.consensusCall(Seq(source))
-    consensus shouldBe 'defined
-    consensus.get.bases shouldBe source.bases
-    consensus.get.quals shouldBe source.quals
+  it should "calculate consensus base and quality given a single base pileup" in {
+    val caller = new ConsensusCaller(errorRatePreLabeling=PhredScore.MaxValue, errorRatePostLabeling=PhredScore.MaxValue)
+    val builder = caller.builder()
+    builder.add('A'.toByte, 20.toByte)
+    val (base, qual) = builder.call()
+    base shouldBe 'A'
+    qual shouldBe 20
   }
 
-  it should "produce a consensus from two reads" in {
-    val source    = src("GATTACA", Seq(10, 10, 10, 10, 10, 10, 10))
-    val sources   = Seq(source, source)
+  it should "calculate consensus base and quality given a massive pileup" in {
+    val caller = new ConsensusCaller(errorRatePreLabeling=50.toByte, errorRatePostLabeling=50.toByte)
+    val builder = caller.builder()
+    (0 to 999).foreach(i => builder.add('C'.toByte, 20.toByte))
+    builder.call() shouldBe ('C', 50)
+    builder.contributions shouldBe 1000
 
-    val expectedQual = expectedConsensusQuality(10, 2)
-    val expectedQuals = source.quals.map(q => expectedQual)
-
-    val consensus = cc(cco(minReads=1, minConsensusBaseQuality=0.toByte, baseQualityShift=0.toByte)).consensusCall(sources)
-    consensus shouldBe 'defined
-    consensus.get.bases shouldBe source.bases
-    consensus.get.quals should contain theSameElementsInOrderAs expectedQuals
+    (0 to 9).foreach(i => builder.add('T'.toByte, 20.toByte))
+    builder.call() shouldBe ('C', 50)
+    builder.contributions shouldBe 1010
   }
 
-  it should "produce a consensus from three reads, with one disagreement" in {
-    val quals = Array(10, 10, 10, 10, 10, 10, 10)
-    val source1 = src("GATTACA", quals)
-    val source2 = src("GATTTCA", quals)
-    val err = LogProbability.normalizeByScalar(LogProbability.fromPhredScore(10), 3)
-    val ok  = LogProbability.not(LogProbability.fromPhredScore(10))
-    val numeratorAgreement = LogProbability.and(Array(ok, ok, ok))
-    val denominatorAgreement = LogProbability.or(numeratorAgreement, LogProbability.and(Array(LnThree, err, err, err)))
-    val agreementQual = LogProbability.not(LogProbability.normalizeByLogProbability(numeratorAgreement, denominatorAgreement))
-
-    val numeratorDisagreement =  LogProbability.and(Array(ok, ok, err))
-    val denominatorDisagreement = LogProbability.or(Array(
-      numeratorDisagreement,
-      LogProbability.and(Array(err, err, ok)),
-      LogProbability.and(Array(LnThree, err, err, err)))
-    )
-    val disagreementQual = LogProbability.not(numeratorDisagreement - denominatorDisagreement)
-
-    val expectedQuals = source1.bases.zip(source2.bases).map {
-      case (left, right) =>
-        if (left == right) agreementQual
-        else disagreementQual
-    }.map(PhredScore.fromLogProbability)
-
-    val caller = cc(cco(errorRatePreUmi=PhredScore.MaxValue, baseQualityShift=0.toByte, minReads=1, minConsensusBaseQuality=0.toByte))
-    val consensus = caller.consensusCall(Seq(source1, source1, source2))
-    consensus shouldBe 'defined
-    consensus.get.bases shouldBe source1.bases
-    consensus.get.quals should contain theSameElementsInOrderAs expectedQuals
+  it should "calculate consensus base and quality given conflicting evidence" in {
+    val caller = new ConsensusCaller(errorRatePreLabeling=50.toByte, errorRatePostLabeling=50.toByte)
+    val builder = caller.builder()
+    builder.add('A'.toByte, 30.toByte)
+    builder.add('C'.toByte, 28.toByte)
+    val (base, qual) = builder.call()
+    base shouldBe 'A'
+    qual.toInt should be <= 5
   }
 
-  it should "produce a consensus from two reads of differing lengths" in {
-    val quals = Array(10, 10, 10, 10, 10, 10, 10)
-    val caller = cc(cco(minReads=2, minConsensusBaseQuality=0.toByte, baseQualityShift=0.toByte))
-    val consensus = caller.consensusCall(Seq(src("GATTACA", quals), src("GATTAC", quals.slice(0, quals.length-1))))
+  it should "support calling multiple pileups from the same builder" in {
+    val caller = new ConsensusCaller(errorRatePreLabeling=50.toByte, errorRatePostLabeling=50.toByte)
+    val builder = caller.builder()
+    builder.add('A'.toByte, 20.toByte)
+    builder.call shouldBe ('A'.toByte, 20.toByte)
+    builder.contributions shouldBe 1
 
-    val newQual = expectedConsensusQuality(10, 2)
-    val newQuals = Array(newQual, newQual, newQual, newQual, newQual, newQual, 2.toByte)
-
-    consensus shouldBe 'defined
-    consensus.get.baseString shouldBe "GATTACN"
-    consensus.get.quals shouldBe newQuals
-  }
-
-  it should "mask bases with too low of a consensus quality" in {
-    val bases = "GATTACA"
-    val quals = Array(10, 10, 10, 10, 10, 10, 0)
-    val expectedQuals = Array(10, 10, 10, 10, 10, 10, 2).map(_.toByte)
-    val caller    = cc(cco(errorRatePreUmi=PhredScore.MaxValue, minReads=1, minConsensusBaseQuality=10.toByte,
-                           minMeanConsensusBaseQuality=PhredScore.MinValue, baseQualityShift=0.toByte))
-    val consensus = caller.consensusCall(Seq(src(bases, quals)))
-    consensus shouldBe 'defined
-    consensus.get.baseString shouldBe "GATTACN"
-    consensus.get.quals shouldBe expectedQuals
-  }
-
-  "ConsensusCaller.consensusFromStringBasesAndQualities" should "return None if there are not enough reads" in {
-    cc(cco(minReads=1)).consensusCall(Seq.empty) shouldBe None
-    cc(cco(minReads=2)).consensusCall(Seq(src("GATTACA", Array(20,20,20,20,20,20,20)))) shouldBe None
-  }
-
-  it should "throw an exception if the bases and qualities are of a different length" in {
-    an[AssertionError] should be thrownBy cc().consensusCall(Seq(src("GATTACA", Array(20))))
-    an[AssertionError] should be thrownBy cc().consensusCall(Seq(src("G", Array(20,20,20,20,20))))
-  }
-
-  it should "not return a consensus read if the mean consensus quality is too low" in {
-    val call1 = cc(cco(errorRatePreUmi=PhredScore.MaxValue, minReads=1, minMeanConsensusBaseQuality=PhredScore.MaxValue))
-                  .consensusCall(Seq(src("GATTACA", "AAAAAAA")))
-    call1 shouldBe None
-
-    val call2 = cc(cco(errorRatePreUmi=PhredScore.MaxValue, minReads=1, minMeanConsensusBaseQuality=PhredScore.MinValue))
-                  .consensusCall(Seq(src("GATTACA", "AAAAAAA")))
-    call2 shouldBe 'defined
-  }
-
-  it should "apply the pre-umi-error-rate when it has probability zero" in {
-    val inputQuals = Seq(10, 10, 10, 10, 10, 10, 10)
-    val source = src("GATTACA", inputQuals)
-    val opts = cco(
-      errorRatePreUmi             = PhredScore.MaxValue,
-      errorRatePostUmi            = PhredScore.MaxValue,
-      maxBaseQuality              = PhredScore.MaxValue,
-      baseQualityShift            = 0.toByte,
-      minConsensusBaseQuality     = PhredScore.MinValue,
-      minReads                    = 1,
-      minMeanConsensusBaseQuality = PhredScore.MinValue
-    )
-
-    cc(opts).consensusCall(Seq(source)) match {
-      case None => fail
-      case Some(consensus) =>
-        consensus.baseString shouldBe "GATTACA"
-        consensus.quals shouldBe inputQuals.map(_.toByte)
-    }
-  }
-
-  it should "apply the pre-umi-error-rate when it has probability greater than zero" in {
-    val caller = cc(cco(
-      errorRatePreUmi             = 10.toByte,
-      errorRatePostUmi            = PhredScore.MaxValue,
-      maxBaseQuality              = PhredScore.MaxValue,
-      baseQualityShift            = 0.toByte,
-      minConsensusBaseQuality     = PhredScore.MinValue,
-      minReads                    = 1,
-      minMeanConsensusBaseQuality = PhredScore.MinValue
-    ))
-
-    val inputQuals = Seq(10, 10, 10, 10, 10, 10, 10)
-    val lnProbError = LogProbability.fromPhredScore(10)
-    val outputQual  = PhredScore.fromLogProbability(caller.probabilityOfErrorTwoTrials(lnProbError, lnProbError))
-    val outputQuals = inputQuals.map(q => outputQual)
-    caller.consensusCall(Seq(src("GATTACA", inputQuals))) match {
-      case None => fail
-      case Some(consensus) =>
-        consensus.baseString shouldBe "GATTACA"
-        consensus.quals      shouldBe outputQuals
-    }
-  }
-
-  it should "apply the post-umi-error-rate when it has probability greater than zero" in {
-    val caller = cc(cco(
-      errorRatePreUmi             = PhredScore.MaxValue,
-      errorRatePostUmi            = 10.toByte,
-      maxBaseQuality              = PhredScore.MaxValue,
-      baseQualityShift            = 0.toByte,
-      minConsensusBaseQuality     = PhredScore.MinValue,
-      minReads                    = 1,
-      minMeanConsensusBaseQuality = PhredScore.MinValue
-    ))
-
-    val inputQuals = Seq(10, 10, 10, 10, 10, 10, 10)
-    val lnProbError = LogProbability.fromPhredScore(10)
-    val outputQual  = PhredScore.fromLogProbability(caller.probabilityOfErrorTwoTrials(lnProbError, lnProbError))
-    val outputQuals = inputQuals.map(q => outputQual)
-
-    caller.consensusCall(Seq(src("GATTACA", inputQuals))) match {
-      case None => fail
-      case Some(consensus) =>
-        consensus.baseString shouldBe "GATTACA"
-        consensus.quals      shouldBe outputQuals
-    }
-  }
-
-  "ConsensusCaller" should "should create two consensus for two UMI groups" in {
-    val builder = new SAMRecordSetBuilder()
-    builder.addFrag("READ1", 0, 1, false).setAttribute(DefaultTag, "GATTACA")
-    builder.addFrag("READ2", 0, 1, false).setAttribute(DefaultTag, "GATTACA")
-    builder.addFrag("READ3", 0, 1, false).setAttribute(DefaultTag, "ACATTAG")
-    builder.addFrag("READ4", 0, 1, false).setAttribute(DefaultTag, "ACATTAG")
-    builder.getRecords.foreach { rec =>
-      rec.setReadString("A" * rec.getReadLength)
-      rec.setBaseQualityString(SAMUtils.phredToFastq(40).toString * rec.getReadLength)
-    }
-    val reader = builder.getSamReader
-    val consensusCaller = new ConsensusCaller(
-      input = reader.iterator().asScala,
-      header = reader.getFileHeader,
-      options = new ConsensusCallerOptions(
-        minReads         = 1,
-        errorRatePreUmi  = PhredScore.MaxValue,
-        errorRatePostUmi = PhredScore.MaxValue
-      )
-    )
-    consensusCaller.hasNext shouldBe true
-    val calls = consensusCaller.toList
-    consensusCaller.hasNext shouldBe false
-    calls should have size 2
-    CloserUtil.close(reader)
-  }
-
-  it should "should create two consensus for a read pair" in {
-    val builder = new SAMRecordSetBuilder()
-    builder.addPair("READ1", 0, 1, 1000)
-    builder.getRecords.foreach {
-      rec =>
-        rec.setAttribute(DefaultTag, "GATTACA")
-        rec.setReadString("A" * rec.getReadLength)
-        rec.setBaseQualityString(SAMUtils.phredToFastq(40).toString * rec.getReadLength)
-    }
-    val reader = builder.getSamReader
-    val consensusCaller = new ConsensusCaller(
-      input = reader.iterator().asScala,
-      header = reader.getFileHeader,
-      options = new ConsensusCallerOptions(
-        minReads         = 1,
-        errorRatePreUmi  = PhredScore.MaxValue,
-        errorRatePostUmi = PhredScore.MaxValue
-      )
-    )
-    consensusCaller.hasNext shouldBe true
-    val calls = consensusCaller.toList
-    consensusCaller.hasNext shouldBe false
-    calls should have size 2
-    calls.foreach { rec =>
-      rec.getReadPairedFlag shouldBe true
-    }
-    calls.head.getFirstOfPairFlag shouldBe true
-    calls.last.getSecondOfPairFlag shouldBe true
-    calls.head.getReadName shouldBe calls.last.getReadName
-    CloserUtil.close(reader)
-  }
-
-  it should "should create four consensus for two read pairs with different group ids" in {
-    val builder = new SAMRecordSetBuilder()
-    builder.addPair("READ1", 0, 1, 1000)
-    builder.addPair("READ2", 1, 1, 1000)
-
-    builder.getRecords.slice(0, 2).foreach {
-      rec =>
-        rec.setAttribute(DefaultTag, "GATTACA")
-        rec.setReadString("A" * rec.getReadLength)
-        rec.setBaseQualityString(SAMUtils.phredToFastq(40).toString * rec.getReadLength)
-    }
-    builder.getRecords.slice(2, 4).foreach {
-      rec =>
-        rec.setAttribute(DefaultTag, "ACATTAG")
-        rec.setReadString("A" * rec.getReadLength)
-        rec.setBaseQualityString(SAMUtils.phredToFastq(40).toString * rec.getReadLength)
-    }
-    val reader = builder.getSamReader
-    val consensusCaller = new ConsensusCaller(
-      input = reader.iterator().asScala,
-      header = reader.getFileHeader,
-      options = new ConsensusCallerOptions(
-        minReads         = 1,
-        errorRatePreUmi  = PhredScore.MaxValue,
-        errorRatePostUmi = PhredScore.MaxValue
-      )
-    )
-    consensusCaller.hasNext shouldBe true
-    val calls = consensusCaller.toList
-    consensusCaller.hasNext shouldBe false
-    calls should have size 4
-    calls.foreach { rec =>
-      rec.getReadPairedFlag shouldBe true
-    }
-    calls.map(_.getFirstOfPairFlag) should contain theSameElementsInOrderAs Seq(true, false, true, false)
-    calls.map(_.getSecondOfPairFlag) should contain theSameElementsInOrderAs Seq(false, true, false, true)
-    calls(0).getReadName shouldBe calls(1).getReadName
-    calls(2).getReadName shouldBe calls(3).getReadName
-    calls(0).getReadName should not be calls(2).getReadName
-    CloserUtil.close(reader)
+    builder.reset()
+    builder.add('C'.toByte, 20.toByte)
+    builder.call shouldBe ('C'.toByte, 20.toByte)
+    builder.contributions shouldBe 1
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCallerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCallerTest.scala
@@ -1,0 +1,357 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 Fulcrum Genomics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package com.fulcrumgenomics.umi
+
+import com.fulcrumgenomics.testing.UnitSpec
+import com.fulcrumgenomics.umi.VanillaUmiConsensusCallerOptions._
+import com.fulcrumgenomics.util.NumericTypes._
+import htsjdk.samtools.util.CloserUtil
+import htsjdk.samtools.{SAMFileHeader, SAMRecordSetBuilder, SAMUtils}
+import net.jafama.FastMath._
+
+import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
+
+/**
+  * Tests for ConsensusCaller.
+  */
+class VanillaUmiConsensusCallerTest extends UnitSpec {
+  /** Helper function to make a set of consensus caller options. */
+  def cco = VanillaUmiConsensusCallerOptions
+
+  /** Helper function to make a consensus caller. */
+  def cc(options: VanillaUmiConsensusCallerOptions = new VanillaUmiConsensusCallerOptions()) = {
+    new VanillaUmiConsensusCaller(Iterator.empty, new SAMFileHeader, options=options)
+  }
+
+  /** Helper function to make a SourceRead. */
+  def src(bases: String, quals: TraversableOnce[Int]) = SourceRead(bases.getBytes(), quals.toArray.map(_.toByte))
+
+  /** Helper function to make a SourceRead from bases and Phred-33 ascii quals. */
+  def src(bases: String, quals: String) = SourceRead(bases.getBytes(), SAMUtils.fastqToPhred(quals))
+
+  /**
+    * Function to calculated the expected quality of a consensus base in non-log math, that should work for
+    * modest values of Q and N.
+    *
+    * @param q The quality score of the correct bases (assumed all the same)
+    * @param n The number of observations at that quality
+    * @return the phred-scaled number (byte) of the consensus base
+    */
+  def expectedConsensusQuality(q: Int, n: Int): Byte = {
+    val p   = BigDecimal(pow(10.0, q  / -10.0))
+    val ok  = BigDecimal(1) - p
+    val err = p / 3 // error could be one of three bases
+
+    val numerator   = ok.pow(n)
+    val denomenator = numerator + (err.pow(2) * 3)
+    val pError = 1 - (numerator / denomenator)
+    val phred = -10 * log10(pError.toDouble)
+    phred.toByte
+  }
+
+  "VanillaUmiConsensusCaller.consensusCalls" should "produce a consensus from one read" in {
+    val source = src("GATTACA", Seq(10, 10, 10, 10, 10, 10, 10))
+    val caller = cc(cco(errorRatePreUmi=PhredScore.MaxValue, minReads=1, rawBaseQualityShift=0.toByte, minConsensusBaseQuality=0.toByte, minMeanConsensusBaseQuality=0.toByte))
+    val consensus = caller.consensusCall(Seq(source))
+    consensus shouldBe 'defined
+    consensus.get.bases shouldBe source.bases
+    consensus.get.quals shouldBe source.quals
+  }
+
+  it should "produce a consensus from two reads" in {
+    val source    = src("GATTACA", Seq(10, 10, 10, 10, 10, 10, 10))
+    val sources   = Seq(source, source)
+
+    val expectedQual = expectedConsensusQuality(10, 2)
+    val expectedQuals = source.quals.map(q => expectedQual)
+
+    val consensus = cc(cco(minReads=1, minConsensusBaseQuality=0.toByte, rawBaseQualityShift=0.toByte)).consensusCall(sources)
+    consensus shouldBe 'defined
+    consensus.get.bases shouldBe source.bases
+    consensus.get.quals should contain theSameElementsInOrderAs expectedQuals
+  }
+
+  it should "produce a consensus from three reads, with one disagreement" in {
+    val quals = Array(10, 10, 10, 10, 10, 10, 10)
+    val source1 = src("GATTACA", quals)
+    val source2 = src("GATTTCA", quals)
+    val err = LogProbability.normalizeByScalar(LogProbability.fromPhredScore(10), 3)
+    val ok  = LogProbability.not(LogProbability.fromPhredScore(10))
+    val numeratorAgreement = LogProbability.and(Array(ok, ok, ok))
+    val denominatorAgreement = LogProbability.or(numeratorAgreement, LogProbability.and(Array(LnThree, err, err, err)))
+    val agreementQual = LogProbability.not(LogProbability.normalizeByLogProbability(numeratorAgreement, denominatorAgreement))
+
+    val numeratorDisagreement =  LogProbability.and(Array(ok, ok, err))
+    val denominatorDisagreement = LogProbability.or(Array(
+      numeratorDisagreement,
+      LogProbability.and(Array(err, err, ok)),
+      LogProbability.and(Array(LnThree, err, err, err)))
+    )
+    val disagreementQual = LogProbability.not(numeratorDisagreement - denominatorDisagreement)
+
+    val expectedQuals = source1.bases.zip(source2.bases).map {
+      case (left, right) =>
+        if (left == right) agreementQual
+        else disagreementQual
+    }.map(PhredScore.fromLogProbability)
+
+    val caller = cc(cco(errorRatePreUmi=PhredScore.MaxValue, rawBaseQualityShift=0.toByte, minReads=1, minConsensusBaseQuality=0.toByte))
+    val consensus = caller.consensusCall(Seq(source1, source1, source2))
+    consensus shouldBe 'defined
+    consensus.get.bases shouldBe source1.bases
+    consensus.get.quals should contain theSameElementsInOrderAs expectedQuals
+  }
+
+  it should "produce a shortened consensus from two reads of differing lengths" in {
+    val quals = Array(10, 10, 10, 10, 10, 10, 10)
+    val caller = cc(cco(minReads=2, minConsensusBaseQuality=0.toByte, rawBaseQualityShift=0.toByte))
+    val consensus = caller.consensusCall(Seq(src("GATTACA", quals), src("GATTAC", quals.slice(0, quals.length-1))))
+
+    val newQual = expectedConsensusQuality(10, 2)
+    val newQuals = Array(newQual, newQual, newQual, newQual, newQual, newQual)
+
+    consensus shouldBe 'defined
+    consensus.get.baseString shouldBe "GATTAC"
+    consensus.get.quals shouldBe newQuals
+  }
+
+  /** This is to test that we don't generate a ton of Q0 or Q2 Ns at the end when we drop below minReads, deflate
+    * the average consensus base quality and then discard the consensus read.
+    */
+  it should "produce a consensus even when most of the bases have < minReads" in {
+    val src1 = src("A" * 10, (1 to 10).map(q => 30))
+    val src2 = src("A" * 20, (1 to 20).map(q => 30))
+
+    val caller = cc(cco(minReads=2, minConsensusBaseQuality=10.toByte, rawBaseQualityShift=0.toByte, minMeanConsensusBaseQuality=25.toByte))
+    val consensus = caller.consensusCall(Seq(src1, src2))
+
+    consensus shouldBe 'defined
+    consensus.get.baseString shouldBe "AAAAAAAAAA"
+  }
+
+
+  it should "mask bases with too low of a consensus quality" in {
+    val bases = "GATTACA"
+    val quals         = Array(10, 10, 10, 10, 10, 10, 5)
+    val expectedQuals = Array(10, 10, 10, 10, 10, 10, 2).map(_.toByte)
+    val caller    = cc(cco(errorRatePreUmi=PhredScore.MaxValue, minReads=1, minConsensusBaseQuality=10.toByte,
+                           minMeanConsensusBaseQuality=PhredScore.MinValue, rawBaseQualityShift=0.toByte))
+    val consensus = caller.consensusCall(Seq(src(bases, quals)))
+    consensus shouldBe 'defined
+    consensus.get.baseString shouldBe "GATTACN"
+    consensus.get.quals shouldBe expectedQuals
+  }
+
+  "ConsensusCaller.consensusFromStringBasesAndQualities" should "return None if there are not enough reads" in {
+    cc(cco(minReads=1)).consensusCall(Seq.empty) shouldBe None
+    cc(cco(minReads=2)).consensusCall(Seq(src("GATTACA", Array(20,20,20,20,20,20,20)))) shouldBe None
+  }
+
+  it should "throw an exception if the bases and qualities are of a different length" in {
+    an[AssertionError] should be thrownBy cc().consensusCall(Seq(src("GATTACA", Array(20))))
+    an[AssertionError] should be thrownBy cc().consensusCall(Seq(src("G", Array(20,20,20,20,20))))
+  }
+
+  it should "not return a consensus read if the mean consensus quality is too low" in {
+    val call1 = cc(cco(errorRatePreUmi=PhredScore.MaxValue, minReads=1, minMeanConsensusBaseQuality=PhredScore.MaxValue))
+                  .consensusCall(Seq(src("GATTACA", "AAAAAAA")))
+    call1 shouldBe None
+
+    val call2 = cc(cco(errorRatePreUmi=PhredScore.MaxValue, minReads=1, minMeanConsensusBaseQuality=PhredScore.MinValue))
+                  .consensusCall(Seq(src("GATTACA", "AAAAAAA")))
+    call2 shouldBe 'defined
+  }
+
+  it should "apply the pre-umi-error-rate when it has probability zero" in {
+    val inputQuals = Seq(10, 10, 10, 10, 10, 10, 10)
+    val source = src("GATTACA", inputQuals)
+    val opts = cco(
+      errorRatePreUmi             = PhredScore.MaxValue,
+      errorRatePostUmi            = PhredScore.MaxValue,
+      maxRawBaseQuality           = PhredScore.MaxValue,
+      rawBaseQualityShift         = 0.toByte,
+      minConsensusBaseQuality     = PhredScore.MinValue,
+      minReads                    = 1,
+      minMeanConsensusBaseQuality = PhredScore.MinValue
+    )
+
+    cc(opts).consensusCall(Seq(source)) match {
+      case None => fail
+      case Some(consensus) =>
+        consensus.baseString shouldBe "GATTACA"
+        consensus.quals shouldBe inputQuals.map(_.toByte)
+    }
+  }
+
+  it should "apply the pre-umi-error-rate when it has probability greater than zero" in {
+    val caller = cc(cco(
+      errorRatePreUmi             = 10.toByte,
+      errorRatePostUmi            = PhredScore.MaxValue,
+      maxRawBaseQuality           = PhredScore.MaxValue,
+      rawBaseQualityShift         = 0.toByte,
+      minConsensusBaseQuality     = PhredScore.MinValue,
+      minReads                    = 1,
+      minMeanConsensusBaseQuality = PhredScore.MinValue
+    ))
+
+    val inputQuals = Seq(10, 10, 10, 10, 10, 10, 10)
+    val lnProbError = LogProbability.fromPhredScore(10)
+    val outputQual  = PhredScore.fromLogProbability(LogProbability.probabilityOfErrorTwoTrials(lnProbError, lnProbError))
+    val outputQuals = inputQuals.map(q => outputQual)
+    caller.consensusCall(Seq(src("GATTACA", inputQuals))) match {
+      case None => fail
+      case Some(consensus) =>
+        consensus.baseString shouldBe "GATTACA"
+        consensus.quals      shouldBe outputQuals
+    }
+  }
+
+  it should "apply the post-umi-error-rate when it has probability greater than zero" in {
+    val caller = cc(cco(
+      errorRatePreUmi             = PhredScore.MaxValue,
+      errorRatePostUmi            = 10.toByte,
+      maxRawBaseQuality           = PhredScore.MaxValue,
+      rawBaseQualityShift         = 0.toByte,
+      minConsensusBaseQuality     = PhredScore.MinValue,
+      minReads                    = 1,
+      minMeanConsensusBaseQuality = PhredScore.MinValue
+    ))
+
+    val inputQuals = Seq(10, 10, 10, 10, 10, 10, 10)
+    val lnProbError = LogProbability.fromPhredScore(10)
+    val outputQual  = PhredScore.fromLogProbability(LogProbability.probabilityOfErrorTwoTrials(lnProbError, lnProbError))
+    val outputQuals = inputQuals.map(q => outputQual)
+
+    caller.consensusCall(Seq(src("GATTACA", inputQuals))) match {
+      case None => fail
+      case Some(consensus) =>
+        consensus.baseString shouldBe "GATTACA"
+        consensus.quals      shouldBe outputQuals
+    }
+  }
+
+  "VanillaUmiConsensusCaller" should "should create two consensus for two UMI groups" in {
+    val builder = new SAMRecordSetBuilder()
+    builder.addFrag("READ1", 0, 1, false).setAttribute(DefaultTag, "GATTACA")
+    builder.addFrag("READ2", 0, 1, false).setAttribute(DefaultTag, "GATTACA")
+    builder.addFrag("READ3", 0, 1, false).setAttribute(DefaultTag, "ACATTAG")
+    builder.addFrag("READ4", 0, 1, false).setAttribute(DefaultTag, "ACATTAG")
+    builder.getRecords.foreach { rec =>
+      rec.setReadString("A" * rec.getReadLength)
+      rec.setBaseQualityString(SAMUtils.phredToFastq(40).toString * rec.getReadLength)
+    }
+    val reader = builder.getSamReader
+    val consensusCaller = new VanillaUmiConsensusCaller(
+      input = reader.iterator().asScala,
+      header = reader.getFileHeader,
+      options = new VanillaUmiConsensusCallerOptions(
+        minReads         = 1,
+        errorRatePreUmi  = PhredScore.MaxValue,
+        errorRatePostUmi = PhredScore.MaxValue
+      )
+    )
+    consensusCaller.hasNext shouldBe true
+    val calls = consensusCaller.toList
+    consensusCaller.hasNext shouldBe false
+    calls should have size 2
+    CloserUtil.close(reader)
+  }
+
+  it should "should create two consensus for a read pair" in {
+    val builder = new SAMRecordSetBuilder()
+    builder.addPair("READ1", 0, 1, 1000)
+    builder.getRecords.foreach {
+      rec =>
+        rec.setAttribute(DefaultTag, "GATTACA")
+        rec.setReadString("A" * rec.getReadLength)
+        rec.setBaseQualityString(SAMUtils.phredToFastq(40).toString * rec.getReadLength)
+    }
+    val reader = builder.getSamReader
+    val consensusCaller = new VanillaUmiConsensusCaller(
+      input = reader.iterator().asScala,
+      header = reader.getFileHeader,
+      options = new VanillaUmiConsensusCallerOptions(
+        minReads         = 1,
+        errorRatePreUmi  = PhredScore.MaxValue,
+        errorRatePostUmi = PhredScore.MaxValue
+      )
+    )
+    consensusCaller.hasNext shouldBe true
+    val calls = consensusCaller.toList
+    consensusCaller.hasNext shouldBe false
+    calls should have size 2
+    calls.foreach { rec =>
+      rec.getReadPairedFlag shouldBe true
+    }
+    calls.head.getFirstOfPairFlag shouldBe true
+    calls.last.getSecondOfPairFlag shouldBe true
+    calls.head.getReadName shouldBe calls.last.getReadName
+    CloserUtil.close(reader)
+  }
+
+  it should "should create four consensus for two read pairs with different group ids" in {
+    val builder = new SAMRecordSetBuilder()
+    builder.addPair("READ1", 0, 1, 1000)
+    builder.addPair("READ2", 1, 1, 1000)
+
+    builder.getRecords.slice(0, 2).foreach {
+      rec =>
+        rec.setAttribute(DefaultTag, "GATTACA")
+        rec.setReadString("A" * rec.getReadLength)
+        rec.setBaseQualityString(SAMUtils.phredToFastq(40).toString * rec.getReadLength)
+    }
+    builder.getRecords.slice(2, 4).foreach {
+      rec =>
+        rec.setAttribute(DefaultTag, "ACATTAG")
+        rec.setReadString("A" * rec.getReadLength)
+        rec.setBaseQualityString(SAMUtils.phredToFastq(40).toString * rec.getReadLength)
+    }
+    val reader = builder.getSamReader
+    val consensusCaller = new VanillaUmiConsensusCaller(
+      input = reader.iterator().asScala,
+      header = reader.getFileHeader,
+      options = new VanillaUmiConsensusCallerOptions(
+        minReads         = 1,
+        errorRatePreUmi  = PhredScore.MaxValue,
+        errorRatePostUmi = PhredScore.MaxValue
+      )
+    )
+    consensusCaller.hasNext shouldBe true
+    val calls = consensusCaller.toList
+    consensusCaller.hasNext shouldBe false
+    calls should have size 4
+    calls.foreach { rec =>
+      rec.getReadPairedFlag shouldBe true
+    }
+    calls.map(_.getFirstOfPairFlag) should contain theSameElementsInOrderAs Seq(true, false, true, false)
+    calls.map(_.getSecondOfPairFlag) should contain theSameElementsInOrderAs Seq(false, true, false, true)
+    calls(0).getReadName shouldBe calls(1).getReadName
+    calls(2).getReadName shouldBe calls(3).getReadName
+    calls(0).getReadName should not be calls(2).getReadName
+    CloserUtil.close(reader)
+  }
+}

--- a/src/test/scala/com/fulcrumgenomics/util/NumericTypesTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/util/NumericTypesTest.scala
@@ -107,4 +107,13 @@ class NumericTypesTest extends UnitSpec {
     LogProbability.or(Array(log(10), log(10), log(10))) shouldBe log(30) +- 0.00001
     LogProbability.or(Array(-718.3947756282423, -8.404216861178751, -710.0756239287693, -718.3947756282423)) shouldBe -8.404216861178751 +- 0.00001
   }
+
+  it should "calculate the correct pError given two trials" in {
+    for (i <- 1 to 100; j <- 1 to 100) {
+      val (p1, p2) = (1/i.toDouble, 1/j.toDouble)
+      val expected = (p1*(1-p2)) + ((1-p1)*p2) + (p1 * p2 * 2/3)
+      val actual   = LogProbability.probabilityOfErrorTwoTrials(LogProbability.toLogProbability(p1), LogProbability.toLogProbability(p2))
+      exp(actual) shouldBe expected +- 0.0001
+    }
+  }
 }


### PR DESCRIPTION
@nh13 This is still a work in progress, but I would like you to take a look please and see if you agree with the general direction this is taking.

A few notes about where I'm at and what else I'd like to do:

1. LogProbability.probabilityOfErrorTwoTrials needs independent tests
2. ConsensusCaller needs independent tests
3. Should SourceRead/ConsensusRead and methods to go from SourceRead -> ConsensusRead exist in ConsensusCaller?  I haven't done this for now because I really want to keep ConsensusCaller as pileup oriented as possible, given it's other potential uses.  I also don't really want to drag some of the other parameters in, like minReads, minMeanQuality etc.  I think that perhaps if we end up having multiple consensus callers that work simililarly to the Vanilla one, we could sub-class and add those methods.

In addition, I think maxReadLength should be computed taking into account minReads.  Because we also filter consensus reads based on their mean quality, I think that we should probably only build a consensus read up to the point where we have enough reads to keep going.  E.g. imagine minReads=3 and minMeanConsensusQual=20 and we have four reads, all high quality, 2 at 100bp each and 2 more at 150bp each.  The current implementation will create a consensus read 150bp long with 50bp of Ns at the end, and then discard the entire read for being too low quality.  What do you think?

