### PR TITLE
SimpleCounter uses a HashMap by default and exposes a method to

### DIFF
--- a/src/test/scala/com/fulcrumgenomics/util/NumericCounterTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/util/NumericCounterTest.scala
@@ -41,6 +41,7 @@ class NumericCounterTest extends UnitSpec {
     counter.stddev() shouldBe  2.875181 +- 0.0001
     counter.mode() shouldBe 1
     counter.median() shouldBe 4.5
+    counter.totalMass shouldBe 46
   }
 
   it should "operate on Doubles" in {
@@ -52,6 +53,7 @@ class NumericCounterTest extends UnitSpec {
     counter.stddev() shouldBe  0.2875181 +- 0.0001
     counter.mode() shouldBe 0.1
     counter.median() shouldBe 0.45
+    counter.totalMass shouldBe 4.6
   }
 
   it should "handle when no objects are counted" in {
@@ -60,6 +62,7 @@ class NumericCounterTest extends UnitSpec {
     counter.stddev() shouldBe 0.0
     counter.mode() shouldBe 0.0
     counter.median() shouldBe 0.0
+    counter.totalMass shouldBe 0
   }
 
   it should "handle when a single object is counted" in {
@@ -69,6 +72,7 @@ class NumericCounterTest extends UnitSpec {
     counter.stddev() shouldBe 0.0
     counter.mode() shouldBe 10.0
     counter.median() shouldBe 10.0
+    counter.totalMass shouldBe 10.0
   }
 
   it should "handle when two objects are counted" in {
@@ -79,6 +83,7 @@ class NumericCounterTest extends UnitSpec {
     counter.stddev() shouldBe 7.071 +- 0.0001
     counter.mode() shouldBe 10.0
     counter.median() shouldBe 15.0
+    counter.totalMass shouldBe 30.0
   }
 
   it should "handle updating the count and re-computing statistics" in {
@@ -93,5 +98,6 @@ class NumericCounterTest extends UnitSpec {
     counter.stddev() shouldBe 5.656854 +- 0.00001
     counter.mode() shouldBe 1
     counter.median() shouldBe 5.0
+    counter.totalMass shouldBe 10
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/util/SimpleCounterTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/util/SimpleCounterTest.scala
@@ -39,6 +39,7 @@ class SimpleCounterTest extends UnitSpec {
     counter.countOf(10) shouldBe 5
     counter.countOf(9) shouldBe 4
     counter.iterator.toList shouldBe List((9, 4), (10, 5))
+    counter.total shouldBe 9
   }
 
   it should "count a type that does not implement comparable" in {
@@ -48,6 +49,6 @@ class SimpleCounterTest extends UnitSpec {
     counter.countOf(10) shouldBe 5
     counter.countOf("10.5") shouldBe 4
     counter.iterator.toList shouldBe List(("10.5", 4), (10, 5))
+    counter.total shouldBe 9
   }
-
 }


### PR DESCRIPTION
sub-classes to make the internal counting object.

@tfenne you mentioned you hit a case where you were creating many counters and the reflection code was the bottleneck.  I also hit such a case.  Take a look.