### PR TITLE
takeWhile in BetterBufferedIterator should not read all the elements.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/util/BetterBufferedIterator.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/BetterBufferedIterator.scala
@@ -51,9 +51,11 @@ class BetterBufferedIterator[A](private val iterator: Iterator[A]) extends Buffe
     * Returns an iterator over contiguous elements that match the predicate.
     */
   override def takeWhile(p: (A) => Boolean): Iterator[A] = {
-    val xs = new ListBuffer[A]
-    while (hasNext && p(head)) xs += next()
-    xs.iterator
+    val outer = this
+    new Iterator[A] {
+      def hasNext: Boolean = outer.hasNext && p(outer.head)
+      def next(): A = outer.next()
+    }
   }
 
   /** Drops items while they match the predicate. */


### PR DESCRIPTION

Currently, `BetterBufferedIterator.takeWhile` will store all the elements that match the predicate in a `ListBuffer` before returning an iterator.  This causes OOM for large numbers of elements that match the predicate.  This fix will create an iterator such that calling `next` on the iterator returned by `BetterBufferedIterator.takeWhile` is on-demand/lazy/whatever-the-buzz-word-is-today.