### PR TITLE
Fixed case where TrimPrimers would erroneously remove some deletions from CIGAR strings.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/bam/SamRecordClipper.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/SamRecordClipper.scala
@@ -256,7 +256,7 @@ trait SamRecordClipper {
     //   a) Empty
     //   b) Contains a single element which is the remainder of an element that had to be split
     while (readBasesClipped < numberOfBasesToClip ||
-      (readBasesClipped == numberOfBasesToClip && postClipElems.hasNext && postClipElems.head.getOperator == Op.DELETION)) {
+      (readBasesClipped == numberOfBasesToClip && newElems.isEmpty && postClipElems.hasNext && postClipElems.head.getOperator == Op.DELETION)) {
       val elem = postClipElems.next()
       val op   = elem.getOperator
       val len  = elem.getLength

--- a/src/test/scala/com/fulcrumgenomics/bam/SamRecordClipperTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/SamRecordClipperTest.scala
@@ -101,6 +101,13 @@ class SamRecordClipperTest extends UnitSpec {
     rec.getCigarString shouldBe "10S40M"
   }
 
+  it should "preseve deletions that are not close to the clipped region" in {
+    val rec = r(10, "25M4D25M")
+    SamRecordClipper.clipStartOfAlignment(rec, 10, ClippingMode.Soft)
+    rec.getAlignmentStart shouldBe 20
+    rec.getCigarString shouldBe "10S15M4D25M"
+  }
+
   it should "NOT throw an exception, but do nothing, with an unmapped read" in {
     val rec = r(10, "50M")
     rec.setReadUnmappedFlag(true)
@@ -213,11 +220,18 @@ class SamRecordClipperTest extends UnitSpec {
     rec.getCigarString shouldBe "36M4I10S"
   }
 
-  it should "remove deletions that immediately follow the clipping" in {
+  it should "remove deletions that immediately precede the clipping" in {
     val rec = r(10, "40M4D10M")
     SamRecordClipper.clipEndOfAlignment(rec, 10, ClippingMode.Soft)
     rec.getAlignmentStart shouldBe 10
     rec.getCigarString shouldBe "40M10S"
+  }
+
+  it should "preserve deletions that are not near the clipped region" in {
+    val rec = r(10, "25M4D25M")
+    SamRecordClipper.clipEndOfAlignment(rec, 10, ClippingMode.Soft)
+    rec.getAlignmentStart shouldBe 10
+    rec.getCigarString shouldBe "25M4D15M10S"
   }
 
   it should "NOT throw an exception, but do nothing, with an unmapped read" in {


### PR DESCRIPTION
A small but important change.  TrimPrimers was incorrectly removing some deletions from CIGAR strings that it should not have been.  

The intent has always been to remove deletions that would be adjacent to the clipping in the cigar string (e.g. `20M5D50M` -> `20S50M` not `20S5D50M`.   The problem was that the way it was implemented caused it to do the wrong thing when splitting a cigar operator with a following deletion.  Examples:
`10M5D90M` trim 10 should go to `10S90M`
`50M5D50M` trim 10 should go to `10S40M5D50M` but was going to `10S40M50M`

