### PR TITLE
Added the option to output a tag family size histogram in GroupReadsByUmi.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
@@ -398,7 +398,7 @@ case class TagFamilySizeMetric(family_size: Int,
 class GroupReadsByUmi
 ( @arg(flag="i", doc="The input BAM file.")              val input: PathToBam  = Io.StdIn,
   @arg(flag="o", doc="The output BAM file.")             val output: PathToBam = Io.StdOut,
-  @arg(flag="f", doc="File to write family size histogram to.") val familySizeHistogram: Option[FilePath] = None,
+  @arg(flag="f", doc="Optional output of tag family size counts.") val familySizeHistogram: Option[FilePath] = None,
   @arg(flag="t", doc="The tag containing the raw UMI.")  val rawTag: String    = "RX",
   @arg(flag="T", doc="The output tag for UMI grouping.") val assignTag: String = "MI",
   @arg(flag="m", doc="Minimum mapping quality.")         val minMapQ: Int      = 30,
@@ -450,7 +450,7 @@ class GroupReadsByUmi
     val outProgress = new ProgressLogger(logger, verb="Output")
 
     val iterator = sorter.iterator().grouped(2).map(i => (i(0), i(1))).buffered // consume in pairs
-    val tagFamilySizeCounter  = new NumericCounter[Int]()
+    val tagFamilySizeCounter = new NumericCounter[Int]()
 
     while (iterator.hasNext) {
       // Take the next set of pairs by position and assign UMIs

--- a/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
@@ -29,10 +29,10 @@ package com.fulcrumgenomics.umi
 import java.nio.file.Paths
 import java.util.concurrent.atomic.AtomicLong
 
+import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.cmdline.{ClpGroups, FgBioTool}
 import com.fulcrumgenomics.util.Sequences.countMismatches
-import com.fulcrumgenomics.util.{Io, ProgressLogger, Sequences, SimpleCounter}
-import dagr.commons.CommonsDef.{DirPath, PathToBam}
+import com.fulcrumgenomics.util._
 import dagr.commons.util.LazyLogging
 import dagr.sopt.cmdline.ValidationException
 import dagr.sopt.{arg, clp}
@@ -347,6 +347,12 @@ object GroupReadsByUmi {
   }
 }
 
+/** Trivial metrics class for representing a tag family size histogram entry. */
+case class TagFamilySizeMetric(family_size: Int,
+                               count: Long,
+                               var fraction: Double = 0,
+                               var fraction_gt_or_eq_family_size: Double = 0) extends Metric
+
 @clp(group=ClpGroups.Umi, description =
   """
     |Groups reads together that appear to have come from the same original molecule. Reads
@@ -390,15 +396,16 @@ object GroupReadsByUmi {
   """
 )
 class GroupReadsByUmi
-( @arg(flag="i", doc="The input BAM file.")              input: PathToBam  = Io.StdIn,
-  @arg(flag="o", doc="The output BAM file.")             output: PathToBam = Io.StdOut,
-  @arg(flag="t", doc="The tag containing the raw UMI.")  rawTag: String    = "RX",
-  @arg(flag="T", doc="The output tag for UMI grouping.") assignTag: String = "MI",
-  @arg(flag="m", doc="Minimum mapping quality.")         minMapQ: Int      = 30,
-  @arg(flag="n", doc="Include non-PF reads.")            includeNonPfReads: Boolean = false,
-  @arg(flag="s", doc="The UMI assignment strategy; one of 'identity', 'edit', 'adjacency' or 'paired'.") strategy: String,
-  @arg(flag="e", doc="The allowable number of edits between UMIs.") edits: Int = 1,
-  @arg(          doc="Temporary directory for sorting.") tmpDir: DirPath = Paths.get(System.getProperty("java.io.tmpdir"))
+( @arg(flag="i", doc="The input BAM file.")              val input: PathToBam  = Io.StdIn,
+  @arg(flag="o", doc="The output BAM file.")             val output: PathToBam = Io.StdOut,
+  @arg(flag="f", doc="File to write family size histogram to.") val familySizeHistogram: Option[FilePath] = None,
+  @arg(flag="t", doc="The tag containing the raw UMI.")  val rawTag: String    = "RX",
+  @arg(flag="T", doc="The output tag for UMI grouping.") val assignTag: String = "MI",
+  @arg(flag="m", doc="Minimum mapping quality.")         val minMapQ: Int      = 30,
+  @arg(flag="n", doc="Include non-PF reads.")            val includeNonPfReads: Boolean = false,
+  @arg(flag="s", doc="The UMI assignment strategy; one of 'identity', 'edit', 'adjacency' or 'paired'.") val strategy: String,
+  @arg(flag="e", doc="The allowable number of edits between UMIs.") val edits: Int = 1,
+  @arg(          doc="Temporary directory for sorting.") val tmpDir: DirPath = Paths.get(System.getProperty("java.io.tmpdir"))
 )extends FgBioTool with LazyLogging {
   import GroupReadsByUmi._
 
@@ -416,6 +423,7 @@ class GroupReadsByUmi
     import scala.collection.JavaConversions.asScalaIterator
     Io.assertReadable(input)
     Io.assertCanWriteFile(output)
+    this.familySizeHistogram.foreach(f => Io.assertCanWriteFile(f))
 
     val in = SamReaderFactory.make().open(input.toFile)
     val header = in.getFileHeader
@@ -442,6 +450,8 @@ class GroupReadsByUmi
     val outProgress = new ProgressLogger(logger, verb="Output")
 
     val iterator = sorter.iterator().grouped(2).map(i => (i(0), i(1))).buffered // consume in pairs
+    val tagFamilySizeCounter  = new NumericCounter[Int]()
+
     while (iterator.hasNext) {
       // Take the next set of pairs by position and assign UMIs
       val pairs = takeNextGroup(iterator)
@@ -450,15 +460,30 @@ class GroupReadsByUmi
 
       // Then output the records in the right order (assigned tag, read name, r1, r2)
       val pairsByAssignedTag = pairs.groupBy(pair => pair._1.getStringAttribute(this.assignTag))
+
       pairsByAssignedTag.keys.toSeq.sorted.foreach(tag => {
         pairsByAssignedTag(tag).sortBy(pair => pair._1.getReadName).flatMap(pair => Seq(pair._1, pair._2)).foreach(rec => {
           out.addAlignment(rec)
           outProgress.record(rec)
         })
       })
+
+      // Count up the family sizes
+      pairsByAssignedTag.values.foreach(ps => tagFamilySizeCounter.count(ps.size))
     }
 
     out.close()
+
+    // Write out the family size histogram
+    this.familySizeHistogram match {
+      case None    => Unit
+      case Some(p) =>
+        val ms = tagFamilySizeCounter.toSeq.map { case (size, count) => TagFamilySizeMetric(size, count)}
+        val total = ms.map(_.count.toDouble).sum
+        ms.foreach(m => m.fraction = m.count / total)
+        ms.tails.foreach { tail => tail.headOption.foreach(m => m.fraction_gt_or_eq_family_size = tail.map(_.fraction).sum) }
+        Metric.write(ms, p)
+    }
   }
 
   /** Consumes the next group of pairs with all matching end positions and returns them. */

--- a/src/test/scala/com/fulcrumgenomics/umi/GroupReadsByUmiTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/GroupReadsByUmiTest.scala
@@ -247,7 +247,8 @@ class GroupReadsByUmiTest extends UnitSpec {
 
     val in  = builder.toTempFile()
     val out = Files.createTempFile("umi_grouped.", ".sam")
-    new GroupReadsByUmi(input=in, output=out, rawTag="RX", assignTag="MI", strategy="edit", edits=1).execute()
+    val hist = Files.createTempFile("umi_grouped.", ".histogram.txt")
+    new GroupReadsByUmi(input=in, output=out, familySizeHistogram=Some(hist), rawTag="RX", assignTag="MI", strategy="edit", edits=1).execute()
 
     val reader = SamReaderFactory.make().open(out.toFile)
     val groups = reader.iterator().toSeq.groupBy(_.getReadName.charAt(0))
@@ -256,6 +257,8 @@ class GroupReadsByUmiTest extends UnitSpec {
     groups('a') should have size 4*2
     groups('a').map(_.getReadName).toSet shouldEqual Set("a01", "a02", "a03", "a04")
     groups('a').map(_.getAttribute("MI")).toSet should have size 1
+
+    hist.toFile.exists() shouldBe true
 
     reader.close()
   }


### PR DESCRIPTION
@nh13 I'm still testing this, but want to take a look?  It's a pretty small change to just generate the tag family histogram since it's trivially easy to do during grouping.