### PR TITLE
Change how per-base errors are counted when calling consensuses.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/ConsensusTags.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/ConsensusTags.scala
@@ -50,7 +50,8 @@ object ConsensusTags {
   object PerBase {
     /** The per-base number of raw-reads contributing to the consensus (stored as a short[]). */
     val RawReadCount    = "cd" // consensus depth
-    /** The number of bases at each position that disagreed with the final consensus call (stored as a short[]). */
+    /** The number of bases at each position that disagreed with the final consensus call (stored as a short[]). If the
+      * final consensus call is a no call (N), then we use the most likely consensus base instead of the final call.  */
     val RawReadErrors   = "ce" // consensus errors
 
     // Duplex versions of the above tags for the two single strand consensus reads

--- a/src/main/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCaller.scala
@@ -199,7 +199,7 @@ class VanillaUmiConsensusCaller(override val readNamePrefix: String,
 
         // Generate the values for depth and count of errors
         val depth  = builder.contributions
-        val errors = depth - builder.observations(rawBase)
+        val errors = if (rawBase == NoCall) depth else depth - builder.observations(rawBase)
         consensusDepths(positionInRead) = if (depth  > Short.MaxValue) Short.MaxValue else depth.toShort
         consensusErrors(positionInRead) = if (errors > Short.MaxValue) Short.MaxValue else errors.toShort
 

--- a/src/main/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCaller.scala
@@ -188,14 +188,10 @@ class VanillaUmiConsensusCaller(override val readNamePrefix: String,
 
         // Call the consensus and do any additional filtering
         val (rawBase, rawQual) = builder.call()
-        val (base, qual)       = {
-          if (builder.contributions < this.options.minReads) {
-            (NoCall, NotEnoughReadsQual)
-          }
-          else {
-            if (rawQual < this.options.minConsensusBaseQuality) (NoCall, TooLowQualityQual) else (rawBase, rawQual)
-
-          }
+        val (base, qual) = {
+          if (builder.contributions < this.options.minReads)       (NoCall, NotEnoughReadsQual)
+          else if (rawQual < this.options.minConsensusBaseQuality) (NoCall, TooLowQualityQual)
+          else (rawBase, rawQual)
         }
 
         consensusBases(positionInRead) = base

--- a/src/main/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCaller.scala
@@ -187,13 +187,13 @@ class VanillaUmiConsensusCaller(override val readNamePrefix: String,
         }
 
         // Call the consensus and do any additional filtering
-        val (base, qual) = {
+        val (rawBase, rawQual) = builder.call()
+        val (base, qual)       = {
           if (builder.contributions < this.options.minReads) {
             (NoCall, NotEnoughReadsQual)
           }
           else {
-            val (b,q) = builder.call()
-            if (q < this.options.minConsensusBaseQuality) (NoCall, TooLowQualityQual) else (b,q)
+            if (rawQual < this.options.minConsensusBaseQuality) (NoCall, TooLowQualityQual) else (rawBase, rawQual)
 
           }
         }
@@ -203,7 +203,7 @@ class VanillaUmiConsensusCaller(override val readNamePrefix: String,
 
         // Generate the values for depth and count of errors
         val depth  = builder.contributions
-        val errors = if (base == NoCall) depth else depth - builder.observations(base)
+        val errors = depth - builder.observations(rawBase)
         consensusDepths(positionInRead) = if (depth  > Short.MaxValue) Short.MaxValue else depth.toShort
         consensusErrors(positionInRead) = if (errors > Short.MaxValue) Short.MaxValue else errors.toShort
 


### PR DESCRIPTION
When the final consensus call is a no-call (N), we instead count the
number of errors relative to the most likely consensus call, whereas we
previously used the total depth.

