### PR TITLE
Improve control of sorting in `Bams` sorting methods

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/bam/RemoveSamTags.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/RemoveSamTags.scala
@@ -1,0 +1,60 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package com.fulcrumgenomics.bam
+
+import com.fulcrumgenomics.FgBioDef.{PathToBam, javaIterableToIterator}
+import com.fulcrumgenomics.cmdline.{ClpGroups, FgBioTool}
+import com.fulcrumgenomics.util.Io
+import dagr.commons.CommonsDef.SafelyClosable
+import dagr.sopt.{arg, clp}
+import htsjdk.samtools.{SAMFileWriter, SAMFileWriterFactory, SamReader, SamReaderFactory}
+
+@clp(
+  description = "Removes SAM tags from a SAM or BAM file.  If no tags to remove are given, the original file is produced.",
+  group = ClpGroups.SamOrBam
+)
+class RemoveSamTags
+( @arg(flag="i", doc = "Input SAM or BAM.") val input: PathToBam,
+  @arg(flag="o", doc = "Output SAM or BAM.") val output: PathToBam,
+  @arg(flag="t", doc = "The tags to remove.", minElements = 0) val tagsToRemove: Seq[String] = Seq.empty
+) extends FgBioTool {
+
+  Io.assertReadable(input)
+  Io.assertCanWriteFile(output)
+
+  validate(tagsToRemove.forall(_.length == 2), "Tags to remove must be of length two: " + tagsToRemove.filter(_.length != 2).mkString(", "))
+
+  override def execute(): Unit = {
+    val reader: SamReader     = SamReaderFactory.makeDefault.open(input.toFile)
+    val writer: SAMFileWriter = new SAMFileWriterFactory().makeSAMOrBAMWriter(reader.getFileHeader, true, output.toFile)
+    reader.foreach { rec =>
+      tagsToRemove.foreach { tag => rec.setAttribute(tag, null) }
+      writer.addAlignment(rec)
+    }
+    reader.safelyClose()
+    writer.close()
+  }
+}

--- a/src/test/scala/com/fulcrumgenomics/bam/RemoveSamTagsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/RemoveSamTagsTest.scala
@@ -1,0 +1,68 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package com.fulcrumgenomics.bam
+
+import com.fulcrumgenomics.testing.{SamRecordSetBuilder, UnitSpec}
+
+class RemoveSamTagsTest extends UnitSpec {
+
+  "RemoveSamTags" should "run end-to-end" in {
+    val builder = new SamRecordSetBuilder()
+    builder.addFrag(unmapped=true).foreach { rec => rec.setAttribute("OK", "foo"); rec.setAttribute("NO", "bar") }
+    builder.addFrag(unmapped=true).foreach { rec => rec.setAttribute("OK", "foo"); }
+    builder.addFrag(unmapped=true).foreach { rec => rec.setAttribute("NO", "bar") }
+    builder.addFrag(unmapped=true)
+
+    val input = builder.toTempFile()
+    val output = makeTempFile("RemoveSamTags", ".bam")
+    val tagsToRemove = Seq("NO")
+
+    new RemoveSamTags(input=input, output=output, tagsToRemove=tagsToRemove).execute()
+
+    val records = readBamRecs(output)
+    records should have size 4
+    records.count(_.getAttribute("OK") != null) shouldBe 2
+    records.count(_.getAttribute("NO") == null) shouldBe 4
+  }
+
+  it should "run end-to-end with no tags to remove" in {
+    val builder = new SamRecordSetBuilder()
+    builder.addFrag(unmapped=true).foreach { rec => rec.setAttribute("OK", "foo"); rec.setAttribute("NO", "bar") }
+    builder.addFrag(unmapped=true).foreach { rec => rec.setAttribute("OK", "foo"); }
+    builder.addFrag(unmapped=true).foreach { rec => rec.setAttribute("NO", "bar") }
+    builder.addFrag(unmapped=true)
+
+    val input = builder.toTempFile()
+    val output = makeTempFile("RemoveSamTags", ".bam")
+
+    new RemoveSamTags(input=input, output=output).execute()
+
+    val records = readBamRecs(output)
+    records should have size 4
+    records.count(_.getAttribute("OK") != null) shouldBe 2
+    records.count(_.getAttribute("NO") != null) shouldBe 2
+  }
+}


### PR DESCRIPTION
I am indifferent to exposing the "reads in memory" option in `ClipOverlappingReads` but I do like the change to `Bams` to make the `maxInMemory` parameter `Optional` as well as adding in a param `tagsToRemove` in case we have very many very large per-record tags.