### PR TITLE
Fix to sort/unique intervals first in ErrorRateByReadPosition.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/bam/ErrorRateByReadPosition.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ErrorRateByReadPosition.scala
@@ -114,7 +114,7 @@ class ErrorRateByReadPosition
   private[bam] def computeMetrics: Seq[ErrorRateByReadPositionMetric] = {
     val progress = new ProgressLogger(logger, verb="Processed", noun="loci", unit=50000)
     val in       = SamReaderFactory.make().referenceSequence(ref.toFile).open(input)
-    val ilist    = this.intervals.map(p => IntervalList.fromFile(p.toFile))
+    val ilist    = this.intervals.map(p => IntervalList.fromFile(p.toFile).uniqued(false))
 
     val refWalker     = new ReferenceSequenceFileWalker(this.ref.toFile)
     val locusIterator = buildSamLocusIterator(in, ilist).iterator()

--- a/src/main/scala/com/fulcrumgenomics/vcf/ByIntervalListVariantContextIterator.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/ByIntervalListVariantContextIterator.scala
@@ -68,7 +68,7 @@ private class OverlapDetectionVariantContextIterator(val iterator: Iterator[Vari
   extends Iterator[VariantContext] {
 
   require(dict != null)
-  private val intervals = intervalList.iterator().buffered
+  private val intervals = intervalList.uniqued(false).iterator().buffered
   private var nextVariantContext: Option[VariantContext] = None
 
   this.advance()

--- a/src/test/scala/com/fulcrumgenomics/vcf/ByIntervalListVariantContextIteratorTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/vcf/ByIntervalListVariantContextIteratorTest.scala
@@ -67,7 +67,7 @@ class ByIntervalListVariantContextIteratorTest extends UnitSpec {
     Stream(true, false).foreach { useIndex =>
       val builder = new VariantContextSetBuilder()
       val intervalList = emtpyIntervalList()
-      intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 1, 1000))
+      intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 1, 1000, false, "foo"))
       val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=emtpyIntervalList(), useIndex=useIndex)
       iterator shouldBe 'empty
     }
@@ -77,7 +77,7 @@ class ByIntervalListVariantContextIteratorTest extends UnitSpec {
     Stream(true, false).foreach { useIndex =>
       val builder = new VariantContextSetBuilder().addVariant(refIdx=0, start=500, variantAlleles=List("A"), genotypeAlleles=List("A"))
       val intervalList = emtpyIntervalList()
-      intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 1, 1000))
+      intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 1, 1000, false, "foo"))
       val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=intervalList, useIndex=useIndex)
       iterator shouldBe 'nonEmpty
       val actual = iterator.next()
@@ -93,7 +93,7 @@ class ByIntervalListVariantContextIteratorTest extends UnitSpec {
     Stream(true, false).foreach { useIndex =>
       val builder = new VariantContextSetBuilder().addVariant(refIdx=0, start=500, variantAlleles=List("A"), genotypeAlleles=List("A"))
       val intervalList = emtpyIntervalList()
-      intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 750, 1000))
+      intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 750, 1000, false, "foo"))
       val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=intervalList, useIndex=useIndex)
       iterator shouldBe 'empty
     }
@@ -103,7 +103,7 @@ class ByIntervalListVariantContextIteratorTest extends UnitSpec {
     Stream(true, false).foreach { useIndex =>
       val builder = new VariantContextSetBuilder().addVariant(refIdx=0, start=500, variantAlleles=List("A"), genotypeAlleles=List("A"))
       val intervalList = emtpyIntervalList()
-      intervalList.add(new Interval(dict.getSequence(1).getSequenceName, 1, 1000))
+      intervalList.add(new Interval(dict.getSequence(1).getSequenceName, 1, 1000, false, "foo"))
       val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=intervalList, useIndex=useIndex)
       iterator shouldBe 'empty
     }
@@ -122,7 +122,7 @@ class ByIntervalListVariantContextIteratorTest extends UnitSpec {
     Stream(true, false).foreach { useIndex =>
       val builder = new VariantContextSetBuilder().addVariant(refIdx=0, start=495, variantAlleles=List("AAAAA", "A"), genotypeAlleles=List("A"))
       val intervalList = emtpyIntervalList()
-      intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 496, 496))
+      intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 496, 496, false, "foo"))
       val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=intervalList, useIndex=useIndex)
       iterator shouldBe 'nonEmpty
       val actual = iterator.next()
@@ -138,8 +138,8 @@ class ByIntervalListVariantContextIteratorTest extends UnitSpec {
     Stream(true, false).foreach { useIndex =>
       val builder = new VariantContextSetBuilder().addVariant(refIdx=0, start=495, variantAlleles=List("AAAAA", "A"), genotypeAlleles=List("A"))
       val intervalList = emtpyIntervalList()
-      intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 496, 496))
-      intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 500, 500))
+      intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 496, 496, false, "foo"))
+      intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 500, 500, false, "foo"))
       val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=intervalList, useIndex=useIndex)
       iterator shouldBe 'nonEmpty
       val actual = iterator.next()
@@ -156,8 +156,8 @@ class ByIntervalListVariantContextIteratorTest extends UnitSpec {
       .addVariant(refIdx=0, start=495, variantAlleles=List("AAAAA", "A"), genotypeAlleles=List("A"))
       .addVariant(refIdx=0, start=595, variantAlleles=List("AAAAA", "A"), genotypeAlleles=List("A"))
     val intervalList = emtpyIntervalList()
-    intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 494, 500))
-    intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 500, 500))
+    intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 494, 500, false, "foo"))
+    intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 500, 500, false, "foo"))
     val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=intervalList, useIndex=true)
     // OK, since we are overlapping the first interval
     iterator shouldBe 'nonEmpty
@@ -169,7 +169,7 @@ class ByIntervalListVariantContextIteratorTest extends UnitSpec {
     Stream(true, false).foreach { useIndex =>
       val builder = new VariantContextSetBuilder().addVariant(refIdx=0, start=495, variantAlleles=List("A", "C"), genotypeAlleles=List("C"))
       val intervalList = emtpyIntervalList()
-      intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 500, 500))
+      intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 500, 500, false, "foo"))
       val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=intervalList, useIndex=useIndex)
       iterator shouldBe 'empty
     }


### PR DESCRIPTION
@nh13 This started out as a trivial PR to add `uniqued(false)` to the intervals in `ErrorRateByReadPosition`, but grew a bit.  It turned out the root of the problem was that `ByIntervalListVariantContextIterator` was not defensive in ensuring the `IntervalList` it was given was sorted/uniqued.  I added that, and then ran into a bug in HTSJDK where calling `uniqued(false)` on intervals without names throws an exception!  Hence the addition of `false, "foo"` to all the intervals in the tests for `ByIntervalListVariantContextIterator`.

I've submitted a PR to htsjdk, but don't want to wait on a release there.