### PR TITLE
Fix so that FilterSomaticVcf doesn't NPE if the input VCF lacks a sequence dictionary.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/vcf/filtration/FilterSomaticVcf.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/filtration/FilterSomaticVcf.scala
@@ -178,10 +178,7 @@ class FilterSomaticVcf
       f.VcfFilterLines.foreach(header.addMetaDataLine)
     }
 
-    Option(in.getSequenceDictionary) match {
-      case Some(sd) => header.setSequenceDictionary(sd)
-      case None     => Unit
-    }
+    Option(in.getSequenceDictionary).foreach(header.setSequenceDictionary)
 
     val writer = new VariantContextWriterBuilder()
       .setOutputFile(output.toFile)

--- a/src/main/scala/com/fulcrumgenomics/vcf/filtration/FilterSomaticVcf.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/filtration/FilterSomaticVcf.scala
@@ -177,7 +177,11 @@ class FilterSomaticVcf
       f.VcfInfoLines.foreach(header.addMetaDataLine)
       f.VcfFilterLines.foreach(header.addMetaDataLine)
     }
-    header.setSequenceDictionary(in.getSequenceDictionary)
+
+    Option(in.getSequenceDictionary) match {
+      case Some(sd) => header.setSequenceDictionary(sd)
+      case None     => Unit
+    }
 
     val writer = new VariantContextWriterBuilder()
       .setOutputFile(output.toFile)


### PR DESCRIPTION
The htsjdk VCF code, in it's ultimate wisdom will return `null` from `VCFHeader.getSequenceDictionary()` if there are no contig lines, and then turn around and throw a `NullPointerException` at you if you call `VCFHeader.setSequenceDictionary(null)`.  So it's not safe to just do `newHeader.setSequenceDictionary(oldHeader.getSequenceDictionary())`.  Sigh.