### PR TITLE
Added the ability to limit the maximum number of reads going into a consensus.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReads.scala
@@ -108,7 +108,11 @@ class CallMolecularConsensusReads
    """)
  val minConsensusBaseQuality: PhredScore = 2.toByte,
  @arg(flag="M", doc="The minimum number of reads to produce a consensus base.") val minReads: Int,
- @arg(doc="The maximum number of reads to use when building a consensus.") val maxReads: Option[Int] = None,
+ @arg(doc="""
+            |The maximum number of reads to use when building a consensus. If more than this many reads are
+            |present in a tag family, the family is randomly downsampled to exactly max-reads reads.
+          """)
+ val maxReads: Option[Int] = None,
  @arg(flag="B", doc="If true produce tags on consensus reads that contain per-base information.") val outputPerBaseTags: Boolean = DefaultProducePerBaseTags,
  @arg(flag="S", doc="The sort order of the output, if None then the same as the input.") val sortOrder: Option[SortOrder] = Some(SortOrder.queryname),
  @arg(flag="D", doc="Turn on debug logging.") val debug: Boolean = false

--- a/src/main/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReads.scala
@@ -108,6 +108,7 @@ class CallMolecularConsensusReads
    """)
  val minConsensusBaseQuality: PhredScore = 2.toByte,
  @arg(flag="M", doc="The minimum number of reads to produce a consensus base.") val minReads: Int,
+ @arg(doc="The maximum number of reads to use when building a consensus.") val maxReads: Option[Int] = None,
  @arg(flag="B", doc="If true produce tags on consensus reads that contain per-base information.") val outputPerBaseTags: Boolean = DefaultProducePerBaseTags,
  @arg(flag="S", doc="The sort order of the output, if None then the same as the input.") val sortOrder: Option[SortOrder] = Some(SortOrder.queryname),
  @arg(flag="D", doc="Turn on debug logging.") val debug: Boolean = false
@@ -139,6 +140,7 @@ class CallMolecularConsensusReads
       minInputBaseQuality          = minInputBaseQuality,
       minConsensusBaseQuality      = minConsensusBaseQuality,
       minReads                     = minReads,
+      maxReads                     = maxReads.getOrElse(Int.MaxValue),
       producePerBaseTags           = outputPerBaseTags
     )
 

--- a/src/main/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCaller.scala
@@ -173,7 +173,7 @@ class VanillaUmiConsensusCaller(override val readNamePrefix: String,
     }
     else {
       // First limit to max reads if necessary
-      val capped  = if (reads.size < this.options.maxReads) reads else this.random.shuffle(reads).take(this.options.maxReads)
+      val capped  = if (reads.size <= this.options.maxReads) reads else this.random.shuffle(reads).take(this.options.maxReads)
 
       // get the most likely consensus bases and qualities
       val consensusLength = consensusReadLength(capped, this.options.minReads)

--- a/src/main/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCaller.scala
@@ -34,6 +34,7 @@ import dagr.commons.util.LazyLogging
 import htsjdk.samtools._
 
 import scala.collection.mutable.ListBuffer
+import scala.util.Random
 
 /**
   * Holds the defaults for consensus caller options.
@@ -46,6 +47,7 @@ object VanillaUmiConsensusCallerOptions {
   val DefaultMinInputBaseQuality: PhredScore     = 10.toByte
   val DefaultMinConsensusBaseQuality: PhredScore = 40.toByte
   val DefaultMinReads: Int                       = 2
+  val DefaultMaxReads: Int                       = Int.MaxValue
   val DefaultProducePerBaseTags: Boolean         = true
 }
 
@@ -60,6 +62,7 @@ case class VanillaUmiConsensusCallerOptions
   minInputBaseQuality: PhredScore     = DefaultMinInputBaseQuality,
   minConsensusBaseQuality: PhredScore = DefaultMinConsensusBaseQuality,
   minReads: Int                       = DefaultMinReads,
+  maxReads: Int                       = DefaultMaxReads,
   producePerBaseTags: Boolean         = DefaultProducePerBaseTags
 )
 
@@ -100,13 +103,15 @@ class VanillaUmiConsensusCaller(override val readNamePrefix: String,
                                 val rejects: Option[SAMFileWriter] = None
                                ) extends UmiConsensusCaller[VanillaConsensusRead] with LazyLogging {
 
+  private val NotEnoughReadsQual: PhredScore = 0.toByte // Score output when masking to N due to insufficient input reads
+  private val TooLowQualityQual: PhredScore = 2.toByte  // Score output when masking to N due to too low consensus quality
   private val DnaBasesUpperCase: Array[Byte] = Array('A', 'C', 'G', 'T').map(_.toByte)
   private val LogThree = LogProbability.toLogProbability(3.0)
+
   private val caller = new ConsensusCaller(errorRatePreLabeling  = options.errorRatePreUmi,
                                            errorRatePostLabeling = options.errorRatePostUmi)
 
-  private val NotEnoughReadsQual: PhredScore = 0.toByte // Score output when masking to N due to insufficient input reads
-  private val TooLowQualityQual: PhredScore = 2.toByte  // Score output when masking to N due to too low consensus quality
+  private val random = new Random(42)
 
   /** Returns the value of the SAM tag directly. */
   override def sourceMoleculeId(rec: SAMRecord): String = rec.getStringAttribute(this.options.tag)
@@ -167,8 +172,11 @@ class VanillaUmiConsensusCaller(override val readNamePrefix: String,
       None
     }
     else {
+      // First limit to max reads if necessary
+      val capped  = if (reads.size < this.options.maxReads) reads else this.random.shuffle(reads).take(this.options.maxReads)
+
       // get the most likely consensus bases and qualities
-      val consensusLength = consensusReadLength(reads, this.options.minReads)
+      val consensusLength = consensusReadLength(capped, this.options.minReads)
       val consensusBases  = new Array[Base](consensusLength)
       val consensusQuals  = new Array[PhredScore](consensusLength)
       val consensusDepths = new Array[Short](consensusLength)
@@ -178,7 +186,7 @@ class VanillaUmiConsensusCaller(override val readNamePrefix: String,
       val builder = this.caller.builder()
       while (positionInRead < consensusLength) {
         // Add the evidence from all reads that are long enough to cover this base
-        reads.foreach { read =>
+        capped.foreach { read =>
           if (read.length > positionInRead) {
             val base = read.bases(positionInRead)
             val qual = read.quals(positionInRead)
@@ -208,7 +216,7 @@ class VanillaUmiConsensusCaller(override val readNamePrefix: String,
         positionInRead += 1
       }
 
-      Some(VanillaConsensusRead(id=reads.head.id, bases=consensusBases, quals=consensusQuals, depths=consensusDepths, errors=consensusErrors))
+      Some(VanillaConsensusRead(id=capped.head.id, bases=consensusBases, quals=consensusQuals, depths=consensusDepths, errors=consensusErrors))
     }
   }
 

--- a/src/test/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCallerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCallerTest.scala
@@ -163,10 +163,9 @@ class VanillaUmiConsensusCallerTest extends UnitSpec with OptionValues {
       val consensus = caller.consensusCall(srcs)
 
       consensus match {
-        case None    => fail("Consensus should have been generated")
-        case Some(c) =>
-          if (n < max) c.depths.forall(_ <= n)   shouldBe true
-          else         c.depths.forall(_ <= max) shouldBe true
+        case None                => fail("Consensus should have been generated")
+        case Some(c) if n <= max => c.depths.forall(_ <= n)   shouldBe true
+        case Some(c)             => c.depths.forall(_ <= max) shouldBe true
       }
     }
   }

--- a/src/test/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCallerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCallerTest.scala
@@ -154,6 +154,22 @@ class VanillaUmiConsensusCallerTest extends UnitSpec with OptionValues {
     consensus.get.baseString shouldBe "AAAAAAAAAA"
   }
 
+  it should "downsample input reads so that each consensus is made from <= max reads" in {
+    val r = src("AAAAAAAAAA", "##########")
+
+    for (max <- Seq(3, 1000); n <- Range.inclusive(1, 10)) {
+      val srcs      = Seq.tabulate(n)(_ => r)
+      val caller    = cc(cco(minReads=1, maxReads=max))
+      val consensus = caller.consensusCall(srcs)
+
+      consensus match {
+        case None    => fail("Consensus should have been generated")
+        case Some(c) =>
+          if (n < max) c.depths.forall(_ <= n)   shouldBe true
+          else         c.depths.forall(_ <= max) shouldBe true
+      }
+    }
+  }
 
   it should "mask bases with too low of a consensus quality" in {
     val bases = "GATTACA"


### PR DESCRIPTION
@nh13 This PR introduces a parameter to allow you to limit the consensus caller to using `n` input reads.  My goal in doing this is to be able to evaluate consensus reads generated at different levels of input more easily.  I.e. what is my reduction in error in going from tag family size 2 to 3, to 4 to 10, etc.  This is hampered by the fact that in a real library the distribution of tag family sizes is often pretty broad and using `min=3` yields consensus reads that have 3+ family members, and often most of the data is at n > 3.

I'm open to putting the downsampling in at a different point, but I figured where I put it a) makes testing simpler (can be done with `SourceRead`s vs. `SAMRecord`s) and b) is after the indel-based filtering, so has the chance to downsample from usable reads vs. reads that may make it in, therefore increasing potential yield.