### PR TITLE
DemuxFastqs improvements

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/illumina/SampleSheet.scala
+++ b/src/main/scala/com/fulcrumgenomics/illumina/SampleSheet.scala
@@ -103,7 +103,7 @@ object SampleSheet {
         val values = line.split(SplitRegex, -1)
         // check we have the correct # of columns
         if (values.size != header.length) {
-          throw new IllegalArgumentException(s"Found a line with a mismatching number of columns: " + line)
+          throw new IllegalArgumentException(s"Found a line with a mismatching number of columns on line #$lineNumber: " + line)
         }
         header.zip(values.map(_.trim)).toMap
       }

--- a/src/main/scala/com/fulcrumgenomics/util/DelimitedDataParser.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/DelimitedDataParser.scala
@@ -63,8 +63,10 @@ class Row private[util] (private val headerIndices: Map[String,Int], private val
     }
   }
 
-  /** Gets a value from the specified column. If the value is null or empty returns None. */
-  def get[A](column: String)(implicit tag: ru.TypeTag[A]): Option[A] = get(headerIndices(column))
+  /** Gets a value from the specified column. If the value is null or empty returns None.  If
+    * `allowMissingColumn` is true, then None is returned if the given column name is not present. */
+  def get[A](column: String, allowMissingColumn: Boolean = false)(implicit tag: ru.TypeTag[A]): Option[A] =
+    if (allowMissingColumn) headerIndices.get(column).map(apply[A]) else get(headerIndices(column))
 }
 
 

--- a/src/main/scala/com/fulcrumgenomics/util/Io.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/Io.scala
@@ -23,7 +23,7 @@
  */
 package com.fulcrumgenomics.util
 
-import java.io.{InputStream, OutputStream}
+import java.io.{BufferedWriter, InputStream, OutputStream, OutputStreamWriter}
 import java.nio.file.{Files, Path, Paths}
 import java.util.zip.{GZIPInputStream, GZIPOutputStream}
 

--- a/src/test/scala/com/fulcrumgenomics/util/DelimitedDataParserTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/util/DelimitedDataParserTest.scala
@@ -147,4 +147,11 @@ class DelimitedDataParserTest extends UnitSpec {
     row3.get[Int]("b") shouldBe None
     row3.get[Int]("c") shouldBe Some(3)
   }
+
+  "DelimitedDataParser.getOrNone" should "return None if the column header does not exist" in {
+    val parser = csv(Seq("a,b,c", "1,2,3"))
+    val row = parser.next()
+    row.get[Int]("d", allowMissingColumn=true) shouldBe None
+    an[Exception] shouldBe thrownBy { row.get[Int]("d", allowMissingColumn=false) }
+  }
 }


### PR DESCRIPTION
Three main features have been added:
1. The output metrics file name is no longer required.
2. A CSV file can be given with sample metadata in lieu of a sample sheet.  Some users requested this feature as they are not experts on Illumina sample sheets.
3. Gzipped FASTQs can now also be written.  Users requested this feature, even though Picard's `SamToFastq` can be used on the outputs of this tool.