### PR TITLE
Add some explicit assumption checks in DuplexConsensusCaller.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
@@ -253,6 +253,10 @@ trait UmiConsensusCaller[C <: SimpleRead] {
     * NOTE: filtered out reads are sent to the [[rejectRecords()]] method and do not need further handling
     */
   protected[umi] def filterToMostCommonAlignment(recs: Seq[SAMRecord]): Seq[SAMRecord] = {
+    if (recs.nonEmpty) {
+      require(recs.forall(r => r.getReadNegativeStrandFlag == recs.head.getReadNegativeStrandFlag),
+        "Not all records were on the same strand.")
+    }
     val groups = recs.groupBy { r =>
       val builder = new mutable.StringBuilder
       val elems = r.getCigar.getCigarElements.iterator().bufferBetter

--- a/src/test/scala/com/fulcrumgenomics/umi/CallDuplexConsensusReadsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/CallDuplexConsensusReadsTest.scala
@@ -27,6 +27,7 @@ package com.fulcrumgenomics.umi
 import java.nio.file.Paths
 
 import com.fulcrumgenomics.FgBioDef._
+import com.fulcrumgenomics.testing.SamRecordSetBuilder.{Minus, Plus}
 import com.fulcrumgenomics.testing.{SamRecordSetBuilder, UnitSpec}
 import htsjdk.samtools.SamReaderFactory
 
@@ -58,14 +59,24 @@ class CallDuplexConsensusReadsTest extends UnitSpec {
     checkClpAnnotations[CallDuplexConsensusReads]
   }
 
+  it should "run fail if AB-R1s are not on the same strand ads BA-R2s" in {
+    val builder = new SamRecordSetBuilder(readLength=10)
+    builder.addPair(name="ab1", start1=100, start2=200, attrs=Map(MI -> "1/A")).foreach { _.setReadString("AAAAAAAAAA") }
+    builder.addPair(name="ba1", start1=200, start2=100, attrs=Map(MI -> "1/B")).foreach { _.setReadString("AAAAAAAAAA") }
+
+    val in  = builder.toTempFile()
+    val out = makeTempFile("duplex.", ".bam")
+    an[Exception] should be thrownBy new CallDuplexConsensusReads(input=in, output=out, readGroupId="ZZ").execute()
+  }
+
   it should "run successfully and create consensus reads" in {
     val builder = new SamRecordSetBuilder(readLength=10)
     builder.addPair(name="ab1", start1=100, start2=100, attrs=Map(MI -> "1/A")).foreach { _.setReadString("AAAAAAAAAA") }
     builder.addPair(name="ab2", start1=100, start2=100, attrs=Map(MI -> "1/A")).foreach { _.setReadString("AAAAAAAAAA") }
     builder.addPair(name="ab3", start1=100, start2=100, attrs=Map(MI -> "1/A")).foreach { _.setReadString("AAAAAAAAAA") }
-    builder.addPair(name="ba1", start1=100, start2=100, attrs=Map(MI -> "1/B")).foreach { _.setReadString("AAAAAAAAAA") }
-    builder.addPair(name="ba2", start1=100, start2=100, attrs=Map(MI -> "1/B")).foreach { _.setReadString("AAAAAAAAAA") }
-    builder.addPair(name="ba3", start1=100, start2=100, attrs=Map(MI -> "1/B")).foreach { _.setReadString("AAAAAAAAAA") }
+    builder.addPair(name="ba1", start1=100, start2=100, strand1=Minus, strand2=Plus, attrs=Map(MI -> "1/B")).foreach { _.setReadString("AAAAAAAAAA") }
+    builder.addPair(name="ba2", start1=100, start2=100, strand1=Minus, strand2=Plus, attrs=Map(MI -> "1/B")).foreach { _.setReadString("AAAAAAAAAA") }
+    builder.addPair(name="ba3", start1=100, start2=100, strand1=Minus, strand2=Plus, attrs=Map(MI -> "1/B")).foreach { _.setReadString("AAAAAAAAAA") }
 
     val in  = builder.toTempFile()
     val out = makeTempFile("duplex.", ".bam")


### PR DESCRIPTION
1. That AB-R1s and BA-R2s should be on the same strand, and the
same for AB-R2s and BA-R1s.
2. That UmiConsensusCaller.filterToMostCommonAlignment should only
receive reads from the same strand.