### PR TITLE
Tune the amount of memory used by DemuxFastqs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache:
 addons:
   apt:
     sources:
-      - r-packages-precise
+      - r-packages-trusty
     packages:
       - r-base
       - r-recommended


### PR DESCRIPTION
Too many reads were stored in RAM when sorting reads with a large # of output samples.