### PR TITLE
Output the consensus UMI bases when calling consensus reads.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/SimpleConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/SimpleConsensusCaller.scala
@@ -1,0 +1,82 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.fulcrumgenomics.umi
+
+import com.fulcrumgenomics.FgBioDef.forloop
+import com.fulcrumgenomics.util.NumericTypes.{LogProbability, PhredScore}
+
+/**
+  * A class that can be mixed in to call sequences represented as strings of the same length.
+  *
+  * If a non-ACGTN bases is encountered at any position in the strings, that position is not consensus called, and the
+  * character from the first sequenced is used.  All strings should have the same non-ACGTN character at this position.
+  *
+  * @param errorRatePreLabeling The error probability prior to adding the UMI.  By default, set to almost surely zero.
+  * @param errorRatePostLabeling The error probability post to adding the UMI.  By default, set to almost surely zero
+  * @param qError The adjusted error probability.  By default set to Q20.
+  */
+private[umi] class SimpleConsensusCaller(val errorRatePreLabeling: Byte = 90.toByte,
+                                         val errorRatePostLabeling: Byte = 90.toByte,
+                                         qError: PhredScore = 20.toByte
+                                        ) {
+  val pError: LogProbability = LogProbability.fromPhredScore(this.qError)
+  val pTruth: LogProbability = LogProbability.not(this.pError)
+
+  /** A consensus caller used to generate consensus UMI sequences */
+  private val consensusBuilder = new ConsensusCaller(
+    errorRatePreLabeling  = this.errorRatePreLabeling,
+    errorRatePostLabeling = this.errorRatePostLabeling
+  ).builder()
+
+  private val DnaBases = Set('A', 'C', 'G', 'T', 'N', 'a', 'c', 'g', 't', 'n')
+
+  /** Calls a simple consensus sequences from a set of sequences all the same length. */
+  def callConsensus(sequences: Seq[String]): String = {
+    require(sequences.nonEmpty, "Can't call consensus on an empty set of sequences!")
+    require(sequences.forall(_.length == sequences.head.length), "Sequences must all have the same length")
+    val buffer = new StringBuilder
+
+    forloop (from=0, until=sequences.head.length) { i =>
+      this.consensusBuilder.reset()
+      var nonDna = 0
+      sequences.foreach { sequence =>
+        val char = sequence.charAt(i)
+        if (!this.DnaBases.contains(char)) {
+          nonDna += 1
+          // verify that all non-DNA bases are the same character
+          require(sequences.head.charAt(i) == char,
+            s"Sequences must have character '${sequences.head.charAt(i)}' at position $i, found '$char'")
+        }
+        else this.consensusBuilder.add(char.toByte, pError=this.pError, pTruth=this.pTruth)
+      }
+
+      if (nonDna == 0) buffer.append(this.consensusBuilder.call()._1.toChar)
+      else if (nonDna == sequences.length) buffer.append(sequences.head.charAt(i)) // NB: we have previously verified they are all the same character
+      else throw new IllegalStateException(s"Sequences contained a mix of DNA and non-DNA characters at offset $i: $sequences")
+    }
+
+    buffer.toString()
+  }
+}

--- a/src/test/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReadsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReadsTest.scala
@@ -36,7 +36,7 @@ import com.fulcrumgenomics.umi.VanillaUmiConsensusCallerOptions._
   */
 class CallMolecularConsensusReadsTest extends UnitSpec {
 
-  def newBam = makeTempFile("call_molecular_consensus_reads_test.", ".bam")
+  private def newBam = makeTempFile("call_molecular_consensus_reads_test.", ".bam")
 
   "CallMolecularConsensusReads" should "run end-to-end" in {
     val rlen    = 100
@@ -46,8 +46,9 @@ class CallMolecularConsensusReadsTest extends UnitSpec {
 
     // Create 2000 paired end reads, where there are two pairs with the same coordinates and have the same group tag.
     Stream.range(0, 1000).foreach { idx =>
-      val firstPair  = builder.addPair(name=s"READ:" + 2*idx,   start1=1+idx, start2=1000000+idx, bases1="A"*rlen, bases2="T"*rlen, attrs=Map(DefaultTag -> ("GATTACA:" + idx)))
-      val secondPair = builder.addPair(name=s"READ:" + 2*idx+1, start1=1+idx, start2=1000000+idx, bases1="A"*rlen, bases2="T"*rlen, attrs=Map(DefaultTag -> ("GATTACA:" + idx)))
+      val attrs = Map(DefaultTag -> ("GATTACA:" + idx), ConsensusTags.UmiBases -> "ACGT-TGCA")
+      builder.addPair(name=s"READ:" + 2*idx,   start1=1+idx, start2=1000000+idx, bases1="A"*rlen, bases2="T"*rlen, attrs=attrs)
+      builder.addPair(name=s"READ:" + 2*idx+1, start1=1+idx, start2=1000000+idx, bases1="A"*rlen, bases2="T"*rlen, attrs=attrs)
     }
 
     // Run the tool
@@ -64,6 +65,8 @@ class CallMolecularConsensusReadsTest extends UnitSpec {
       rec.readGroup.getId shouldBe "ABC"
       rec.basesString shouldBe "A" * 100
       rec.length shouldBe 100
+      rec[String](DefaultTag).startsWith("GATTACA") shouldBe true
+      rec[String](ConsensusTags.UmiBases) shouldBe "ACGT-TGCA"
     }
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/umi/SimpleConsensusCallerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/SimpleConsensusCallerTest.scala
@@ -1,0 +1,66 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.fulcrumgenomics.umi
+
+import com.fulcrumgenomics.testing.UnitSpec
+
+class SimpleConsensusCallerTest extends UnitSpec {
+
+  "SimpleConsensusCaller" should "fail if no sequences are given" in {
+    val caller = new SimpleConsensusCaller()
+    an[Exception] should be thrownBy caller.callConsensus(Seq.empty)
+  }
+
+  it should "fail if the sequences have different lengths" in {
+    val caller = new SimpleConsensusCaller()
+    an[Exception] should be thrownBy caller.callConsensus(Seq("A", "AC"))
+  }
+
+  it should "fail if not all strings had the same non-ACGTN character at the same position" in {
+    val caller = new SimpleConsensusCaller()
+    an[Exception] should be thrownBy caller.callConsensus(Seq("GATT-ACA", "GATT-ACA", "GATTAACA"))
+  }
+
+  it should "create a consensus from the sequences that all agree" in {
+    val caller = new SimpleConsensusCaller()
+    caller.callConsensus(Seq("A", "A")) shouldBe "A"
+    caller.callConsensus(Seq("GATTACA", "GATTACA")) shouldBe "GATTACA"
+  }
+
+  it should "create a consensus from sequences that differ" in {
+    val caller = new SimpleConsensusCaller()
+    caller.callConsensus(Seq("A", "C", "G", "T")) shouldBe "N"
+    caller.callConsensus(Seq("A", "C", "C", "C")) shouldBe "C"
+    caller.callConsensus(Seq("C", "C", "C", "A")) shouldBe "C"
+    caller.callConsensus(Seq("GATTACA", "GATTACA", "GATTACA", "NNNNNNN")) shouldBe "GATTACA"
+  }
+
+  it should "gracefully handle non-ACGTN bases" in {
+    val caller = new SimpleConsensusCaller()
+    caller.callConsensus(Seq("GATT-ACA", "GATT-ACA", "GATT-ACA")) shouldBe "GATT-ACA"
+    caller.callConsensus(Seq("XGAT", "XGAT")) shouldBe "XGAT"
+    caller.callConsensus(Seq("GATY", "GATY")) shouldBe "GATY"
+  }
+}


### PR DESCRIPTION
For vanilla consensus reads, this is just the consensus sequence across all input reads.  The consensus is generated per-end for a read-pair.

For duplex consensus reads, we group the reads into two sets (AB R1s with BA R2s, and BA R1s with AB R2s), and call the consensus UMI on each set respectively.