### PR TITLE
Adding the option to output duplex consensus reads generated from onl…

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
@@ -52,6 +52,14 @@ object GroupReadsByUmi {
   /** A type to represent a unique ID assigned to a molecule. */
   type MoleculeId = String
 
+  /** The suffix appended to molecular identifier reads from the "top strand" of the duplex molecule. These reads have
+    * 5' coordinate for read 1 less than or equal to the 5' coordinate for read 2. */
+  val TopStrandDuplex = "/A"
+
+  /** The suffix appended to molecular identifier reads from the "bottom strand" of the duplex molecule. These reads have
+    * 5' coordinate for read 1 greater than the 5' coordinate for read 2. */
+  val BottomStrandDuplex = "/B"
+
   private val ReadInfoTempAttributeName = "__GRBU_ReadInfo"
 
   /** A case class to represent all the information we need to order reads for duplicate marking / grouping. */
@@ -267,8 +275,8 @@ object GroupReadsByUmi {
       val mappings = mutable.Buffer[(Umi,MoleculeId)]()
       roots.foreach(root => {
         val id = nextId
-        val ab = id + "/A"
-        val ba = id + "/B"
+        val ab = id + GroupReadsByUmi.TopStrandDuplex
+        val ba = id + GroupReadsByUmi.BottomStrandDuplex
 
         mappings.append((root.umi, ab))
         mappings.append((reverse(root.umi), ba))


### PR DESCRIPTION
…y a single-strand.

@tfenne Some things I want to highlight two things:
1. The option `--allow-single-strand` is off by default.
2. We do not output the single strand `SamRecord`, but instead a `SamRecord` without the per-read and per-base tags for the missing single-strand consensus.  In my own thinking, I want this behavior for consistency in downstream tools that will consume duplex `SamRecord`s.