### PR TITLE
Add a SamOrder that can sort by tag.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/bam/Bams.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/Bams.scala
@@ -124,8 +124,7 @@ object Bams extends LazyLogging {
              header: SAMFileHeader,
              maxRecordsInRam: Int = MaxInMemory,
              tmpDir: DirPath = Io.tmpDir): Sorter[SamRecord,order.A] = {
-    // FIXME: tmpDir not used
-    new Sorter(maxRecordsInRam, new SamRecordCodec(header), order.sortkey)
+    new Sorter(maxRecordsInRam, new SamRecordCodec(header), order.sortkey, tmpDir=tmpDir)
   }
 
   /** A wrapper to order objects of type [[TagType]] using the ordering given.  Used when sorting by tag where we wish
@@ -254,8 +253,7 @@ object Bams extends LazyLogging {
         }
       )
     )
-    // FIXME: tmpDir not used
-    val sort = new Sorter(maxInMemory, new SamRecordCodec(header), f)
+    val sort = new Sorter(maxInMemory, new SamRecordCodec(header), f, tmpDir=tmpDir)
     sort ++= iterator
     new SelfClosingIterator(sort.iterator, () => sort.close())
   }

--- a/src/test/scala/com/fulcrumgenomics/bam/api/SamOrderTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/api/SamOrderTest.scala
@@ -90,14 +90,14 @@ class SamOrderTest extends UnitSpec {
     val f = SamOrder.Coordinate.sortkey
     val recs = SamOrderTest.builder.iterator.toSeq.sortBy(f(_))
     val comp = new SAMRecordCoordinateComparator()
-    recs.grouped(2).foreach { case Seq(lhs,rhs) => comp.fileOrderCompare(lhs.asSam, rhs.asSam) <= 0 shouldBe true }
+    recs.sliding(2).foreach { case Seq(lhs,rhs) => comp.fileOrderCompare(lhs.asSam, rhs.asSam) <= 0 shouldBe true }
   }
 
   "SamOrder.Queryname" should "sort reads into queryname order" in {
     val f = SamOrder.Queryname.sortkey
     val recs = SamOrderTest.builder.iterator.toSeq.sortBy(f(_))
     val comp = new SAMRecordQueryNameComparator()
-    recs.grouped(2).foreach { case Seq(lhs,rhs) => comp.fileOrderCompare(lhs.asSam, rhs.asSam) <= 0 shouldBe true }
+    recs.sliding(2).foreach { case Seq(lhs,rhs) => comp.fileOrderCompare(lhs.asSam, rhs.asSam) <= 0 shouldBe true }
   }
 
   "SamOrder.Random" should "randomize the order of the reads" in {
@@ -108,7 +108,7 @@ class SamOrderTest extends UnitSpec {
     val counter1 = new SimpleCounter[Int]()
     val counter2 = new SimpleCounter[Int]()
 
-    recs.grouped(2).foreach { case Seq(r1, r2) =>
+    recs.sliding(2).foreach { case Seq(r1, r2) =>
       counter1.count(comp1.fileOrderCompare(r1.asSam, r2.asSam))
       counter2.count(comp2.fileOrderCompare(r1.asSam, r2.asSam))
     }


### PR DESCRIPTION
Also allows for records with missing values for a tag, and a transformation method to be applied to tag to generate a key on which to sort.