### PR TITLE
ProgressLogger should by default use the plural form of "record".

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/util/ProgressLogger.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/ProgressLogger.scala
@@ -31,7 +31,7 @@ import htsjdk.samtools.util.AbstractProgressLogger
   * A subclass of HTSJDK's progress logger that uses fgbio's logging system.
   */
 case class ProgressLogger(logger: Logger,
-                          noun: String = "record",
+                          noun: String = "records",
                           verb: String = "processed",
                           unit: Int = 1000 * 1000) extends AbstractProgressLogger(noun, verb, unit) {
 


### PR DESCRIPTION

@tfenne quick review.  It annoys me when it says "record" instead of "records":
```
[2017/10/30 20:31:19 | DemuxFastqs | Info] processed     4,000,000 record.  Elapsed time: 00:02:13s.  Time for last 1,000,000:   33s.  Last read position: */*
```