### PR TITLE
Bump htsjdk and scalatest to latest versions.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -125,13 +125,13 @@ lazy val root = Project(id="fgbio", base=file("."))
       "org.scala-lang.modules"    %% "scala-xml"      % "1.0.6",
       "com.fulcrumgenomics"       %% "commons"        % "0.2.0",
       "com.fulcrumgenomics"       %% "sopt"           % "0.3.0",
-      "com.github.samtools"       %  "htsjdk"         % "2.11.0" excludeAll(htsjdkExcludes: _*),
+      "com.github.samtools"       %  "htsjdk"         % "2.13.0" excludeAll(htsjdkExcludes: _*),
       "net.jafama"                %  "jafama"         % "2.1.0",
       "org.apache.commons"        %  "commons-math3"  % "3.6.1",
       "com.beachape"              %% "enumeratum"     % "1.5.12",
 
       //---------- Test libraries -------------------//
-      "org.scalatest"             %% "scalatest"     % "3.0.1"  % "test->*" excludeAll ExclusionRule(organization="org.junit", name="junit")
+      "org.scalatest"             %% "scalatest"     % "3.0.4"  % "test->*" excludeAll ExclusionRule(organization="org.junit", name="junit")
     ))
 
 ////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/main/scala/com/fulcrumgenomics/cmdline/FgBioMain.scala
+++ b/src/main/scala/com/fulcrumgenomics/cmdline/FgBioMain.scala
@@ -127,7 +127,7 @@ class FgBioMain extends LazyLogging {
     val host       = InetAddress.getLocalHost.getHostName
     val user       = System.getProperty("user.name")
     val jreVersion = System.getProperty("java.runtime.version")
-    val snappy     = if (new SnappyLoader(false).SnappyAvailable) "with snappy" else "without snappy"
+    val snappy     = if (new SnappyLoader().isSnappyAvailable) "with snappy" else "without snappy"
     logger.info(s"Executing $tool from $name version $version as $user@$host on JRE $jreVersion $snappy")
   }
 


### PR DESCRIPTION
@nh13 The main motivation here is to update htsjdk because I've been trying to use a newer version in some downstream projects, and `SnappyLoader` has changed and the line in `FgBioMain` was causing everything to fail.  This updates us to the latest htsjdk and updates the call to SnappyLoader to match.