### PR TITLE
Add an option to specify a minimum UMI length.

### DIFF
--- a/src/test/scala/com/fulcrumgenomics/FgBioDefTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/FgBioDefTest.scala
@@ -28,7 +28,10 @@ import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.bam.api.{SamOrder, SamSource, SamWriter}
 import com.fulcrumgenomics.commons.io.PathUtil
 import com.fulcrumgenomics.testing.UnitSpec
+import enumeratum.EnumEntry
 import htsjdk.samtools.{SAMFileHeader, SAMReadGroupRecord}
+
+import scala.collection.immutable.IndexedSeq
 
 class FgBioDefTest extends UnitSpec {
   private case class SampleAndLibrary(sample: String, library: String)
@@ -89,5 +92,19 @@ class FgBioDefTest extends UnitSpec {
     val reader = SamSource(path)
     FgBioDef.plotDescription(reader, path) shouldBe PathUtil.basename(path, trimExt=true).toString
     reader.close()
+  }
+
+  sealed trait CustomEnum extends EnumEntry
+  object CustomEnum extends FgBioEnum[CustomEnum] {
+    def values: IndexedSeq[CustomEnum] = findValues
+    case object Foo extends CustomEnum
+    case object Bar extends CustomEnum
+  }
+
+  "FgbioDef.FgBioEnum" should "return the correct enum by name" in {
+    CustomEnum("Foo") shouldBe CustomEnum.Foo
+    CustomEnum("foo") shouldBe CustomEnum.Foo
+    CustomEnum("fOO") shouldBe CustomEnum.Foo
+    CustomEnum("bar") shouldBe CustomEnum.Bar
   }
 }


### PR DESCRIPTION
This will filter out any UMIs less than this length, and will truncate the remaining UMIs in a cluster to the minimum UMI length in that cluster.

Will need to be fixed up after https://github.com/fulcrumgenomics/fgbio/pull/308 is merged :/