### PR TITLE
Fix the quality score for duplex consensus reads in rare cases

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/DuplexConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/DuplexConsensusCaller.scala
@@ -296,9 +296,9 @@ class DuplexConsensusCaller(override val readNamePrefix: String,
           // Capture the raw consensus base prior to masking it to N, so that we can compute
           // errors vs. the actually called base.
           val (rawBase, rawQual) = {
-            if      (aBase == bBase) (aBase, (aQual + bQual).toByte)
-            else if (aQual > bQual)  (aBase, (aQual - bQual).toByte)
-            else if (bQual > aQual)  (bBase, (bQual - aQual).toByte)
+            if      (aBase == bBase) (aBase, PhredScore.cap(aQual + bQual))
+            else if (aQual > bQual)  (aBase, PhredScore.cap(aQual - bQual))
+            else if (bQual > aQual)  (bBase, PhredScore.cap(bQual - aQual))
             else                     (aBase, PhredScore.MinValue)
           }
 


### PR DESCRIPTION
If we have a duplex who have single strand consensus qualities that differ by two or less, the output base quality will be less than 2 (less than `PhredScore.MaxValue`).  I have added a test and a fix, to prove the bug and cap the value.