### PR TITLE
WIP: Use MSA to call duplex consensus reads.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/CallDuplexConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CallDuplexConsensusReads.scala
@@ -25,6 +25,7 @@
 package com.fulcrumgenomics.umi
 
 import com.fulcrumgenomics.FgBioDef._
+import com.fulcrumgenomics.bam.Bams
 import com.fulcrumgenomics.bam.api.{SamOrder, SamSource, SamWriter}
 import com.fulcrumgenomics.cmdline.{ClpGroups, FgBioTool}
 import com.fulcrumgenomics.sopt.clp
@@ -34,6 +35,7 @@ import com.fulcrumgenomics.sopt._
 import com.fulcrumgenomics.umi.VanillaUmiConsensusCallerOptions._
 import com.fulcrumgenomics.util.NumericTypes.PhredScore
 import com.fulcrumgenomics.util.ProgressLogger
+import htsjdk.samtools.SAMFileHeader.{GroupOrder, SortOrder}
 
 @clp(description =
   """
@@ -99,7 +101,10 @@ class CallDuplexConsensusReads
  @arg(flag='m', doc="Ignore bases in raw reads that have Q below this value.") val minInputBaseQuality: PhredScore = DefaultMinInputBaseQuality,
  @arg(flag='t', doc="If true, quality trim input reads in addition to masking low Q bases.") val trim: Boolean = false,
  @arg(flag='S', doc="The sort order of the output, if `:none:` then the same as the input.") val sortOrder: Option[SamOrder] = Some(SamOrder.Queryname),
- @arg(flag='M', minElements=1, maxElements=3, doc="The minimum number of input reads to a consensus read.") val minReads: Seq[Int] = Seq(1)
+ @arg(flag='M', minElements=1, maxElements=3, doc="The minimum number of input reads to a consensus read.") val minReads: Seq[Int] = Seq(1),
+ @arg(flag='X', doc="Use the multiple sequence alignment (SSSSLLLLOOOOWWWW).") val useMsa: Boolean = false,
+ @arg(flag='x', doc="The multiple sequence alignment command to use; the input file (FASTA) will be appended.") val msaCommand: String = DuplexConsensusCaller.MsaCommand,
+ @arg(flag='C', doc="Maximum fraction of reads filtered due to minority cigar before using multiple sequence alignment.") val maxFilterMinorityFraction: Double = 0.05
 ) extends FgBioTool with LazyLogging {
 
   Io.assertReadable(input)
@@ -110,22 +115,31 @@ class CallDuplexConsensusReads
   override def execute(): Unit = {
     val in  = SamSource(input)
 
+    val inIterator = if (in.header.getSortOrder != SortOrder.unsorted && in.header.getGroupOrder != GroupOrder.query) {
+      Bams.sortByTag[String](iterator=in.iterator, header=in.header, tag=ConsensusTags.MolecularId)
+    }
+    else {
+      in.iterator
+    }
+
     // The output file is unmapped, so for now let's clear out the sequence dictionary & PGs
     val outHeader = UmiConsensusCaller.outputHeader(in.header, readGroupId, sortOrder)
     val out = SamWriter(output, outHeader, sort=sortOrder)
 
     val caller = new DuplexConsensusCaller(
-      readNamePrefix      = readNamePrefix.getOrElse(UmiConsensusCaller.makePrefixFromSamHeader(in.header)),
-      readGroupId         = readGroupId,
-      minInputBaseQuality = minInputBaseQuality,
-      trim                = trim,
-      errorRatePreUmi     = errorRatePreUmi,
-      errorRatePostUmi    = errorRatePostUmi,
-      minReads            = minReads
+      readNamePrefix            = readNamePrefix.getOrElse(UmiConsensusCaller.makePrefixFromSamHeader(in.header)),
+      readGroupId               = readGroupId,
+      minInputBaseQuality       = minInputBaseQuality,
+      trim                      = trim,
+      errorRatePreUmi           = errorRatePreUmi,
+      errorRatePostUmi          = errorRatePostUmi,
+      minReads                  = minReads,
+      useMsa                  = useMsa,
+      msaCommand                = msaCommand,
+      maxFilterMinorityFraction = maxFilterMinorityFraction
     )
 
-    val iterator = new ConsensusCallingIterator(in.toIterator, caller, Some(ProgressLogger(logger)))
-    out ++= iterator
+    out ++= new ConsensusCallingIterator(inIterator, caller, Some(ProgressLogger(logger)))
 
     in.safelyClose()
     out.close()

--- a/src/main/scala/com/fulcrumgenomics/umi/CallDuplexConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CallDuplexConsensusReads.scala
@@ -139,7 +139,7 @@ class CallDuplexConsensusReads
       maxFilterMinorityFraction = maxFilterMinorityFraction
     )
 
-    out ++= new ConsensusCallingIterator(inIterator, caller, Some(ProgressLogger(logger)))
+    out ++= new ConsensusCallingIterator(inIterator, caller, Some(ProgressLogger(logger))).take(100)
 
     in.safelyClose()
     out.close()

--- a/src/main/scala/com/fulcrumgenomics/umi/GraphBaseConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/GraphBaseConsensusCaller.scala
@@ -1,0 +1,182 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package com.fulcrumgenomics.umi
+
+import com.fulcrumgenomics.commons.util.SimpleCounter
+import com.fulcrumgenomics.umi.ConsensusCaller.Base
+import com.fulcrumgenomics.umi.UmiConsensusCaller.SourceRead
+import com.fulcrumgenomics.util.NumericTypes.PhredScore
+
+import scala.collection.mutable.ArrayBuffer
+
+class GraphBaseConsensusCaller(msaCommand: String = DuplexConsensusCaller.MsaCommand,
+                               fallbackToVanillaCaller: Boolean = false,
+                               options: VanillaUmiConsensusCallerOptions = new VanillaUmiConsensusCallerOptions())
+  extends MultipleSequenceAlignmentConsensusCaller(msaCommand=msaCommand, fallbackToVanillaCaller=fallbackToVanillaCaller, options=options) {
+
+
+  override protected def call(aligned: Seq[SourceRead]): VanillaConsensusRead = {
+    val expectedLength = aligned.head.length
+    require(aligned.forall(_.length == expectedLength))
+
+    // One extra node for the source, and one extra node for the sink
+    val nodes = Array.range(0, expectedLength+2).map { offset => Node(offset=offset-1)}
+
+    // add the edges
+    aligned.map(_.bases).foreach { bases =>
+      // NB: i an j are 1-based relative to the bases, and 0-based relative to the nodes
+      var i = 0
+      while (i < nodes.length - 1) { // all but the last node (sink)
+        var j = i + 1
+        while (j-1 < bases.length && bases(j-1) == Gap) {
+          j = j + 1
+        }
+        Node.connect(nodes(i), nodes(j))
+        i = j
+      }
+    }
+
+    // sanity checks
+    require(nodes.head.incoming.isEmpty)
+    require(nodes.head.outgoing.map(_._2).sum == aligned.length)
+    require(nodes.last.outgoing.isEmpty)
+    require(nodes.last.incoming.map(_._2).sum == aligned.length)
+    nodes.foreach { node =>
+      require(node.incoming.map(_._2).sum <= aligned.length)
+      require(node.outgoing.map(_._2).sum <= aligned.length)
+      node.incoming.foreach{ case (inc, count) =>
+        require(inc.outgoingCount(node) == count)
+      }
+      node.outgoing.foreach { case (out, count) =>
+        require(out.incomingCount(node) == count)
+      }
+    }
+
+    // Get the consensus alignment, returned as a list of offsets
+    val offsets = {
+      import scala.collection.mutable
+      val from   = new mutable.HashMap[Node, Node]() // cur -> predecessor
+      val scores = new mutable.HashMap[Node, Long]()
+
+      scores(nodes.head) = 0
+
+      nodes.drop(1).foreach { node =>
+        val incoming = node.incoming.map { case (prevNode, count) =>
+          // the score is the sum of the previous node's score and the count of the edge
+          (prevNode, count + scores(prevNode))
+        }
+        val (bestIncoming, bestScore) = incoming.maxBy(_._2)
+        from(node)   = bestIncoming
+        scores(node) = bestScore
+      }
+
+      // traceback
+      var curNode = nodes.last
+      val bestPath = new ArrayBuffer[Node]()
+      bestPath += curNode
+      while (from.contains(curNode)) {
+        val prevNode = from(curNode)
+        bestPath += prevNode
+        curNode = prevNode
+      }
+      bestPath.reverse
+        .map(_.offset)
+        .filter { offset => 0 <= offset && offset < expectedLength}
+    }
+
+    // Call the consensus read
+    {
+      val consensusLength = offsets.length
+      val consensusBases  = new Array[Base](consensusLength)
+      val consensusQuals  = new Array[PhredScore](consensusLength)
+      val consensusDepths = new Array[Short](consensusLength)
+      val consensusErrors = new Array[Short](consensusLength)
+
+      val builder = this.caller.builder()
+      offsets.zipWithIndex.foreach { case (offset, consensusOffset) =>
+        // Add the evidence
+        aligned.foreach { read =>
+          val base = read.bases(offset)
+          val qual = read.quals(offset)
+          if (base != NoCall && base != Gap)  builder.add(base=base, qual=qual)
+        }
+
+        // Call the consensus and do any additional filtering
+        val (rawBase, rawQual) = builder.call()
+        val (base, qual) = {
+          if (builder.contributions < this.options.minReads)       (NoCall, NotEnoughReadsQual)
+          else if (rawQual < this.options.minConsensusBaseQuality) (NoCall, TooLowQualityQual)
+          else (rawBase, rawQual)
+        }
+
+        consensusBases(consensusOffset) = base
+        consensusQuals(consensusOffset) = qual
+
+        // Generate the values for depth and count of errors
+        val depth  = builder.contributions
+        val errors = if (rawBase == NoCall) depth else depth - builder.observations(rawBase)
+        consensusDepths(consensusOffset) = if (depth  > Short.MaxValue) Short.MaxValue else depth.toShort
+        consensusErrors(consensusOffset) = if (errors > Short.MaxValue) Short.MaxValue else errors.toShort
+
+        // Get ready for the next pass
+        builder.reset()
+      }
+      VanillaConsensusRead(
+        id     = aligned.head.id,
+        bases  = consensusBases,
+        quals  = consensusQuals,
+        depths = consensusDepths,
+        errors = consensusErrors
+      )
+    }
+  }
+}
+
+private object Node {
+  def connect(from: Node, to:Node): Unit = {
+    from.addSuccessor(to)
+    to.addPredecessor(from)
+  }
+}
+
+private case class Node(offset: Int) {
+  private val _incoming = new SimpleCounter[Node]
+  private val _outgoing = new SimpleCounter[Node]
+
+  def incoming: Seq[(Node, Long)] = this._incoming.toSeq
+  def outgoing: Seq[(Node, Long)] = this._outgoing.toSeq
+
+  def incomingCount(node: Node): Long = this._incoming.countOf(node)
+  def outgoingCount(node: Node): Long = this._outgoing.countOf(node)
+
+  def addSuccessor(successor: Node): Unit = {
+    this._outgoing.count(successor)
+  }
+
+  def addPredecessor(predecessor: Node): Unit = {
+    this._incoming.count(predecessor)
+  }
+}

--- a/src/main/scala/com/fulcrumgenomics/umi/MultipleSequenceAlignmentConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/MultipleSequenceAlignmentConsensusCaller.scala
@@ -1,0 +1,208 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) $year Fulcrum Genomics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package com.fulcrumgenomics.umi
+
+import com.fulcrumgenomics.commons.io.Io
+import com.fulcrumgenomics.commons.util.SimpleCounter
+import com.fulcrumgenomics.commons.CommonsDef.FilePath
+import com.fulcrumgenomics.umi.ConsensusCaller.Base
+import com.fulcrumgenomics.umi.UmiConsensusCaller.SourceRead
+import com.fulcrumgenomics.util.NumericTypes.PhredScore
+
+import scala.collection.mutable.ArrayBuffer
+import scala.reflect.ClassTag
+import scala.util.{Failure, Random, Success, Try}
+import sys.process._
+
+class MultipleSequenceAlignmentConsensusCaller(val msaCommand: String = DuplexConsensusCaller.MsaCommand,
+                                               val fallbackToVanillaCaller: Boolean = false,
+                                               val options: VanillaUmiConsensusCallerOptions = new VanillaUmiConsensusCallerOptions()) extends ConsensusCallerTrait {
+
+  private val NoCall: Byte                   = 'N'.toByte
+  private val Gap: Byte                      = '-'.toByte
+  private val GapQual: PhredScore            = 30.toByte
+  private val NotEnoughReadsQual: PhredScore = 0.toByte // Score output when masking to N due to insufficient input reads
+  private val TooLowQualityQual: PhredScore  = 2.toByte  // Score output when masking to N due to too low consensus quality
+  private val vanillaCaller = new VanillaUmiConsensusCaller(readNamePrefix="x", options=options)
+
+  private val random = new Random(42)
+  private val caller = new ConsensusCaller(errorRatePreLabeling=options.errorRatePreUmi, errorRatePostLabeling=options.errorRatePostUmi)
+
+  private var numMsaFailures: Long = 0
+
+  private def updateReads(reads: Seq[SourceRead], result: Seq[String]): Seq[SourceRead] = {
+    // create one string builder for each read
+    val basesBuilders = reads.map { _ => new ArrayBuffer[Byte] }.toArray
+
+    // aggregate bases for each read
+    result
+      .drop(3)
+      .filterNot { line => line.startsWith(" ") || line.startsWith("*") || line.isEmpty }
+      .zipWithIndex.foreach { case (line, i) =>
+        val Seq(id, bases) = line.split("[ ]+").toSeq
+        basesBuilders(id.toInt) ++= bases.map(_.toByte)
+      }
+
+    val expectedLength = basesBuilders.head.length
+    require(basesBuilders.forall(_.length == expectedLength))
+
+    basesBuilders.zipWithIndex.map { case (bases, i) =>
+      // pad the qualities
+      val read      = reads(i)
+      var qualIndex = 0
+      val quals = bases.map { b =>
+        if (b != Gap) read.quals(qualIndex)
+        else {
+          qualIndex += 1
+          Gap
+        }
+      }.toArray
+      read.copy(bases=bases.toArray, quals=quals)
+    }.toSeq
+  }
+
+  /**
+    * Calculates the length of the consensus read that should be produced. The length is calculated
+    * as the maximum length at which minReads reads still have bases.
+    *
+    * @param reads the set of reads being fed into the consensus
+    * @param minReads the minimum number of reads required
+    * @return the length of consensus read that should be created
+    */
+  private def consensusReadLength(reads: Seq[SourceRead], minReads: Int): Int = {
+    require(reads.size >= minReads, "Too few reads to create a consensus.")
+    reads.map(_.length).sortBy(len => -len).drop(minReads-1).head
+  }
+
+  private def align(reads: Seq[SourceRead], fastaPath: FilePath): Try[Seq[SourceRead]] = {
+    // First limit to max reads if necessary
+    //val capped = if (reads.size <= 32) reads else this.random.shuffle(reads).take(32)
+    val capped = if (reads.size <= this.options.maxReads) reads else this.random.shuffle(reads).take(this.options.maxReads)
+
+    // Create a FASTA
+    val lines = capped.zipWithIndex.flatMap { case (read, id) => Seq(s">$id", read.baseString) }
+    Io.writeLines(fastaPath, lines)
+
+    // Run the MSA tool
+    // NB: can run pretty much anything that produces valid CLUSTAL output.
+    Try { s"$msaCommand $fastaPath" !! ProcessLogger(_ => ()) split '\n' }.map { result => updateReads(capped, result) }
+  }
+
+  private def call(aligned: Seq[SourceRead]): VanillaConsensusRead = {
+    // get the most likely consensus bases and qualities
+    val consensusLength = consensusReadLength(aligned, this.options.minReads)
+    val consensusBases  = new Array[Base](consensusLength)
+    val consensusQuals  = new Array[PhredScore](consensusLength)
+    val consensusDepths = new Array[Short](consensusLength)
+    val consensusErrors = new Array[Short](consensusLength)
+
+    var positionInRead = 0
+    val builder = this.caller.builder()
+    while (positionInRead < consensusLength) {
+      val reads = aligned.filter(_.length > positionInRead)
+
+      // Find the base that has the fewest # of observations, and ignore it, and use it for gap in the model
+      val baseCounter = new SimpleCounter[Byte]()
+      Seq('A', 'C', 'T', 'G').foreach { base => baseCounter.count(base.toByte, 0) }
+      reads.map { _.bases(positionInRead) }.filterNot(_ == NoCall).foreach { base => baseCounter.count(base) }
+      val zeroObservationsBase = baseCounter.minBy(_._2)._1
+
+      // Add the evidence from all reads that are long enough to cover this base
+      reads.foreach { read =>
+        val base = read.bases(positionInRead)
+        val qual = read.quals(positionInRead)
+        if (base != NoCall && base != zeroObservationsBase) {
+          if (base == Gap) builder.add(base=zeroObservationsBase, qual=GapQual)
+          else builder.add(base=base, qual=qual)
+        }
+      }
+
+      // Call the consensus and do any additional filtering
+      val (rawBase, rawQual) = builder.call()
+      val (base, qual) = {
+        if (builder.contributions < this.options.minReads)       (NoCall, NotEnoughReadsQual)
+        else if (rawQual < this.options.minConsensusBaseQuality) (NoCall, TooLowQualityQual)
+        else (rawBase, rawQual)
+      }
+
+      consensusBases(positionInRead) = if (base == zeroObservationsBase) Gap else base
+      consensusQuals(positionInRead) = qual
+
+      // Generate the values for depth and count of errors
+      val depth  = builder.contributions
+      val errors = if (rawBase == NoCall) depth else depth - builder.observations(rawBase)
+      consensusDepths(positionInRead) = if (depth  > Short.MaxValue) Short.MaxValue else depth.toShort
+      consensusErrors(positionInRead) = if (errors > Short.MaxValue) Short.MaxValue else errors.toShort
+
+      // Get ready for the next pass
+      builder.reset()
+      positionInRead += 1
+    }
+
+    val gapMask = consensusBases.map { base => base == Gap }
+    def filterGap[T](things: Array[T])(implicit ev1: ClassTag[T]): Array[T] = things.toList.zip(gapMask).filterNot(_._2).map(_._1).toArray
+
+    VanillaConsensusRead(
+      id     = aligned.head.id,
+      bases  = filterGap(consensusBases),
+      quals  = filterGap(consensusQuals),
+      depths = filterGap(consensusDepths),
+      errors = filterGap(consensusErrors)
+    )
+  }
+
+  /** Creates a consensus read from the given read and qualities sequences.
+    * If no consensus read was created, None is returned.
+    *
+    * The same number of base sequences and quality sequences should be given.
+    * */
+  def consensusCall(reads: Seq[SourceRead]): Option[VanillaConsensusRead] = {
+    // check to see if we have enough reads.
+    if (reads.size < this.options.minReads) {
+      None
+    }
+    else if (reads.size <= 2) {
+      vanillaCaller.consensusCall(reads)
+    }
+    else {
+      val fastaPath  = Io.makeTempFile(s"batch.${this.random.nextInt}.", ".fasta")
+      align(reads, fastaPath) match {
+        case Failure(thr)       =>
+          fastaPath.toFile.delete()
+          numMsaFailures += 1
+          if (this.fallbackToVanillaCaller) {
+            vanillaCaller.consensusCall(reads)
+          } else {
+            throw new IllegalStateException(s"MSA command failed: '${this.msaCommand}'", thr)
+          }
+        case Success(aligned) =>
+          fastaPath.toFile.delete()
+          Some(call(aligned))
+
+      }
+    }
+  }
+}

--- a/src/main/scala/com/fulcrumgenomics/umi/MultipleSequenceAlignmentConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/MultipleSequenceAlignmentConsensusCaller.scala
@@ -41,15 +41,15 @@ class MultipleSequenceAlignmentConsensusCaller(val msaCommand: String = DuplexCo
                                                val fallbackToVanillaCaller: Boolean = false,
                                                val options: VanillaUmiConsensusCallerOptions = new VanillaUmiConsensusCallerOptions()) extends ConsensusCallerTrait {
 
-  private val NoCall: Byte                   = 'N'.toByte
-  private val Gap: Byte                      = '-'.toByte
-  private val GapQual: PhredScore            = 30.toByte
-  private val NotEnoughReadsQual: PhredScore = 0.toByte // Score output when masking to N due to insufficient input reads
-  private val TooLowQualityQual: PhredScore  = 2.toByte  // Score output when masking to N due to too low consensus quality
-  private val vanillaCaller = new VanillaUmiConsensusCaller(readNamePrefix="x", options=options)
+  protected val NoCall: Byte                   = 'N'.toByte
+  protected val Gap: Byte                      = '-'.toByte
+  protected val GapQual: PhredScore            = 30.toByte
+  protected val NotEnoughReadsQual: PhredScore = 0.toByte // Score output when masking to N due to insufficient input reads
+  protected val TooLowQualityQual: PhredScore  = 2.toByte  // Score output when masking to N due to too low consensus quality
+  protected val vanillaCaller = new VanillaUmiConsensusCaller(readNamePrefix="x", options=options)
 
-  private val random = new Random(42)
-  private val caller = new ConsensusCaller(errorRatePreLabeling=options.errorRatePreUmi, errorRatePostLabeling=options.errorRatePostUmi)
+  protected val random = new Random(42)
+  protected val caller = new ConsensusCaller(errorRatePreLabeling=options.errorRatePreUmi, errorRatePostLabeling=options.errorRatePostUmi)
 
   private var numMsaFailures: Long = 0
 
@@ -62,9 +62,9 @@ class MultipleSequenceAlignmentConsensusCaller(val msaCommand: String = DuplexCo
       .drop(3)
       .filterNot { line => line.startsWith(" ") || line.startsWith("*") || line.isEmpty }
       .zipWithIndex.foreach { case (line, i) =>
-        val Seq(id, bases) = line.split("[ ]+").toSeq
-        basesBuilders(id.toInt) ++= bases.map(_.toByte)
-      }
+      val Seq(id, bases) = line.split("[ ]+").toSeq
+      basesBuilders(id.toInt) ++= bases.map(_.toByte)
+    }
 
     val expectedLength = basesBuilders.head.length
     require(basesBuilders.forall(_.length == expectedLength))
@@ -111,7 +111,7 @@ class MultipleSequenceAlignmentConsensusCaller(val msaCommand: String = DuplexCo
     Try { s"$msaCommand $fastaPath" !! ProcessLogger(_ => ()) split '\n' }.map { result => updateReads(capped, result) }
   }
 
-  private def call(aligned: Seq[SourceRead]): VanillaConsensusRead = {
+  protected def call(aligned: Seq[SourceRead]): VanillaConsensusRead = {
     // get the most likely consensus bases and qualities
     val consensusLength = consensusReadLength(aligned, this.options.minReads)
     val consensusBases  = new Array[Base](consensusLength)
@@ -201,7 +201,6 @@ class MultipleSequenceAlignmentConsensusCaller(val msaCommand: String = DuplexCo
         case Success(aligned) =>
           fastaPath.toFile.delete()
           Some(call(aligned))
-
       }
     }
   }

--- a/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
@@ -283,7 +283,7 @@ trait UmiConsensusCaller[C <: SimpleRead] {
     *
     * NOTE: filtered out reads are sent to the [[rejectRecords()]] method and do not need further handling
     */
-  protected[umi] def filterToMostCommonAlignment(recs: Seq[SourceRead]): Seq[SourceRead] = {
+  protected[umi] def filterToMostCommonAlignment(recs: Seq[SourceRead], reject: Boolean = true): Seq[SourceRead] = {
     val groups = new ArrayBuffer[mutable.Buffer[SourceRead]]
     val cigars = new ArrayBuffer[Cigar]
 
@@ -311,7 +311,7 @@ trait UmiConsensusCaller[C <: SimpleRead] {
       val sorted  = groups.sortBy(g => - g.size)
       val keepers = sorted.head
       val rejects = recs.filter(r => !keepers.contains(r))
-      rejectRecords(rejects.flatMap(_.sam), FilterMinorityAlignment)
+      if (reject) rejectRecords(rejects.flatMap(_.sam), FilterMinorityAlignment)
 
       keepers
     }

--- a/src/main/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCaller.scala
@@ -92,6 +92,11 @@ case class VanillaConsensusRead(id: String, bases: Array[Byte], quals: Array[Byt
   }
 }
 
+// FIXME
+trait ConsensusCallerTrait {
+  def consensusCall(reads: Seq[SourceRead]): Option[VanillaConsensusRead]
+}
+
 /** Calls consensus reads by grouping consecutive reads with the same SAM tag.
   *
   * Consecutive reads with the SAM tag are partitioned into fragments, first of pair, and
@@ -103,7 +108,7 @@ class VanillaUmiConsensusCaller(override val readNamePrefix: String,
                                 override val readGroupId: String = "A",
                                 val options: VanillaUmiConsensusCallerOptions = new VanillaUmiConsensusCallerOptions(),
                                 val rejects: Option[SamWriter] = None
-                               ) extends UmiConsensusCaller[VanillaConsensusRead] with LazyLogging {
+                               ) extends UmiConsensusCaller[VanillaConsensusRead] with ConsensusCallerTrait with LazyLogging {
 
   private val NotEnoughReadsQual: PhredScore = 0.toByte // Score output when masking to N due to insufficient input reads
   private val TooLowQualityQual: PhredScore = 2.toByte  // Score output when masking to N due to too low consensus quality
@@ -172,7 +177,7 @@ class VanillaUmiConsensusCaller(override val readNamePrefix: String,
     *
     * The same number of base sequences and quality sequences should be given.
     * */
-  private[umi] def consensusCall(reads: Seq[SourceRead]): Option[VanillaConsensusRead] = {
+  def consensusCall(reads: Seq[SourceRead]): Option[VanillaConsensusRead] = {
     // check to see if we have enough reads.
     if (reads.size < this.options.minReads) {
       None


### PR DESCRIPTION
Three options are added to `CallDuplexConsensusReads`:

1. `--use-msa`: Use multiple-sequence-alignment when the # of records filtered due to minority alignments is too high.  
2. `--max-filter-minority-fraction`: The maximum fraction of reads filtered due to minority cigar before using multiple sequence alignment.
3. `--msa--command`: The multiple sequence alignment command to use; the input file (FASTA) will be appended.  Some example uses of the `--msa--command` option:
```
--msa-command "clustalo --outt=clustal --in"
--msa-command "mafft --thread 8 --anysymbol --clustalout --bl 62 --op 1.53 --ep 0.123 --reorder --retree 2 --treeout --maxiterate 2"
```
The idea is that when the cigars do not match up well, we can use multiple-sequence alignment to do a better job.  Since MSA is expensive to perform, only do it when a non-trivial fraction of reads are discarded.