### PR TITLE
Better handling of multi-line failure messages.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/cmdline/FgBioMain.scala
+++ b/src/main/scala/com/fulcrumgenomics/cmdline/FgBioMain.scala
@@ -105,7 +105,7 @@ class FgBioMain extends LazyLogging {
             val banner = "#" * ex.message.map(_.length).getOrElse(80)
             logger.fatal(banner)
             logger.fatal("Execution failed!")
-            ex.message.foreach(logger.fatal)
+            ex.message.foreach(msg => msg.lines.foreach(logger.fatal))
             logger.fatal(banner)
             printEndingLines(startTime, name, false)
             ex.exit


### PR DESCRIPTION
Nice little one-line PR for you.  The idea being that if you invoke:

```scala
fail("Found a bunch of problems:\n" + errors.mkString("\n"))
```

That all the lines are prefixed the same amount, instead of having a big out-dent for lines 2-n.