### PR TITLE
Adding in options to DemuxFastqs for asynchronous reading and writing

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/Writer.scala
+++ b/src/main/scala/com/fulcrumgenomics/Writer.scala
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2017 Fulcrum Genomics LLC
+ * Copyright (c) 2017 Fulcrum Genomics
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,31 +20,11 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
+ *
  */
 
 package com.fulcrumgenomics
 
-import java.io.Closeable
-
-import com.fulcrumgenomics.FgBioDef._
-
 /** Writer trait to standardize how to interact with classes that write out objects. */
-trait Writer[A] extends Closeable {
-  /** Writes an individual item. */
-  def write(item: A): Unit
-
-  /** Writes out one or more items in order. */
-  def write[B <: A](items: TraversableOnce[B]): Unit = items.foreach(write)
-
-  /** Writes an item and returns a reference to the writer. */
-  def +=(item: A): this.type = {
-    write(item)
-    this
-  }
-
-  /** Writes an item and returns a reference to the writer. */
-  def ++=[B <: A](items: TraversableOnce[B]): this.type = {
-    write(items)
-    this
-  }
-}
+@deprecated("Use  com.fulcrumgenomics.commons.io.Writer", since="0.5.0")
+trait Writer[A] extends com.fulcrumgenomics.commons.io.Writer[A]

--- a/src/main/scala/com/fulcrumgenomics/fastq/FastqSource.scala
+++ b/src/main/scala/com/fulcrumgenomics/fastq/FastqSource.scala
@@ -59,14 +59,14 @@ object FastqSource {
     * @param sources a Seq of one or more FastqSource objects
     * @return an Iterator that returns a Seq of FastqRecord, one per source
     */
-  def zipped(sources: Seq[FastqSource]): Iterator[Seq[FastqRecord]] = new Iterator[Seq[FastqRecord]] {
+  def zipped(sources: Seq[Iterator[FastqRecord]]): Iterator[Seq[FastqRecord]] = new Iterator[Seq[FastqRecord]] {
     require(sources.nonEmpty, "No sources provided")
 
     def hasNext(): Boolean = sources.exists(_.hasNext)
 
     def next(): Seq[FastqRecord] = {
       if (!this.hasNext) throw new NoSuchElementException("Calling next() when hasNext() is false.")
-      require(sources.forall(_.hasNext) == sources.head.hasNext, "Sources are out of sync.")
+      require(sources.forall(_.hasNext) == sources.head.hasNext, s"Sources are out of sync: ${sources.map(_.hasNext).mkString(", ")}")
       val records = sources.map(_.next)
       // Check that the FASTQ records all have the same name
       require(records.forall(_.name == records.head.name), "Fastqs are out of sync, found read names: " + records.map(_.name).mkString(", "))

--- a/src/main/scala/com/fulcrumgenomics/fastq/FastqWriter.scala
+++ b/src/main/scala/com/fulcrumgenomics/fastq/FastqWriter.scala
@@ -23,7 +23,7 @@
  */
 package com.fulcrumgenomics.fastq
 
-import java.io.{BufferedWriter, Closeable}
+import java.io.BufferedWriter
 import java.nio.file.Path
 
 import com.fulcrumgenomics.Writer
@@ -37,16 +37,16 @@ object FastqWriter {
   def apply(path: Path): FastqWriter = apply(Io.toWriter(path))
 
   /** Constructs a FastqWriter from a Writer. */
-  def apply(writer: java.io.Writer): FastqWriter = {
-    if (writer.isInstanceOf[BufferedWriter]) new FastqWriter(writer.asInstanceOf[BufferedWriter])
-    else new FastqWriter(new BufferedWriter(writer))
+  def apply(writer: java.io.Writer): FastqWriter = writer match {
+      case w: BufferedWriter => new FastqWriter(w)
+      case _                 => new FastqWriter(new BufferedWriter(writer))
   }
 }
 
 /**
   * Implements a writer for fastq records.
   */
-class FastqWriter private(val out: BufferedWriter) extends Closeable with Writer[FastqRecord] {
+class FastqWriter private(val out: BufferedWriter) extends Writer[FastqRecord] {
   /** Writes a single record to the output. */
   override def write(rec: FastqRecord): Unit = {
     out.append('@').append(rec.header).append('\n')


### PR DESCRIPTION
* Added the --async-reading option to specify if and how to perform
  asynchronous reading of the inputs
* Added the --num-writing-threads to specify if and how many threads
  to use when writing asynchronously
* Deprecate the --threads option, use --async-reading and
  --num-writing-threads instead
* Added a number of classes to handle the asynchronous reading and
  writing
Depends on:
* https://github.com/fulcrumgenomics/commons/pull/22
* https://github.com/fulcrumgenomics/commons/pull/23

Click the link below to see some in-depth analysis of the various added options.
<details>

I looked at the six various combination of options:
1. "memory": the amount of memory used by the tool (values: 8g, 16g, 32g)
2. "output type": the type of output files for the `--output-type` option (values: `Bam`, `Fastq`, or `BamAndFastq`)
3. "threads in master": the # of threads for the `--threads` option in the `master` branch (values: `0`, `1`, `2`, `4`, `8`, `16`, `32`).
4. "async reading in devel": the type of asynchronous reading for the `--async-reading` option for the branch in this PR (values: `None`, `SingleThreads`, `ThreadPerReader`).
5. "threads for async writing in devel": the # of threads to use when writing output(s) for the `--async-writing-threads` (values: `0`, `1`, `2`, `4`, `8`, `16`, `32`).
6. "threads for demux in devel": whether or not to use a separate thread for asynchronous demultiplexing (values `true` or `false`).

I ran the tool for all combinations of six values, and I plotted the elapsed time in six plots to examine the affect of run time for each option.  I sub-sorted by "output-type" to show the affect on each relative to outputting BAM, FASTQs or both, since I found that this was informative.

My observations are:
* memory has no real effect
* writing both BAMs and FASTQs causes a significant spike in run time; using increasing # of threads for writing mitigates this issue
* threading in the master branch improves performance of the demultiplexing step (computational portion), but has a lower limit imposed by IO (hence the addition of asynchronous reading and writing)
* interestingly for asynchronous reading, having a single thread read all the inputs is faster than a thread-per-input;  I am not sure why.
* multiple threads for asynchronous writing really improves performance, and makes writing BAMs equivalent to writing both BAMs and FASTQs, but writing just FASTQs is slightly faster
* having a separate thread for the demultiplexing step (computational portion) has some very slight gains.  I did not try multiple threads for the demultiplexing step like in `master`.

In summary, asynchronous writing has huge benefits, which makes sense when we have 96 or 384 samples (and as many output files), but 4-8 thread maxes out write performance.  Asynchronous reading has a small benefit since we are just decompressing 2-4 gzipped FASTQs and are likely limited by a read speed anyhow.  Asynchronously barcode matching (the demultiplexing step) has some small benefits, but perhaps using multiple threads could yield benefits.  I can see retaining all three options (async-reading type, # of async-writing threads, and whether or not to async demux), but they could be confusing to the user since there are so many already.  I'd like to think about this further.

![plots](https://user-images.githubusercontent.com/846274/34427976-169603ca-ec05-11e7-832d-2f6ddb8740b0.png)

  