### PR TITLE
Added checks for sort order to consensus calling tools.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/CallDuplexConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CallDuplexConsensusReads.scala
@@ -109,6 +109,7 @@ class CallDuplexConsensusReads
 
   override def execute(): Unit = {
     val in  = SamSource(input)
+    UmiConsensusCaller.checkSortOrder(in.header, input, logger.warning, fail)
 
     // The output file is unmapped, so for now let's clear out the sequence dictionary & PGs
     val outHeader = UmiConsensusCaller.outputHeader(in.header, readGroupId, sortOrder)

--- a/src/main/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReads.scala
@@ -35,6 +35,7 @@ import com.fulcrumgenomics.sopt.cmdline.ValidationException
 import com.fulcrumgenomics.umi.VanillaUmiConsensusCallerOptions._
 import com.fulcrumgenomics.util.NumericTypes.PhredScore
 import com.fulcrumgenomics.util.ProgressLogger
+import htsjdk.samtools.SAMFileHeader.{GroupOrder, SortOrder}
 
 @clp(description =
   """
@@ -137,6 +138,7 @@ class CallMolecularConsensusReads
   /** Main method that does the work of reading input files, creating the consensus reads, and writing the output file. */
   override def execute(): Unit = {
     val in  = SamSource(input)
+    UmiConsensusCaller.checkSortOrder(in.header, input, logger.warning, fail)
     val rej = rejects.map(r => SamWriter(r, in.header))
 
     // The output file is unmapped, so for now let's clear out the sequence dictionary & PGs
@@ -161,7 +163,7 @@ class CallMolecularConsensusReads
       rejects        = rej
     )
 
-    val iterator = new ConsensusCallingIterator(in.toIterator, caller, Some(new ProgressLogger(logger, unit=5e5.toInt)))
+    val iterator = new ConsensusCallingIterator(in.toIterator, caller, Some(ProgressLogger(logger, unit=5e5.toInt)))
     out ++= iterator
 
     in.safelyClose()

--- a/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
@@ -473,8 +473,7 @@ class GroupReadsByUmi
     // Output the reads in the new ordering
     logger.info("Assigning reads to UMIs and outputting.")
     val outHeader = header.clone()
-    outHeader.setSortOrder(SortOrder.unsorted)
-    outHeader.setGroupOrder(GroupOrder.query)
+    SamOrder.TemplateCoordinate.applyTo(outHeader)
     val out = SamWriter(output, outHeader)
 
     val iterator = sorter.iterator.grouped(2).map { case Seq(x,y) => if (x.firstOfPair) (x, y) else (y, x) }.buffered // consume in pairs

--- a/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
@@ -123,12 +123,14 @@ object UmiConsensusCaller {
   }
 
   /**
-    * Helper method to check that the input BAM is in the correct order for consensus calling.
+    * Helper method to check that the input BAM is in the correct order for consensus calling. Will call
+    * the warn function if the sort order looks like it's probably compatible but it's not 100% sure.
+    * Will invoke the error function in cases where the sort order is definitely incompatible.
     *
     * @param header the header of the BAM file to be used for consensus calling
     * @param source a path or string representing the source of the header
     * @param warn a function to be called when any warnings are detected/emitted
-    * @param error a function to be called when any errors are encountered
+    * @param error a function to be called when any errors are encountered; should probably throw an exception!
     */
   def checkSortOrder(header: SAMFileHeader, source: Any, warn: String => Unit, error: String => Unit): Unit = {
     // Check that the SAM file is sorted appropriately

--- a/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
@@ -30,7 +30,7 @@ import com.fulcrumgenomics.bam.api.{SamOrder, SamRecord}
 import com.fulcrumgenomics.commons.util.{Logger, SimpleCounter}
 import com.fulcrumgenomics.umi.UmiConsensusCaller._
 import com.fulcrumgenomics.util.NumericTypes.PhredScore
-import htsjdk.samtools.SAMFileHeader.GroupOrder
+import htsjdk.samtools.SAMFileHeader.{GroupOrder, SortOrder}
 import htsjdk.samtools.util.{Murmur3, SequenceUtil, TrimmingUtil}
 import htsjdk.samtools._
 
@@ -120,6 +120,27 @@ object UmiConsensusCaller {
 
     outHeader.addComment(s"Read group ${rg.getId} contains consensus reads generated from ${oldRgs.size} input read groups.")
     outHeader
+  }
+
+  /**
+    * Helper method to check that the input BAM is in the correct order for consensus calling.
+    *
+    * @param header the header of the BAM file to be used for consensus calling
+    * @param source a path or string representing the source of the header
+    * @param warn a function to be called when any warnings are detected/emitted
+    * @param error a function to be called when any errors are encountered
+    */
+  def checkSortOrder(header: SAMFileHeader, source: Any, warn: String => Unit, error: String => Unit): Unit = {
+    // Check that the SAM file is sorted appropriately
+    if (!SamOrder(header).contains(SamOrder.TemplateCoordinate)) {
+      // Group reads used to output the header without the sub-sort, so allow this for now
+      if (header.getSortOrder == SortOrder.unsorted && header.getGroupOrder == GroupOrder.query) {
+        warn(s"File $source may not be sorted correctly for consensus read generation.")
+      }
+      else {
+        error(s"File $source is not sorted correctly. Please sort with fgbio SortBam -s TemplateCoordinate.")
+      }
+    }
   }
 }
 

--- a/src/test/scala/com/fulcrumgenomics/umi/CallDuplexConsensusReadsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/CallDuplexConsensusReadsTest.scala
@@ -26,7 +26,7 @@ package com.fulcrumgenomics.umi
 
 import java.nio.file.Paths
 
-import com.fulcrumgenomics.bam.api.SamSource
+import com.fulcrumgenomics.bam.api.{SamOrder, SamSource}
 import com.fulcrumgenomics.testing.SamBuilder.{Minus, Plus}
 import com.fulcrumgenomics.testing.{SamBuilder, UnitSpec}
 
@@ -60,7 +60,7 @@ class CallDuplexConsensusReadsTest extends UnitSpec {
   }
 
   it should "not generate a consensus if AB-R1s are not on the same strand ads BA-R2s" in {
-    val builder = new SamBuilder(readLength=10)
+    val builder = new SamBuilder(readLength=10, sort=Some(SamOrder.TemplateCoordinate))
     builder.addPair(name="ab1", start1=100, start2=200, attrs=Map(MI -> "1/A"), bases1="AAAAAAAAAA", bases2="AAAAAAAAAA", strand1=Plus, strand2=Plus)
     builder.addPair(name="ba1", start1=200, start2=100, attrs=Map(MI -> "1/B"), bases1="AAAAAAAAAA", bases2="AAAAAAAAAA", strand1=Plus, strand2=Minus)
 
@@ -76,7 +76,7 @@ class CallDuplexConsensusReadsTest extends UnitSpec {
   }
 
   it should "not generate a consensus if AB-R2s are not on the same strand ads BA-R1s" in {
-    val builder = new SamBuilder(readLength=10)
+    val builder = new SamBuilder(readLength=10, sort=Some(SamOrder.TemplateCoordinate))
     builder.addPair(name="ab1", start1=100, start2=200, attrs=Map(MI -> "1/A"), bases1="AAAAAAAAAA", bases2="AAAAAAAAAA", strand1=Plus, strand2=Minus)
     builder.addPair(name="ba1", start1=200, start2=100, attrs=Map(MI -> "1/B"), bases1="AAAAAAAAAA", bases2="AAAAAAAAAA", strand1=Plus, strand2=Plus)
 
@@ -92,7 +92,7 @@ class CallDuplexConsensusReadsTest extends UnitSpec {
   }
 
   it should "run successfully and create consensus reads" in {
-    val builder = new SamBuilder(readLength=10)
+    val builder = new SamBuilder(readLength=10, sort=Some(SamOrder.TemplateCoordinate))
     builder.addPair(name="ab1", start1=100, start2=100, attrs=Map(MI -> "1/A"), bases1="AAAAAAAAAA", bases2="AAAAAAAAAA")
     builder.addPair(name="ab2", start1=100, start2=100, attrs=Map(MI -> "1/A"), bases1="AAAAAAAAAA", bases2="AAAAAAAAAA")
     builder.addPair(name="ab3", start1=100, start2=100, attrs=Map(MI -> "1/A"), bases1="AAAAAAAAAA", bases2="AAAAAAAAAA")

--- a/src/test/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReadsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReadsTest.scala
@@ -25,6 +25,7 @@
 
 package com.fulcrumgenomics.umi
 
+import com.fulcrumgenomics.bam.api.SamOrder
 import com.fulcrumgenomics.testing.{SamBuilder, UnitSpec}
 import com.fulcrumgenomics.umi.VanillaUmiConsensusCallerOptions._
 
@@ -40,7 +41,7 @@ class CallMolecularConsensusReadsTest extends UnitSpec {
 
   "CallMolecularConsensusReads" should "run end-to-end" in {
     val rlen    = 100
-    val builder = new SamBuilder(baseQuality=30, readLength=rlen, readGroupId=Some("ABC"))
+    val builder = new SamBuilder(baseQuality=30, readLength=rlen, readGroupId=Some("ABC"), sort=Some(SamOrder.TemplateCoordinate))
     val output  = newBam
     val rejects = newBam
 

--- a/src/test/scala/com/fulcrumgenomics/umi/UmiConsensusCallerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/UmiConsensusCallerTest.scala
@@ -1,0 +1,60 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.fulcrumgenomics.umi
+
+import com.fulcrumgenomics.bam.api.SamOrder
+import com.fulcrumgenomics.testing.{SamBuilder, UnitSpec}
+import htsjdk.samtools.SAMFileHeader.GroupOrder
+import org.scalatest.OptionValues
+
+class UmiConsensusCallerTest extends UnitSpec with OptionValues {
+  "UmiConsensusCaller" should "do nothing when the header has the right sort order in it" in {
+    val builder = new SamBuilder(sort=Some(SamOrder.TemplateCoordinate))
+    var warning : Option[String] = None
+    var error   : Option[String] = None
+    UmiConsensusCaller.checkSortOrder(builder.header, "foo.bam", w => warning = Some(w), e => error = Some(e))
+    warning shouldBe None
+    error shouldBe None
+  }
+
+  it should "fire a warning if the file is query grouped and unsorted but without sub-sort specified" in {
+    val builder = new SamBuilder(sort=Some(SamOrder.Unsorted))
+    builder.header.setGroupOrder(GroupOrder.query)
+    var warning : Option[String] = None
+    var error   : Option[String] = None
+    UmiConsensusCaller.checkSortOrder(builder.header, "foo.bam", w => warning = Some(w), e => error = Some(e))
+    warning.value.indexOf("foo.bam") should be >= 0
+    error shouldBe None
+  }
+
+  it should "fire an error if the file is coordinate sorted" in {
+    val builder = new SamBuilder(sort=Some(SamOrder.Coordinate))
+    var warning : Option[String] = None
+    var error   : Option[String] = None
+    UmiConsensusCaller.checkSortOrder(builder.header, "foo.bam", w => warning = Some(w), e => error = Some(e))
+    warning shouldBe None
+    error.value.indexOf("foo.bam") should be >= 0
+  }
+}


### PR DESCRIPTION
Fix for #368.  Checks that the sort order in the header makes sense for consensus calling.

I updated GroupReadsByUmi to correctly set the sort order in the header, it was only doing it partially before.  Because of that there are three levels of checking:

1. If the header matches what GroupReadsByUmi now produces, everything proceeds normally
2. If the header matches what GroupReadsByUmi used to produce, a _warning_ is emitted that the file _may not be_ sorted correctly
3. If the header matches any other sort/group order the programs fail with a clear message.

For (2) the output looks like this:
```
[2018/02/27 08:07:10 | CallMolecularConsensusReads | Warning] File /tmp/old_group_reads.bam may not be sorted correctly for consensus read generation.
```

For (3) the output looks like this:
```
[2018/02/27 08:16:45 | FgBioMain | Fatal] ########################################################################################################################################
[2018/02/27 08:16:45 | FgBioMain | Fatal] Execution failed!
[2018/02/27 08:16:45 | FgBioMain | Fatal] File tmp/resorted_by_samtools.bam is not sorted correctly. Please sort with fgbio SortBam -s TemplateCoordinate.
[2018/02/27 08:16:45 | FgBioMain | Fatal] ########################################################################################################################################
[2018/02/27 08:16:45 | FgBioMain | Info] CallDuplexConsensusReads failed. Elapsed time: 0.04 minutes.
```