### PR TITLE
Fix ExtractUmisFromBam when only one read has a UMI in it.

### DIFF
--- a/src/test/scala/com/fulcrumgenomics/umi/ExtractUmisFromBamTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/ExtractUmisFromBamTest.scala
@@ -29,7 +29,6 @@ import com.fulcrumgenomics.bam.api.{SamRecord, SamWriter}
 import com.fulcrumgenomics.sopt.cmdline.ValidationException
 import com.fulcrumgenomics.testing.{SamBuilder, UnitSpec}
 import com.fulcrumgenomics.util.ReadStructure
-import htsjdk.samtools.SAMRecord
 import org.scalatest.OptionValues
 
 /**
@@ -397,8 +396,8 @@ class ExtractUmisFromBamTest extends UnitSpec with OptionValues {
     val r2Out = recs.find(_.secondOfPair).getOrElse(fail("Couldnt find R2 in the output"))
     r1Out.length shouldBe 42
     r2Out.length shouldBe 50
-    r1Out.get("A1") shouldBe Some(umi)
-    r2Out.get("A1") shouldBe Some(umi)
+    r1Out.get("A1").value shouldBe umi
+    r2Out.get("A1").value shouldBe umi
   }
 
   "ExtractUmisFromBam.updateClippingInformation" should "update the clipping information for non-template bases" in {


### PR DESCRIPTION
The code as it was previously would write a UMI with a trailing `-` in it in the new test.  This is because, when giving a single tag it would create `molecularIndexTags1` and `molecularIndexTags2` as `Seq(tag)`, and then compute an empty-string as the molecular barcode for the second read.

I think what I've done is a little clearer up front, but you can be the judge of that!