### PR TITLE
Add a method to expose the output sort of GroupReadsByUmi

### DIFF
--- a/src/test/scala/com/fulcrumgenomics/bam/api/SamOrderTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/api/SamOrderTest.scala
@@ -28,9 +28,12 @@ import java.util.Random
 
 import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.commons.util.SimpleCounter
+import com.fulcrumgenomics.testing.SamBuilder.{Minus, Plus}
 import com.fulcrumgenomics.testing.{SamBuilder, UnitSpec}
 import htsjdk.samtools.{SAMFileHeader, SAMRecordCoordinateComparator, SAMRecordQueryNameComparator}
 import htsjdk.samtools.SAMFileHeader.{GroupOrder, SortOrder}
+
+import scala.collection.mutable.ListBuffer
 
 object SamOrderTest {
   // Builder to for a set of records to be used in testing sorting
@@ -134,5 +137,56 @@ class SamOrderTest extends UnitSpec {
     }
 
     counts.foreach { case (name, count) => count shouldBe 1}
+  }
+
+  "SamOrder.TemplateCoordinate" should "sort by molecular identifier then name" in {
+    val addFuncs: Seq[SamBuilder => Unit] = Seq(
+      b => b.addPair(name="ab0", start1=200, start2=200, attrs=Map("MI" -> "0/A"), bases1="AAAAAAAAAA", bases2="AAAAAAAAAA"),
+      b => b.addPair(name="ab1", start1=100, start2=100, attrs=Map("MI" -> "1/A"), bases1="AAAAAAAAAA", bases2="AAAAAAAAAA"),
+      b => b.addPair(name="ab2", start1=100, start2=100, attrs=Map("MI" -> "1/A"), bases1="AAAAAAAAAA", bases2="AAAAAAAAAA"),
+      b => b.addPair(name="ab3", start1=100, start2=100, attrs=Map("MI" -> "2/A"), bases1="AAAAAAAAAA", bases2="AAAAAAAAAA"),
+      b => b.addPair(name="ba0", start1=200, start2=200, strand1=Minus, strand2=Plus, attrs=Map("MI" -> "0/B"), bases1="AAAAAAAAAA", bases2="AAAAAAAAAA"),
+      b => b.addPair(name="ba1", start1=100, start2=100, strand1=Minus, strand2=Plus, attrs=Map("MI" -> "1/B"), bases1="AAAAAAAAAA", bases2="AAAAAAAAAA"),
+      b => b.addPair(name="ba2", start1=100, start2=100, strand1=Minus, strand2=Plus, attrs=Map("MI" -> "1/B"), bases1="AAAAAAAAAA", bases2="AAAAAAAAAA"),
+      b => b.addPair(name="ba3", start1=100, start2=100, strand1=Minus, strand2=Plus, attrs=Map("MI" -> "2/B"), bases1="AAAAAAAAAA", bases2="AAAAAAAAAA")
+    )
+
+    def seq(n: Int, str: String): Seq[String] = Array.fill[String](n)(str)
+
+    Range.inclusive(start=1, end=10).foreach { _ =>
+      val builder = new SamBuilder(readLength=10)
+      scala.util.Random.shuffle(addFuncs).foreach { func => func(builder) }
+      val f = SamOrder.TemplateCoordinate.sortkey
+      val recs = builder.iterator.toSeq.sortBy(f(_))
+      recs should have length 16
+      val moleclarIdentifiers = seq(4, "1/A") ++ seq(4, "1/B") ++ seq(2, "2/A") ++ seq(2, "2/B") ++ seq(2, "0/A") ++ seq(2, "0/B")
+      recs.map(_.apply[String]("MI")) should contain theSameElementsInOrderAs moleclarIdentifiers
+      val names = Seq("ab1", "ab2", "ba1", "ba2", "ab3", "ba3", "ab0", "ba0").flatMap { name => seq(2, name)}
+      recs.map(_.name) should contain theSameElementsInOrderAs names
+      recs.grouped(2).foreach { pair =>
+        pair.count(_.firstOfPair) shouldBe 1
+        pair.count(_.secondOfPair) shouldBe 1
+        pair.foreach(_.name shouldBe pair.head.name)
+      }
+    }
+  }
+
+  it should "sort pairs by the 'lower' 5' position of the pair" in {
+    val builder = new SamBuilder(readLength=100, sort=Some(SamOrder.Coordinate))
+    val exp = ListBuffer[SamRecord]()
+    // Records are added to the builder in the order that we expect them to be sorted, but the builder
+    // will coordinate sort them for us, so we can re-sort them and test the results
+    exp ++= builder.addPair("q1", contig=0, start1=100, start2=300)
+    exp ++= builder.addPair("q2", contig=0, start1=106, start2=300, cigar1="5S95M") // effective=101
+    exp ++= builder.addPair("q3", contig=0, start1=102, start2=299)
+    exp ++= builder.addPair("q4", contig=0, start1=300, start2=110, strand1=Minus, strand2=Plus)
+    exp ++= builder.addPair("q5", contig=0, start1=120, start2=320)
+    exp ++= builder.addPair("q6", contig=1, start1=1,   start2=200)
+
+    // Order they are added in except for q4 gets it's mate's flipped because of strand order
+    val expected = List("q1/1", "q1/2", "q2/1", "q2/2", "q3/1", "q3/2", "q4/2", "q4/1", "q5/1", "q5/2", "q6/1", "q6/2")
+    val actual   = builder.toList.sortBy(r => SamOrder.TemplateCoordinate.sortkey(r)).map(_.id)
+
+    actual should contain theSameElementsInOrderAs expected
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/umi/GroupReadsByUmiTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/GroupReadsByUmiTest.scala
@@ -170,27 +170,6 @@ class GroupReadsByUmiTest extends UnitSpec {
     }
   }
 
-  {
-    "TemplateCoordinate SamOrder" should "sort pairs by the 'lower' 5' position of the pair" in {
-      val builder = new SamBuilder(readLength=100, sort=Some(SamOrder.Coordinate))
-      val exp = ListBuffer[SamRecord]()
-      // Records are added to the builder in the order that we expect them to be sorted, but the builder
-      // will coordinate sort them for us, so we can re-sort them and test the results
-      exp ++= builder.addPair("q1", contig=0, start1=100, start2=300)
-      exp ++= builder.addPair("q2", contig=0, start1=106, start2=300, cigar1="5S95M") // effective=101
-      exp ++= builder.addPair("q3", contig=0, start1=102, start2=299)
-      exp ++= builder.addPair("q4", contig=0, start1=300, start2=110, strand1=Minus, strand2=Plus)
-      exp ++= builder.addPair("q5", contig=0, start1=120, start2=320)
-      exp ++= builder.addPair("q6", contig=1, start1=1,   start2=200)
-
-      // Order they are added in except for q4 gets it's mate's flipped because of strand order
-      val expected = List("q1/1", "q1/2", "q2/1", "q2/2", "q3/1", "q3/2", "q4/2", "q4/1", "q5/1", "q5/2", "q6/1", "q6/2")
-      val actual   = builder.toList.sortBy(r => SamOrder.TemplateCoordinate.sortkey(r)).map(_.id)
-
-      actual should contain theSameElementsInOrderAs expected
-    }
-  }
-
   // Test for running the GroupReadsByUmi command line program with some sample input
   "GroupReadsByUmi" should "group reads correctly" in {
     val builder = new SamBuilder(readLength=100, sort=Some(SamOrder.Coordinate))


### PR DESCRIPTION
Also, `TemplateCoordinate` is not the right sort order for the output of `GroupReadsByUmi`, so we should also update the various consensus calling tests that use it, although there is not `SamOrder` for it, so we may be stuck.