### PR TITLE
Allow glocal alignment of longer query to shorter target.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/alignment/NeedlemanWunschAligner.scala
+++ b/src/main/scala/com/fulcrumgenomics/alignment/NeedlemanWunschAligner.scala
@@ -89,15 +89,13 @@ class NeedlemanWunschAligner(val scoringFunction: (Byte,Byte) => Int,
   def align(query: String, target: String): Alignment = align(query.getBytes, target.getBytes)
 
   /**
-    * Align two sequences with the current scoring system.  If the [[Mode]] is `Global` the query and target
-    * may be of any length.  If the [[Mode]] is Glocal then the target must be at least as long as the query.
+    * Align two sequences with the current scoring system and mode.
     *
     * @param query the query sequence
     * @param target the target sequence
     * @return an [[Alignment]] object describing the optimal global alignment of the two sequences
     */
   def align(query: Array[Byte], target: Array[Byte]): Alignment = {
-    require(query.length <= target.length || this.mode == Mode.Global, "For glocal, query length must be <= target length.")
     val (scoring, trace) = buildMatrices(query, target)
     generateAlignment(query, target, scoring, trace)
   }

--- a/src/test/scala/com/fulcrumgenomics/alignment/NeedlemanWunschAlignerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/alignment/NeedlemanWunschAlignerTest.scala
@@ -278,7 +278,10 @@ class NeedlemanWunschAlignerTest extends UnitSpec {
     result.score shouldBe 4
   }
 
-  it should "fail if the target sequence is shorter than the query sequence" in {
-    an[Exception] shouldBe thrownBy { NeedlemanWunschAligner(1, -1, -3, -1, mode=Glocal).align("ACGTACGTACGT", "ACGT") }
+  it should "align a query that is longer than the target, creating an insertino" in {
+    val result = NeedlemanWunschAligner(1, -1, -3, -1, mode=Glocal).align("AAAAGGGGTTTT", "AAAATTTT")
+    result.queryStart shouldBe 1
+    result.targetStart shouldBe 1
+    result.cigar.toString shouldBe "4=4I4="
   }
 }


### PR DESCRIPTION
@nh13 I thought I was being clever requiring the query to be <= the target for glocal alignment, and that it would help catch bugs where query and target got reversed.  But of course it is valid to align a longer query to a shorter target, and this comes up frequently in the case on long insertions.