### PR TITLE
Fix the NeedlemanWunschAligner to support affine gap penalties.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/alignment/NeedlemanWunschAligner.scala
+++ b/src/main/scala/com/fulcrumgenomics/alignment/NeedlemanWunschAligner.scala
@@ -66,7 +66,27 @@ object NeedlemanWunschAligner {
   val Up  : Direction     = 2.toByte
   val Diagonal: Direction = 3.toByte
   val Done: Direction     = 4.toByte
+
+  // NB: the order of LeftAndDiagonal and UpAndDiagonal matters when breaking ties!
+  val AllDirections: Seq[Direction]   = Seq(Diagonal, Left, Up)
+  val LeftAndUp: Seq[Direction]       = Seq(Left, Up)
+  val LeftAndDiagonal: Seq[Direction] = Seq(Diagonal, Left)
+  val UpAndDiagonal: Seq[Direction]   = Seq(Diagonal, Up)
+
+  /** The minimum score allowed to start an alignment.  This prevents underflow. */
+  val MinStartScore: Int = Int.MinValue / 2
 }
+
+
+object AlignmentMatrix {
+  def apply(direction: Direction, queryLength: Int, targetLength: Int): AlignmentMatrix = {
+    AlignmentMatrix(direction=direction, scoring=Matrix[Int](queryLength+1, targetLength+1), trace=Matrix[Direction](queryLength+1, targetLength+1))
+  }
+}
+
+/** A single alignment matrix for a given [[Direction]] storing both the scoring and traceback matrices produce by the aligner. */
+case class AlignmentMatrix(direction: Direction, scoring: Matrix[Int], trace: Matrix[Direction])
+
 
 /**
   * Implementation of the Needleman-Wunsch algorithm for global alignment of two sequences with support for an
@@ -98,8 +118,8 @@ class NeedlemanWunschAligner(val scoringFunction: (Byte,Byte) => Int,
     * @return an [[Alignment]] object describing the optimal global alignment of the two sequences
     */
   def align(query: Array[Byte], target: Array[Byte]): Alignment = {
-    val (scoring, trace) = buildMatrices(query, target)
-    generateAlignment(query, target, scoring, trace)
+    val matrices = buildMatrices(query, target)
+    generateAlignment(query, target, matrices)
   }
 
   /**
@@ -118,25 +138,38 @@ class NeedlemanWunschAligner(val scoringFunction: (Byte,Byte) => Int,
     * @param target the target sequence
     * @return a tuple of the scoring matrix and the traceback matrix
     */
-  protected def buildMatrices(query: Array[Byte], target: Array[Byte]): (Matrix[Int], Matrix[Direction]) = {
-    val scoring = Matrix[Int](query.length + 1, target.length + 1)
-    val trace   = Matrix[Direction](query.length + 1, target.length + 1)
+  protected def buildMatrices(query: Array[Byte], target: Array[Byte]): Map[Direction, AlignmentMatrix] = {
+    val matrices = Seq(Diagonal, Left, Up).map { direction =>
+      direction -> AlignmentMatrix(direction=direction, queryLength=query.length, targetLength=target.length)
+    }.toMap
 
-    // Top left corner
-    scoring(0,0) = 0
-    trace(0,0)   = Done
+    // Top left corner - allow all to be zero score but then must be careful to initialize Up and Left to have a gap open
+    AllDirections.foreach { direction =>
+      matrices(direction).scoring(0, 0) = 0
+      matrices(direction).trace(0, 0)   = Done
+    }
 
     // Down the left hand side - for global/glocal we have to keep going up, for local we're done
     mode match {
       case Global | Glocal =>
         forloop(from=1, until=query.length+1) { i =>
-          trace(i, 0)   = Up
-          scoring(i, 0) = scoring(i-1, 0) + gapExtend + (if (i == 1) gapOpen else 0)
+          LeftAndDiagonal.foreach { direction =>
+            matrices(direction).scoring(i, 0) = MinStartScore
+            matrices(direction).trace(i, 0)   = Done
+          }
+          matrices(Up).scoring(i, 0) = matrices(Up).scoring(i-1, 0) + gapExtend + (if (i == 1) gapOpen else 0)
+          matrices(Up).trace(i, 0)   = if (i == 1) Diagonal else Up
         }
       case Local =>
         forloop(from=1, until=query.length+1) { i =>
-          trace(i, 0)   = Done
-          scoring(i, 0) = 0
+          forloop(from=1, until=query.length+1) { i =>
+            LeftAndUp.foreach { direction =>
+              matrices(direction).scoring(i, 0) = MinStartScore
+              matrices(direction).trace(i, 0)   = Done
+            }
+            matrices(Diagonal).scoring(i, 0) = 0
+            matrices(Diagonal).trace(i, 0)   = Done
+          }
         }
     }
 
@@ -144,38 +177,57 @@ class NeedlemanWunschAligner(val scoringFunction: (Byte,Byte) => Int,
     mode match {
       case Global =>
         forloop(from=1, until=target.length+1) { j =>
-          trace(0, j)   = Left
-          scoring(0, j) = scoring(0, j-1) + gapExtend + (if (j == 1) gapOpen else 0)
+          UpAndDiagonal.foreach { direction =>
+            matrices(direction).scoring(0, j) = MinStartScore
+            matrices(direction).trace(0 , j)   = Done
+          }
+          matrices(Left).scoring(0, j) = matrices(Left).scoring(0, j-1) + gapExtend + (if (j == 1) gapOpen else 0)
+          matrices(Left).trace(0, j)   = if (j == 1) Diagonal else Left
         }
       case Glocal | Local =>
         forloop(from=1, until=target.length+1) { j =>
-          trace(0, j)   = Done
-          scoring(0, j) = 0
+          LeftAndUp.foreach { direction =>
+            matrices(direction).scoring(0, j) = MinStartScore
+            matrices(direction).trace(0, j)   = Done
+          }
+          matrices(Diagonal).scoring(0, j) = 0
+          matrices(Diagonal).trace(0, j)   = Done
         }
     }
 
     // The interior of the matrix
     forloop(from=1, until=query.length+1) { i =>
       forloop(from=1, until=target.length+1) { j =>
-        val diagonalScore = scoring(i-1, j-1) + scoringFunction(query(i-1), target(j-1))
-        val upScore       = scoring(i-1, j  ) + gapExtend + (if (trace(i-1, j  ) == Up) 0 else gapOpen)
-        val leftScore     = scoring(i,   j-1) + gapExtend + (if (trace(i,   j-1) == Left) 0 else gapOpen)
-
-        val maxScore = max(max(diagonalScore, upScore), leftScore)
-        scoring(i,j) = maxScore
-
-        // Prefer mismatches first when back-tracing so as to push indels to the left of the alignment
-        // The choice to prefer deletions before insertions is largely arbitrary!
-        trace(i,j)   = if (maxScore == diagonalScore) Diagonal else if (maxScore == leftScore) Left else Up
-        // For local mode, we can start anywhere
-        if (mode == Local && scoring(i,j) < 0) {
-          scoring(i,j) = 0
-          trace(i,j)   = Done
+        // Diagonal matrix can come from the previous diagonal, up, or left
+        val maxDiagDirection = AllDirections.maxBy(direction => matrices(direction).scoring(i-1, j-1))
+        matrices(Diagonal).scoring(i, j) = matrices(maxDiagDirection).scoring(i-1, j-1) + scoringFunction(query(i-1), target(j-1))
+        matrices(Diagonal).trace(i, j)   = maxDiagDirection
+        assert(maxDiagDirection == Diagonal || matrices(maxDiagDirection).scoring(i-1, j-1) > matrices(Diagonal).scoring(i-1, j-1))
+        // For local mode, we can start anywhere.  We use < 0 to prefer longer alignments
+        if (mode == Local && matrices(Diagonal).scoring(i, j) < 0) {
+          matrices(Diagonal).scoring(i, j) = 0
+          matrices(Diagonal).trace(i, j)   = Done
         }
+
+        // Up matrix can come from diagonal or up
+        val maxUpDirection = UpAndDiagonal.maxBy { direction =>
+          val gapPenalty = gapExtend + (if (direction == Up) 0 else gapOpen)
+          matrices(direction).scoring(i-1, j) + gapPenalty
+        }
+        matrices(Up).scoring(i, j) = matrices(maxUpDirection).scoring(i-1, j) + gapExtend + (if (maxUpDirection == Up) 0 else gapOpen)
+        matrices(Up).trace(i, j)   = maxUpDirection
+
+        // Left matrix can come from diagonal or left
+        val maxLeftDirection = LeftAndDiagonal.maxBy { direction =>
+          val gapPenalty = gapExtend + (if (direction == Left) 0 else gapOpen)
+          matrices(direction).scoring(i, j-1) + gapPenalty
+        }
+        matrices(Left).scoring(i, j) = matrices(maxLeftDirection).scoring(i, j-1) + gapExtend + (if (maxLeftDirection == Left) 0 else gapOpen)
+        matrices(Left).trace(i, j)   = maxLeftDirection
       }
     }
 
-    (scoring, trace)
+    matrices
   }
 
   /**
@@ -184,67 +236,71 @@ class NeedlemanWunschAligner(val scoringFunction: (Byte,Byte) => Int,
     *
     * @param query the query sequence
     * @param target the target sequence
-    * @param scoring the scoring matrix
-    * @param trace the trace back matrix
+    * @param matrices the scoring and trace back matrices for the [[Left]], [[Up]], and [[Diagonal]] directions.
     * @return an [[Alignment]] object representing the alignment
     */
-  protected def generateAlignment(query: Array[Byte], target: Array[Byte], scoring: Matrix[Int], trace: Matrix[Direction]): Alignment = {
+  protected def generateAlignment(query: Array[Byte], target: Array[Byte], matrices: Map[Direction, AlignmentMatrix]): Alignment = {
     var currOperator: CigarOperator = null
     var currLength: Int = 0
     val elems = new mutable.ArrayBuffer[CigarElem]()
 
     // For the target sequence, start at the end for Global, or the highest scoring cell in the last row for Glocal, or
-    // the highest scoring cell anywhere in the matrix
-    var (i, j) = this.mode match {
-      case Global => (query.length, target.length)
+    // the highest scoring cell anywhere in the matrix for Local
+    var (curI, curJ, curD) = this.mode match {
+      case Global =>
+        (query.length, target.length, AllDirections.maxBy(d => matrices(d).scoring(query.length, target.length)))
       case Glocal =>
-        var (maxScore, maxJ) = (Int.MinValue, -1)
+        var (maxScore, maxJ, maxD) = (MinStartScore, -1, Done)
         forloop(from=1, until=target.length+1) { j =>
-          val score = scoring(query.length, j)
+          val direction = AllDirections.maxBy(d => matrices(d).scoring(query.length, j))
+          val score     = matrices(direction).scoring(query.length, j)
           if (score > maxScore) {
             maxScore = score
             maxJ = j
+            maxD = direction
           }
         }
-        (query.length, maxJ)
+        (query.length, maxJ, maxD)
       case Local =>
-        var (maxScore, maxI, maxJ) = (Int.MinValue, -1, -1)
+        var (maxScore, maxI, maxJ, maxD) = (MinStartScore, -1, -1, Done)
         forloop(from=1, until=query.length+1) { i =>
           forloop(from=1, until=target.length+1) { j =>
-            val score = scoring(i, j)
+            val direction = AllDirections.maxBy(d => matrices(d).scoring(i, j))
+            val score     = matrices(direction).scoring(i, j)
             if (score > maxScore) {
               maxScore = score
               maxI = i
               maxJ = j
+              maxD = direction
             }
           }
         }
-        (maxI, maxJ)
+        (maxI, maxJ, maxD)
       }
 
     // The score is always the score from the starting cell
-    val score = scoring(i,j)
+    val score = matrices(curD).scoring(curI, curJ)
 
     // For global we have to reach the origin, for glocal we just have to reach the top row, and for local we can stop
     // anywhere.  Fortunately, we have initialized the appropriate cells to "Done"
-    val done = () => trace(i,j) == Done
-
+    val done = () => matrices(curD).trace(curI,curJ) == Done
     while (!done()) {
-      val op = trace(i,j) match {
+      val nextD = matrices(curD).trace(curI,curJ)
+      val op    = curD match {
         case Up       =>
-          i -= 1
+          curI -= 1
           CigarOperator.INSERTION
         case Left     =>
-          j -= 1
+          curJ -= 1
           CigarOperator.DELETION
         case Diagonal =>
-          i -= 1
-          j -= 1
-          if (query(i) == target(j)) this.matchOp else this.mismatchOp
+          curI -= 1
+          curJ -= 1
+          if (query(curI) == target(curJ)) this.matchOp else this.mismatchOp
       }
+      curD = nextD
 
       val extending = op == currOperator
-
       if (extending) {
         currLength += 1
       }
@@ -257,6 +313,6 @@ class NeedlemanWunschAligner(val scoringFunction: (Byte,Byte) => Int,
       if (done()) elems += CigarElem(currOperator, currLength)
     }
 
-    Alignment(query=query, target=target, queryStart=i+1, targetStart=j+1, cigar=Cigar(elems.reverse), score=score)
+    Alignment(query=query, target=target, queryStart=curI+1, targetStart=curJ+1, cigar=Cigar(elems.reverse), score=score)
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/alignment/NeedlemanWunschAlignerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/alignment/NeedlemanWunschAlignerTest.scala
@@ -295,6 +295,15 @@ class NeedlemanWunschAlignerTest extends UnitSpec {
     result.cigar.toString shouldBe "4=4I4="
   }
 
+  it should "align a query with leading and trailing gaps" in {
+    val q = s("-------------------GGTTTTAGAGCTAGAAATAGCAAGTTAAAATAAGGCTAGTCCGTTATCAACTTG---------------------------")
+    val t = s("AGGGCTATAGACTGCTAGAGGTTTTAGAGCTAGAAATAGCAAGTTAAAATAAGGCTAGTCCGTTATCAACTTGAAATGAGCTATTAGTCATGACGCTTTT")
+    val result = NeedlemanWunschAligner(1, -3, -3, -1).align(q, t)
+    assertValidGlobalAlignment(result)
+    result.cigar.toString() shouldBe "19D54=27D"
+    result.score shouldBe 54 - (1*19 + 3) - (1*27 + 3)
+  }
+
   "NeedlemanWunschAligner.align(Local)" should "align two identical sequences with all matches" in {
     val result = NeedlemanWunschAligner(1, -1, -3, -1, mode=Local).align(s("ACGTAACC"), s("ACGTAACC"))
     assertValidLocalAlignment(result)


### PR DESCRIPTION
Using only one scoring matrix causes us to not align gaps correctly and
return a sub-optimal alignment.