### PR TITLE
Moved snapshot builds to include the git commit hash.

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,7 @@
-version in ThisBuild := "0.6.0-SNAPSHOT"
+val gitHeadCommitSha = settingKey[String]("current git commit SHA")
+gitHeadCommitSha in ThisBuild := scala.sys.process.Process("git rev-parse --short HEAD").lineStream.head
+
+// *** IMPORTANT ***
+// One of the two "version" lines below needs to be uncommented.
+// version in ThisBuild := "0.6.0" // the release version
+version in ThisBuild := s"0.6.0-${gitHeadCommitSha.value}-SNAPSHOT" // the snapshot version


### PR DESCRIPTION
We talked about doing this a while ago, and just never did it.  @nh13 I'd find it really useful to have the hashes in the snapshots to ensure I'm getting the right snapshot in downstream projects.