### PR TITLE
Fixed writing and parsing of Double.Nan, Double.PositiveInfinity and …

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/util/Metric.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/Metric.scala
@@ -200,6 +200,7 @@ trait Metric extends Product with Iterable[(String,String)] {
     case f: Float       => formatValue(f.toDouble)
     case d: Double if d != 0.0 && d < 0.00001 && d > -0.00001 =>
       Metric.SmallDoubleFormat.synchronized { Metric.SmallDoubleFormat.format(d) }
+    case d: Double if d.isNaN || d.isInfinity => d.toString
     case d: Double      => Metric.BigDoubleFormat.synchronized { Metric.BigDoubleFormat.format(d) }
     case other          => other.toString
   }


### PR DESCRIPTION
…Double.NegativeInfinity in Metric classes.

@nh13 I get bitten by this occasionally where something goes to infinity, I write it out as a metric and then cannot read it back without a gory exception.  Turns out that DecimalFormat does not output Double.Infinity in a was that Double.parseDouble() can read it back.