### PR TITLE
Aligner to emit multiple alignments & allow customized gap scoring

### DIFF
--- a/src/test/scala/com/fulcrumgenomics/alignment/AlignerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/alignment/AlignerTest.scala
@@ -24,6 +24,7 @@
 
 package com.fulcrumgenomics.alignment
 
+import com.fulcrumgenomics.alignment.Aligner.AlignmentScorer
 import com.fulcrumgenomics.alignment.Mode.{Global, Glocal, Local}
 import com.fulcrumgenomics.commons.util.NumericCounter
 import com.fulcrumgenomics.testing.UnitSpec
@@ -303,6 +304,54 @@ class AlignerTest extends UnitSpec {
     assertValidGlobalAlignment(result)
     result.cigar.toString() shouldBe "19D54=27D"
     result.score shouldBe 54 - (1*19 + 3) - (1*27 + 3)
+  }
+
+  it should "work correctly with a custom scoring function" in {
+    val scorer  = new AlignmentScorer {
+      /** Matches case insensitive, but score is doubled if query is lower case! */
+      override def scorePairing(queryBase: Byte, targetBase: Byte): Int = {
+        val q = queryBase.toChar.toUpper
+        val t = targetBase.toChar.toUpper
+        if (queryBase.toChar.isLower) {
+          if (q == t) 10 else -10
+        }
+        else {
+          if (q == t) 5 else -5
+        }
+      }
+
+      /** Gap open and extend are 5-fold higher if within lower case query sequence. */
+      override def scoreGap(query: Array[Byte], target: Array[Byte], qOffset: Int, tOffset: Int, inQuery: Boolean, extend: Boolean): Int = {
+        if (query(qOffset).toChar.isLower) {
+          if (extend) -25 else -60
+        }
+        else {
+          if (extend) -5 else -12
+        }
+      }
+    }
+    val aligner = new Aligner(scorer, mode=Mode.Glocal)
+
+    val q1 = "ACGTTACGcccccc"
+    val t1 = "ACGTTACGCCCAAACCC"
+    aligner.align(q1.toUpperCase, t1.toUpperCase).cigar.toString shouldBe "11=3D3=" // upper case will prefer to insert a gap
+    aligner.align(q1, t1).cigar.toString shouldBe "11=3X"                           // lower case should give mismatches
+  }
+
+  it should "force a gap to before or after a G when gaps at G are penalized" in {
+    val scorer = new AlignmentScorer {
+      override def scorePairing(queryBase: Byte, targetBase: Byte): Int = if (queryBase == targetBase) 5 else -4
+      override def scoreGap(query: Array[Byte], target: Array[Byte], qOffset: Int, tOffset: Int, inQuery: Boolean, extend: Boolean): Int = {
+        if (query(qOffset) == 'G') -100
+        else if (extend) -5
+        else -12
+      }
+    }
+
+    val aligner = new Aligner(scorer, mode=Mode.Glocal)
+    val q = s("ACACGTACTCA")
+    val t = s("ACAC-TACTCA")
+    aligner.align(q, t).cigar.toString shouldBe "3=1I1X6="  // the gap is moved over the C, and a G/C mismatch created
   }
 
   "Aligner.align(Local)" should "align two identical sequences with all matches" in {

--- a/src/test/scala/com/fulcrumgenomics/alignment/AlignerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/alignment/AlignerTest.scala
@@ -398,6 +398,12 @@ class AlignerTest extends UnitSpec {
     aln shouldBe "|||.|||||||||||||||||"
   }
 
+  "Aligner.align(minScore)" should "return at least the perfect alignment" in {
+    val results = Aligner(5, -4, -5, -3, mode=Glocal).align("ACGTTTGCAT", "ACGTTTGCAT", 20).sortBy(- _.score)
+    results.size should be >= 1
+    results.head.cigar.toString shouldBe "10="
+  }
+
   /** Timing test - change "ignore" to "it" to enable. */
   ignore should "perform lots of glocal alignments" in {
     val count = 25000

--- a/src/test/scala/com/fulcrumgenomics/alignment/AlignerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/alignment/AlignerTest.scala
@@ -453,6 +453,17 @@ class AlignerTest extends UnitSpec {
     results.head.cigar.toString shouldBe "10="
   }
 
+  it should "produce multiple alignments" in {
+    val query = "TTTTT"
+    val target = "AAAAATTTTTGGGGGTTTTT"
+    val results = Aligner(5, -4, -10, -5, mode=Glocal).align(query, target, 25).sortBy(- _.score)
+    results should have size 2
+    results.foreach { r =>
+      r.score shouldBe 25
+      r.cigar.toString() shouldBe "5="
+    }
+  }
+
   /** Timing test - change "ignore" to "it" to enable. */
   ignore should "perform lots of glocal alignments" in {
     val count = 25000


### PR DESCRIPTION
@nh13 no rush on this since I know you are on vacation. 

When you do get to it, note that there are two commits which are likely easier to review independently.  The first refactors to expose the ability to generate multiple alignments from a matrix.  The second exposes the ability to customize gap scoring.

I'd really appreciate close scrutiny of and feedback on:

1) Where I've subbed in calls to the new scorer.scoreGap(), making sure I've got them right!
2) Whether the scoring API is sufficiently general to do anything else we might think of in future without changing the API _again_