### PR TITLE
Bugfix: Rscript.Available now tests for both Rscript and ggplot2

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ fgbio is built using [sbt](http://www.scala-sbt.org/).
 
 Use ```sbt assembly``` to build an executable jar in ```target/scala-2.11/```.
 
-Tests may be run with ```sbt test```. `R` and `ggplot2` are test dependencies.
+Tests may be run with ```sbt test```.
 
 Java SE 8 is required.
 

--- a/src/main/scala/com/fulcrumgenomics/util/Rscript.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/Rscript.scala
@@ -45,7 +45,7 @@ object Rscript extends LazyLogging {
   /** Returns true if R and ggplot2 are available and false otherwise. */
   lazy val Available: Boolean = {
     try {
-      val process = new ProcessBuilder(Executable, "-e", "require(ggplot2) || stop(1)").redirectErrorStream(true).start()
+      val process = new ProcessBuilder(Executable, "-e", "stopifnot(require(ggplot2))").redirectErrorStream(true).start()
       process.waitFor() == 0
     }
     catch { case e: Exception => false }

--- a/src/main/scala/com/fulcrumgenomics/util/Rscript.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/Rscript.scala
@@ -28,7 +28,6 @@ import java.nio.file.Path
 
 import com.fulcrumgenomics.commons.util.LazyLogging
 
-import scala.io.Source
 import scala.util.{Success, Try}
 
 /**
@@ -43,10 +42,10 @@ object Rscript extends LazyLogging {
     override def getMessage: String = s"Rscript failed with exit code ${status}."
   }
 
-  /** Returns true if R is available and false otherwise. */
+  /** Returns true if R and ggplot2 are available and false otherwise. */
   lazy val Available: Boolean = {
     try {
-      val process = new ProcessBuilder(Executable, "-e", "require(ggplot2)").redirectErrorStream(true).start()
+      val process = new ProcessBuilder(Executable, "-e", "require(ggplot2) || stop(1)").redirectErrorStream(true).start()
       process.waitFor() == 0
     }
     catch { case e: Exception => false }

--- a/src/test/scala/com/fulcrumgenomics/rnaseq/CollectErccMetricsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/rnaseq/CollectErccMetricsTest.scala
@@ -31,7 +31,7 @@ import com.fulcrumgenomics.commons.CommonsDef.{FilePath, PathPrefix}
 import com.fulcrumgenomics.commons.io.{Io, PathUtil}
 import com.fulcrumgenomics.commons.util.DelimitedDataParser
 import com.fulcrumgenomics.testing.{SamBuilder, UnitSpec}
-import com.fulcrumgenomics.util.Metric
+import com.fulcrumgenomics.util.{Metric, Rscript}
 import htsjdk.samtools.{SAMSequenceDictionary, SAMSequenceRecord}
 import org.scalatest.OptionValues
 
@@ -212,7 +212,7 @@ class CollectErccMetricsTest extends UnitSpec with OptionValues {
       metrics.head.ercc_templates shouldBe 3
       metrics.head.pearsons_correlation.value shouldBe 1
       metrics.head.slope.value shouldBe 1
-      Files.exists(outputs.plotPath) shouldBe true
+      Files.exists(outputs.plotPath) shouldBe Rscript.Available
     }
   }
 

--- a/src/test/scala/com/fulcrumgenomics/umi/CollectDuplexSeqMetricsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/CollectDuplexSeqMetricsTest.scala
@@ -32,7 +32,7 @@ import com.fulcrumgenomics.bam.api.SamOrder
 import com.fulcrumgenomics.commons.util.SimpleCounter
 import com.fulcrumgenomics.testing.SamBuilder.{Minus, Plus}
 import com.fulcrumgenomics.testing.{SamBuilder, UnitSpec}
-import com.fulcrumgenomics.util.{Io, Metric}
+import com.fulcrumgenomics.util.{Io, Metric, Rscript}
 import htsjdk.samtools.util.{Interval, IntervalList}
 import org.apache.commons.math3.distribution.NormalDistribution
 
@@ -272,8 +272,8 @@ class CollectDuplexSeqMetricsTest extends UnitSpec {
       counter.count((max(abs, bas), min(abs, bas)))
     }
 
-    val metrics = exec(builder, plot=true)
-    metrics.plots.toFile.exists() shouldBe true
+    val metrics = exec(builder, plot=Rscript.Available)
+    metrics.plots.toFile.exists() shouldBe Rscript.Available
 
     // Check that the duplex family sizes tie out
     metrics.duplexFamilyMetrics.foreach { m => m.count shouldBe counter.countOf((m.ab_size, m.ba_size)) }


### PR DESCRIPTION
Finally found the bug (https://github.com/fulcrumgenomics/fgbio/pull/342)!

When you require an installed package:

```bash
❯ Rscript -e 'require(stats)'
❯ echo $?
0
❯ Rscript -e 'stopifnot(require(stats))'
❯ echo $?
0
```

When you require a **non**-installed package:

```bash
❯ Rscript -e 'require(idontexist)'
❯ echo $?
0
❯ Rscript -e 'stopifnot(require(idontexist))'
❯ echo $?
1
```