### PR TITLE
Bug fix: output consensus UMI bases (RX) was wrongly computed

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
@@ -539,7 +539,7 @@ class GroupReadsByUmi
   }
 
   /** When a minimum UMI length is specified, truncates all the UMIs to the length of the shortest UMI.  For the paired
-    * assigner, truncates the first UMI and second UMI sepeartely.*/
+    * assigner, truncates the first UMI and second UMI separately.*/
   private def truncateUmis(umis: Seq[Umi]): Seq[Umi] = this.minUmiLength match {
     case None => umis
     case Some(length) =>

--- a/src/test/scala/com/fulcrumgenomics/umi/DuplexConsensusCallerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/DuplexConsensusCallerTest.scala
@@ -289,13 +289,8 @@ class DuplexConsensusCallerTest extends UnitSpec {
     // Add the original UMI bases to each read
     builder.foreach { rec =>
       val mi = rec[String](MI)
-      // first of pair ABs and second of pair BAs
-      if ((rec.firstOfPair && mi.endsWith("/A")) || (rec.secondOfPair && mi.endsWith("/B"))) {
-        rec(RX) = "AAT-CCG"
-      }
-      else {
-        rec(RX) = "CCG-AAT"
-      }
+      // all "/A" have the same UMI bases, while the "/B" bases have them swapped
+      if (mi.endsWith("/A")) rec(RX) = "AAT-CCG" else rec(RX) = "CCG-AAT"
     }
 
     val recs = caller(q=20).consensusReadsFromSamRecords(builder.toSeq)
@@ -327,7 +322,7 @@ class DuplexConsensusCallerTest extends UnitSpec {
       r2[Float](AbRawReadErrorRate)  shouldBe (1 / 30f)
       r2[Float](BaRawReadErrorRate)  shouldBe 0f
       r2[String](MI) shouldBe "foo"
-      r2[String](RX) shouldBe "CCG-AAT"
+      r2[String](RX) shouldBe "AAT-CCG"
     }
 
     { // Check the per-base tags


### PR DESCRIPTION
@tfenne could you take a close look at this.  I've read through `GroupReadsByUmi` and convinced myself of this, and also tested it on a BAM to make sure it does the right thing.