### PR TITLE
Speeding up the duplex consensus caller

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: required
 language: scala
+dist: trusty
 scala:
 - 2.12.2
 jdk:

--- a/build.sbt
+++ b/build.sbt
@@ -126,7 +126,6 @@ lazy val root = Project(id="fgbio", base=file("."))
       "com.fulcrumgenomics"       %% "commons"        % "0.7.0",
       "com.fulcrumgenomics"       %% "sopt"           % "0.7.0",
       "com.github.samtools"       %  "htsjdk"         % "2.16.1" excludeAll(htsjdkExcludes: _*),
-      "net.jafama"                %  "jafama"         % "2.1.0",
       "org.apache.commons"        %  "commons-math3"  % "3.6.1",
       "com.beachape"              %% "enumeratum"     % "1.5.12",
       "com.intel.gkl"             %  "gkl"            % "0.8.6",

--- a/src/main/scala/com/fulcrumgenomics/Writer.scala
+++ b/src/main/scala/com/fulcrumgenomics/Writer.scala
@@ -24,27 +24,6 @@
 
 package com.fulcrumgenomics
 
-import java.io.Closeable
-
-import com.fulcrumgenomics.FgBioDef._
-
 /** Writer trait to standardize how to interact with classes that write out objects. */
-trait Writer[A] extends Closeable {
-  /** Writes an individual item. */
-  def write(item: A): Unit
-
-  /** Writes out one or more items in order. */
-  def write[B <: A](items: TraversableOnce[B]): Unit = items.foreach(write)
-
-  /** Writes an item and returns a reference to the writer. */
-  def +=(item: A): this.type = {
-    write(item)
-    this
-  }
-
-  /** Writes an item and returns a reference to the writer. */
-  def ++=[B <: A](items: TraversableOnce[B]): this.type = {
-    write(items)
-    this
-  }
-}
+@deprecated("Use com.fulcrumgenomics.commons.io.Writer instead.", since="0.8.1")
+trait Writer[A] extends com.fulcrumgenomics.commons.io.Writer[A]

--- a/src/main/scala/com/fulcrumgenomics/bam/api/SamRecord.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/api/SamRecord.scala
@@ -60,6 +60,10 @@ class TransientAttrs(private val rec: SamRecord) {
     if (value == null) rec.asSam.removeTransientAttribute(key) else rec.asSam.setTransientAttribute(key, value)
   }
   def get[A](key: Any): Option[A] = Option(apply(key))
+  def getOrElse[A](key: Any, default: => A): A = rec.asSam.getTransientAttribute(key) match {
+    case null => default
+    case value => value.asInstanceOf[A]
+  }
 }
 
 /**

--- a/src/main/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReads.scala
@@ -152,7 +152,7 @@ class CallMolecularConsensusReads
       minInputBaseQuality          = minInputBaseQuality,
       minConsensusBaseQuality      = minConsensusBaseQuality,
       minReads                     = minReads,
-      maxReads                     = maxReads.getOrElse(Int.MaxValue),
+      maxReads                     = maxReads.getOrElse(VanillaUmiConsensusCallerOptions.DefaultMaxReads),
       producePerBaseTags           = outputPerBaseTags
     )
 

--- a/src/main/scala/com/fulcrumgenomics/util/NumericTypes.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/NumericTypes.scala
@@ -27,11 +27,10 @@ package com.fulcrumgenomics.util
 import java.lang.Math.exp
 
 import htsjdk.samtools.SAMUtils
-import net.jafama.FastMath._
+import org.apache.commons.math3.util.FastMath._
 
 /**
-  * Container object for a set of numeric types for working with common probability
-  * scalings.
+  * Container object for a set of numeric types for working with common probability scalings.
   */
 object NumericTypes {
   /** The value of toLogProbability(x) for [0, 1, ..., 10] */

--- a/src/test/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCallerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCallerTest.scala
@@ -33,8 +33,8 @@ import com.fulcrumgenomics.umi.VanillaUmiConsensusCallerOptions._
 import com.fulcrumgenomics.util.NumericTypes._
 import htsjdk.samtools.SAMUtils
 import htsjdk.samtools.util.CloserUtil
-import net.jafama.FastMath._
 import org.scalatest.OptionValues
+import org.apache.commons.math3.util.FastMath._
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -453,6 +453,11 @@ class VanillaUmiConsensusCallerTest extends UnitSpec with OptionValues {
     output.map(_.cigar.toString()).sorted shouldBe expected
   }
 
+  it should "return a single read if a single read was given" in {
+    val srcs = Seq(src(cigar="50M"))
+    val recs = cc().filterToMostCommonAlignment(srcs)
+    recs should have size 1
+  }
 
   "VanillaConsensusCaller.toSourceRead" should "mask bases that are below the quality threshold" in {
     val builder = new SamBuilder(readLength=10)


### PR DESCRIPTION
This can speed up the consensus caller by 1.5-2.15x for 2 and 4 threads respectively.  Speeds up by 1.15x for a single thread.  If there is _very_ high per-molecule coverage, this can speed up by 20x or more (single threaded). 

