### PR TITLE
UmiConsensusCaller now merges Platform tags case-insensitively

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
@@ -107,7 +107,7 @@ object UmiConsensusCaller {
     rg.setDescription     (collapse(_.getDescription))
     rg.setLibrary         (collapse(_.getLibrary))
     rg.setSample          (collapse(_.getSample))
-    rg.setPlatform        (collapse(_.getPlatform))
+    rg.setPlatform        (collapse(x => Option(x.getPlatform).map(_.toUpperCase).orNull)) // NB: this to ensure that platforms are all upper-case; not all tools are modern or well-behaved
     rg.setPlatformUnit    (collapse(_.getPlatformUnit))
     rg.setSequencingCenter(collapse(_.getSequencingCenter))
 

--- a/src/test/scala/com/fulcrumgenomics/umi/UmiConsensusCallerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/UmiConsensusCallerTest.scala
@@ -27,6 +27,7 @@ package com.fulcrumgenomics.umi
 import com.fulcrumgenomics.bam.api.SamOrder
 import com.fulcrumgenomics.testing.{SamBuilder, UnitSpec}
 import htsjdk.samtools.SAMFileHeader.GroupOrder
+import htsjdk.samtools.SAMReadGroupRecord
 import org.scalatest.OptionValues
 
 class UmiConsensusCallerTest extends UnitSpec with OptionValues {
@@ -56,5 +57,21 @@ class UmiConsensusCallerTest extends UnitSpec with OptionValues {
     UmiConsensusCaller.checkSortOrder(builder.header, "foo.bam", w => warning = Some(w), e => error = Some(e))
     warning shouldBe None
     error.value.indexOf("foo.bam") should be >= 0
+  }
+
+  "outputHeader" should "return correct platform id" in {
+    def buildRg(id: String, sample: String, platform: String): SAMReadGroupRecord = {
+      val rg = new SAMReadGroupRecord(id)
+      rg.setSample(sample)
+      rg.setPlatform(platform)
+      return rg
+    }
+
+    val builder = new SamBuilder(sort=Some(SamOrder.TemplateCoordinate))
+
+    builder.header.addReadGroup(buildRg(id = "B", sample ="Sample", platform = "ILLUMINA"))
+    builder.header.addReadGroup(buildRg(id = "C", sample ="Sample2", platform = "illumina"))
+    val outHeader = UmiConsensusCaller.outputHeader(in=builder.header, readGroupId = "A")
+    outHeader.getReadGroup("A").getPlatform shouldBe "ILLUMINA"
   }
 }


### PR DESCRIPTION
Due to historical reasons, some BAM files that UmiConsensusCaller will create consensus reads from may have multiple read groups with platform (or `PL` tags) that are inconsistently uppercase and lower case.  

This PR now merges the `PL` tag in a case insensitive manner, reporting only the final, merged uppercase `PL` tag.

I'm also happy to add an error message if there is more than one `PL` tag still in a `UmiConsensusCaller` output BAM, but feel that may be more appropriately handled by a downstream `ValidateSamFile` call.   