### PR TITLE
Setting intel deflater logging to stdout breaks pipeing and streaming clps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -108,10 +108,7 @@ lazy val htsjdkExcludes = Seq(
   ExclusionRule(organization="org.testng"),
   ExclusionRule(organization="com.google.cloud.genomics")
 )
-lazy val gkExcludes = Seq(
-  ExclusionRule(organization="commons-io", name="commons-io"),
-  //ExclusionRule(organization="org.apache.logging.log4j", name="log4j-core")
-)
+
 lazy val assemblySettings = Seq(
   test in assembly     := {},
   logLevel in assembly := Level.Info
@@ -132,7 +129,7 @@ lazy val root = Project(id="fgbio", base=file("."))
       "net.jafama"                %  "jafama"         % "2.1.0",
       "org.apache.commons"        %  "commons-math3"  % "3.6.1",
       "com.beachape"              %% "enumeratum"     % "1.5.12",
-      "com.intel.gkl"             %  "gkl"            % "0.8.6" excludeAll(gkExcludes: _*),
+      "com.intel.gkl"             %  "gkl"            % "0.8.6",
 
       //---------- Test libraries -------------------//
       "org.scalatest"             %% "scalatest"     % "3.0.4"  % "test->*" excludeAll ExclusionRule(organization="org.junit", name="junit")

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
   <Appenders>
-    <Console name="Console" target="SYSTEM_OUT">
+    <Console name="Console" target="SYSTEM_ERR">
       <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level %logger{1} - %msg%n"/>
     </Console>
   </Appenders>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -6,6 +6,11 @@
     </Console>
   </Appenders>
   <Loggers>
+    <!-- Suppress any log messages less severe than WARN for the Intel deflater and set additivity to false to avoid
+          passing messages to the Root logger and causing duplicate messages  -->
+    <Logger name="com.intel.gkl" level="WARN" additivity="false">
+      <AppenderRef ref="Console"/>
+    </Logger>
     <Root level="INFO">
       <AppenderRef ref="Console"/>
     </Root>


### PR DESCRIPTION
This fixes the issue of intel deflater logs outputting to /dev/stdout which breaks program streaming support.

For example: 

```
java -XX:GCTimeLimit=50 -XX:GCHeapFreeLimit=10 -Xmx4096m -jar fgbio.jar RemoveSamTags -i input.bam -o /dev/stdout -t cd -t ce -t ad -t ae -t bd -t be -t aq -t bq -t ac -t bc | java -XX:GCTimeLimit=50 -XX:GCHeapFreeLimit=10 -Xmx4096m -jar fgbio.jar ClipBam -i /dev/stdin -o /dev/stdout -r rn6.fa -c Hard -a false --upgrade-clipping false --read-one-five-prime 0 --read-one-three-prime 0 --read-two-five-prime 0 --read-two-three-prime 0 --clip-overlapping-reads true
Picked up _JAVA_OPTIONS: -Djava.io.tmpdir=/pipeline/tmp
Picked up _JAVA_OPTIONS: -Djava.io.tmpdir=/pipeline/tmp
06:46:42.898 INFO  NativeLibraryLoader - Loading libgkl_compression.so from jar:file:/pipeline/packages/fgbio.jar!/com/intel/gkl/native/libgkl_compression.so
06:46:42.899 WARN  NativeLibraryLoader - Unable to load libgkl_compression.so from native/libgkl_compression.so (org/apache/commons/io/FilenameUtils)
06:46:42.903 INFO  NativeLibraryLoader - Loading libgkl_compression.so from jar:file:/pipeline/packages/fgbio.jar!/com/intel/gkl/native/libgkl_compression.so
06:46:42.921 WARN  NativeLibraryLoader - Unable to load libgkl_compression.so from native/libgkl_compression.so (org/apache/commons/io/FilenameUtils)
[2019/07/03 06:46:45 | FgBioMain | Info] Executing RemoveSamTags from fgbio version 0.9.0-4370dfe-SNAPSHOT as root@19b4b2aa8bc6 on JRE 1.8.0_212-b04 with snappy, JdkInflater, and JdkDeflater
WARNING	2019-07-03 06:46:45	SAMFileWriterFactory	Cannot create index for BAM because output file is not a regular file: file:///dev/stdout
[2019/07/03 06:46:46 | FgBioMain | Info] Executing ClipBam from fgbio version 0.9.0-4370dfe-SNAPSHOT as root@19b4b2aa8bc6 on JRE 1.8.0_212-b04 with snappy, JdkInflater, and JdkDeflater
[2019/07/03 06:46:46 | FgBioMain | Info] ClipBam failed. Elapsed time: 0.06 minutes.
Exception in thread "main" htsjdk.samtools.SAMFormatException: Error parsing text SAM file. Not enough fields; File /dev/stdin; Line 1
Line: 06:46:42.969 INFO  NativeLibraryLoader - Loading libgkl_compression.so from jar:file:/pipeline/packages/fgbio.jar!/com/intel/gkl/native/libgkl_compression.so
```