### PR TITLE
Scala VCF API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: required
 language: scala
+dist: trusty
 scala:
 - 2.12.2
 jdk:

--- a/build.sbt
+++ b/build.sbt
@@ -126,7 +126,7 @@ lazy val root = Project(id="fgbio", base=file("."))
       "org.scala-lang.modules"    %% "scala-collection-compat" % "2.1.1",
       "com.fulcrumgenomics"       %% "commons"        % "0.8.0-87f4b88-SNAPSHOT",
       "com.fulcrumgenomics"       %% "sopt"           % "0.8.0-6330673-SNAPSHOT",
-      "com.github.samtools"       %  "htsjdk"         % "2.16.1" excludeAll(htsjdkExcludes: _*),
+      "com.github.samtools"       %  "htsjdk"         % "2.19.0" excludeAll(htsjdkExcludes: _*),
       "org.apache.commons"        %  "commons-math3"  % "3.6.1",
       "com.beachape"              %% "enumeratum"     % "1.5.13",
       "com.intel.gkl"             %  "gkl"            % "0.8.6",

--- a/build.sbt
+++ b/build.sbt
@@ -126,7 +126,6 @@ lazy val root = Project(id="fgbio", base=file("."))
       "com.fulcrumgenomics"       %% "commons"        % "0.7.0",
       "com.fulcrumgenomics"       %% "sopt"           % "0.7.0",
       "com.github.samtools"       %  "htsjdk"         % "2.16.1" excludeAll(htsjdkExcludes: _*),
-      "net.jafama"                %  "jafama"         % "2.1.0",
       "org.apache.commons"        %  "commons-math3"  % "3.6.1",
       "com.beachape"              %% "enumeratum"     % "1.5.12",
       "com.intel.gkl"             %  "gkl"            % "0.8.6",

--- a/build.sbt
+++ b/build.sbt
@@ -83,8 +83,8 @@ lazy val commonSettings = Seq(
   organizationName     := "Fulcrum Genomics LLC",
   homepage             := Some(url("http://github.com/fulcrumgenomics/fgbio")),
   startYear            := Some(2015),
-  scalaVersion         := "2.12.8",
-  crossScalaVersions   :=  Seq("2.11.12", "2.12.8"),
+  scalaVersion         := "2.13.0",
+  crossScalaVersions   :=  Seq("2.12.8", "2.13.0"),
   scalacOptions        ++= Seq("-target:jvm-1.8", "-deprecation", "-unchecked"),
   scalacOptions in (Compile, doc) ++= docScalacOptions,
   scalacOptions in (Test, doc) ++= docScalacOptions,
@@ -122,17 +122,19 @@ lazy val root = Project(id="fgbio", base=file("."))
     libraryDependencies ++= Seq(
       "org.scala-lang"            %  "scala-reflect"  % scalaVersion.value,
       "org.scala-lang"            %  "scala-compiler" % scalaVersion.value,
-      "org.scala-lang.modules"    %% "scala-xml"      % "1.0.6",
-      "com.fulcrumgenomics"       %% "commons"        % "0.7.0",
-      "com.fulcrumgenomics"       %% "sopt"           % "0.7.0",
+      "org.scala-lang.modules"    %% "scala-xml"      % "1.2.0",
+      "org.scala-lang.modules"    %% "scala-collection-compat" % "2.1.1",
+      "com.fulcrumgenomics"       %% "commons"        % "0.8.0-87f4b88-SNAPSHOT",
+      "com.fulcrumgenomics"       %% "sopt"           % "0.8.0-6330673-SNAPSHOT",
       "com.github.samtools"       %  "htsjdk"         % "2.16.1" excludeAll(htsjdkExcludes: _*),
       "org.apache.commons"        %  "commons-math3"  % "3.6.1",
-      "com.beachape"              %% "enumeratum"     % "1.5.12",
+      "com.beachape"              %% "enumeratum"     % "1.5.13",
       "com.intel.gkl"             %  "gkl"            % "0.8.6",
 
       //---------- Test libraries -------------------//
-      "org.scalatest"             %% "scalatest"     % "3.0.4"  % "test->*" excludeAll ExclusionRule(organization="org.junit", name="junit")
+      "org.scalatest"             %% "scalatest"     % "3.0.8"  % "test->*" excludeAll ExclusionRule(organization="org.junit", name="junit")
     ))
+
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
 // Merge strategy for assembly

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.1
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("fix-sbt-plugin-releases", url("http://dl.bintray.com/
 addSbtPlugin("com.typesafe.sbt"  % "sbt-git"       % "0.9.3")
 addSbtPlugin("com.github.gseitz" % "sbt-release"   % "1.0.6")
 addSbtPlugin("com.eed3si9n"      % "sbt-assembly"  % "0.14.6")
-addSbtPlugin("org.scoverage"     % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("org.scoverage"     % "sbt-scoverage" % "1.6.0")
 addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"  % "2.2")
 addSbtPlugin("com.jsuereth"      % "sbt-pgp"       % "1.1.0")
 addSbtPlugin("net.virtual-void"  % "sbt-dependency-graph" % "0.9.0")

--- a/src/main/java/com/fulcrumgenomics/util/PickLongIndices.scala
+++ b/src/main/java/com/fulcrumgenomics/util/PickLongIndices.scala
@@ -179,7 +179,7 @@ class PickLongIndices
   private val dnaFoldPredictor = viennaRnaDir.map(dir => new DnaFoldPredictor(dir.toFile, temperature))
   private[util] val adapterRegex = Pattern.compile("^[ACGT]*N+[ACGT]*$")
   adapters.map(_.toUpperCase).filterNot(adapterRegex.matcher(_).matches()) match {
-    case Seq() => Unit
+    case Seq() => ()
     case xs    => invalid(s"Adapters must be all [ACGT] with a single contiguous block of Ns where the index goes: ${xs}")
   }
 
@@ -332,7 +332,7 @@ class PickLongIndices
         x.distances.count(n)
         y.distances.count(n)
       }
-      case _ => Unit
+      case _ => ()
     }
 
     val metrics = annotated.map { ann =>

--- a/src/main/scala/com/fulcrumgenomics/Writer.scala
+++ b/src/main/scala/com/fulcrumgenomics/Writer.scala
@@ -24,27 +24,6 @@
 
 package com.fulcrumgenomics
 
-import java.io.Closeable
-
-import com.fulcrumgenomics.FgBioDef._
-
 /** Writer trait to standardize how to interact with classes that write out objects. */
-trait Writer[A] extends Closeable {
-  /** Writes an individual item. */
-  def write(item: A): Unit
-
-  /** Writes out one or more items in order. */
-  def write[B <: A](items: TraversableOnce[B]): Unit = items.foreach(write)
-
-  /** Writes an item and returns a reference to the writer. */
-  def +=(item: A): this.type = {
-    write(item)
-    this
-  }
-
-  /** Writes an item and returns a reference to the writer. */
-  def ++=[B <: A](items: TraversableOnce[B]): this.type = {
-    write(items)
-    this
-  }
-}
+@deprecated("Use com.fulcrumgenomics.commons.io.Writer instead.", since="0.8.1")
+trait Writer[A] extends com.fulcrumgenomics.commons.io.Writer[A]

--- a/src/main/scala/com/fulcrumgenomics/alignment/Aligner.scala
+++ b/src/main/scala/com/fulcrumgenomics/alignment/Aligner.scala
@@ -415,7 +415,7 @@ class Aligner(val scorer: AlignmentScorer,
                                   location: MatrixLocation): Alignment = {
     var currOperator: CigarOperator = null
     var currLength: Direction = 0
-    val elems = new mutable.ArrayBuffer[CigarElem]()
+    val elems = IndexedSeq.newBuilder[CigarElem]
     var MatrixLocation(curI, curJ, curD) = location
 
     // The score is always the score from the starting cell
@@ -453,7 +453,7 @@ class Aligner(val scorer: AlignmentScorer,
       if (nextD == Done) elems += CigarElem(currOperator, currLength)
     }
 
-    Alignment(query=query, target=target, queryStart=curI+1, targetStart=curJ+1, cigar=Cigar(elems.reverse), score=score)
+    Alignment(query=query, target=target, queryStart=curI+1, targetStart=curJ+1, cigar=Cigar(elems.result.reverse), score=score)
   }
 
   /**
@@ -512,7 +512,7 @@ class Aligner(val scorer: AlignmentScorer,
   private def findByScore(matrices: Array[AlignmentMatrix], minScore: Int): Seq[MatrixLocation] = {
     val qLen = matrices(0).queryLength
     val tLen = matrices(0).targetLength
-    val hits = new ArrayBuffer[MatrixLocation]()
+    val hits = IndexedSeq.newBuilder[MatrixLocation]
 
     this.mode match {
       case Global =>
@@ -532,7 +532,7 @@ class Aligner(val scorer: AlignmentScorer,
         }
     }
 
-    hits
+    hits.result
   }
 
   /** Returns true if the two bases should be considered a match when generating the alignment from the matrix

--- a/src/main/scala/com/fulcrumgenomics/bam/Bams.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/Bams.scala
@@ -92,7 +92,7 @@ case class Template(r1: Option[SamRecord],
 
     (x1, x2) match {
       case (Some(a), Some(b)) => SamPairUtil.setMateInfo(a.asSam, b.asSam)
-      case _ => Unit
+      case _ => ()
     }
 
     Template(x1, x2)

--- a/src/main/scala/com/fulcrumgenomics/bam/BaseCounts.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/BaseCounts.scala
@@ -39,7 +39,7 @@ object BaseCounts {
     * Generates a BaseCounts object from a collection of RecordAndOffest objects
     * representing a pileup.  Ensures that each template is only counted once.
     */
-  def apply(recs: Traversable[SamLocusIterator.RecordAndOffset]): BaseCounts = {
+  def apply(recs: Iterable[SamLocusIterator.RecordAndOffset]): BaseCounts = {
     val countsByBase = recs.groupBy(r => Character.toUpperCase(r.getReadBase.toChar))
       .map { case (ch, rs) => (ch, rs.map(_.getRecord.getReadName).toSeq.distinct.size) }
 

--- a/src/main/scala/com/fulcrumgenomics/bam/ClipBam.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ClipBam.scala
@@ -114,7 +114,7 @@ class ClipBam
           template.r2Supplementals.foreach(s => SamPairUtil.setMateInformationOnSupplementalAlignment(s.asSam, r1.asSam, true))
         case (Some(frag), None) =>
           clipFragment(frag=frag, metric=metricsMap.get(ReadType.Fragment))
-        case _ => Unit
+        case _ => ()
       }
 
       template.allReads.foreach { r =>
@@ -143,7 +143,7 @@ class ClipBam
       metricsMap.foreach {
         case (Fragment, metric)          => metricsMap(All).add(metric)
         case (ReadOne | ReadTwo, metric) => Seq(Pair, All).foreach { r => metricsMap(r).add(metric) }
-        case _                           => Unit
+        case _                           => ()
       }
       // Write it!
       Metric.write(path, ReadType.values.map { readType => metricsMap(readType)})

--- a/src/main/scala/com/fulcrumgenomics/bam/ClipBam.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ClipBam.scala
@@ -71,9 +71,7 @@ class ClipBam
   @arg(flag='o', doc="Output SAM or BAM file.") val output: PathToBam,
   @arg(flag='m', doc="Optional output of clipping metrics.") val metrics: Option[FilePath] = None,
   @arg(flag='r', doc="Reference sequence fasta file.") val ref: PathToFasta,
-  @deprecated("Use clipping-mode instead.", since="0.4.0")
-  @arg(flag='s', doc="Soft clip reads instead of hard clipping.", mutex=Array("clippingMode")) val softClip: Boolean = false,
-  @arg(flag='c', doc="The type of clipping to perform.", mutex=Array("softClip")) val clippingMode: Option[ClippingMode] = None,
+  @arg(flag='c', doc="The type of clipping to perform.") val clippingMode: ClippingMode = ClippingMode.Hard,
   @arg(flag='a', doc="Automatically clip extended attributes that are the same length as bases.") val autoClipAttributes: Boolean = false,
   @arg(flag='H', doc="Upgrade all existing clipping in the input to the given clipping mode prior to applying any other clipping criteria.") val upgradeClipping: Boolean = false,
   @arg(          doc="Require at least this number of bases to be clipped on the 5' end of R1") val readOneFivePrime: Int  = 0,
@@ -86,12 +84,10 @@ class ClipBam
   Io.assertReadable(ref)
   Io.assertCanWriteFile(output)
 
-  private val mode = this.clippingMode.getOrElse { if (this.softClip) ClippingMode.Soft else ClippingMode.Hard }
-
   validate(upgradeClipping || clipOverlappingReads || Seq(readOneFivePrime, readOneThreePrime, readTwoFivePrime, readTwoThreePrime).exists(_ != 0),
     "At least one clipping option is required")
 
-  private val clipper = new SamRecordClipper(mode=this.mode, autoClipAttributes=autoClipAttributes)
+  private val clipper = new SamRecordClipper(mode=clippingMode, autoClipAttributes=autoClipAttributes)
 
   override def execute(): Unit = {
     val in         = SamSource(input)

--- a/src/main/scala/com/fulcrumgenomics/bam/ErrorRateByReadPosition.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ErrorRateByReadPosition.scala
@@ -102,8 +102,8 @@ class ErrorRateByReadPosition
     val in          = SamSource(input, ref=Some(ref))
     val metrics     = computeMetrics(in)
     val prefix      = output.getOrElse(PathUtil.removeExtension(input))
-    val metricsPath = PathUtil.pathTo(prefix + ErrorRateByReadPositionMetric.FileExtension)
-    val plotPath    = PathUtil.pathTo(prefix + ErrorRateByReadPositionMetric.PlotExtension)
+    val metricsPath = PathUtil.pathTo(s"${prefix}${ErrorRateByReadPositionMetric.FileExtension}")
+    val plotPath    = PathUtil.pathTo(s"${prefix}${ErrorRateByReadPositionMetric.PlotExtension}")
     Metric.write(metricsPath, metrics=metrics)
 
     // And try plotting
@@ -114,7 +114,7 @@ class ErrorRateByReadPosition
       val description = plotDescription(in, input)
       Rscript.execIfAvailable(ScriptPath, metricsPath.toString, plotPath.toString, description) match {
         case Failure(e) => logger.warning(s"Generation of PDF plots failed: ${e.getMessage}")
-        case _ => Unit
+        case _ => ()
       }
     }
   }

--- a/src/main/scala/com/fulcrumgenomics/bam/FindSwitchbackReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/FindSwitchbackReads.scala
@@ -401,7 +401,7 @@ class FindSwitchbackReads
         mean_gap                 = switchbackGaps.mean()
       )
 
-      Metric.write(PathUtil.pathTo(prefix + ".summary.txt"), m)
+      Metric.write(PathUtil.pathTo(s"${prefix}.summary.txt"), m)
 
       Seq(
         ("lengths", switchbackLengths, "length"),

--- a/src/main/scala/com/fulcrumgenomics/bam/FindSwitchbackReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/FindSwitchbackReads.scala
@@ -182,7 +182,7 @@ object FindSwitchbackReads {
   private[bam] def findTandemSwitchback(template: Template, maxGap: Int) : Option[TandemBasedHit] =
     if (maxGap <=0 ) None else template.pairOrientation match {
       case Some(PairOrientation.TANDEM) =>
-        (template.r1, template.r2) match {
+        ((template.r1, template.r2): @unchecked) match {
           case (Some(r1), Some(r2)) =>
             val (earlier, later) = if (r1.start <= r2.start) (r1, r2) else (r2, r1)
             val gap = later.start - earlier.end - 1

--- a/src/main/scala/com/fulcrumgenomics/bam/FindTechnicalReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/FindTechnicalReads.scala
@@ -93,7 +93,7 @@ class FindTechnicalReads
       val recs = Seq(Some(r1), r2).flatten
 
       val isTechnical = if (isUnmappedTemplate(r1)) {
-        recs.toStream.flatMap(r => matcher.findMatch(r.bases)).headOption match {
+        recs.view.flatMap(r => matcher.findMatch(r.bases)).headOption match {
           case None =>
             false
           case Some(hit) =>

--- a/src/main/scala/com/fulcrumgenomics/bam/SamRecordClipper.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/SamRecordClipper.scala
@@ -360,7 +360,7 @@ class SamRecordClipper(val mode: ClippingMode, val autoClipAttributes: Boolean) 
       val addedHardClip = existingSoftClip + readBasesClipped
       val totalHardClip = existingHardClip + addedHardClip
       newElems.prepend(CigarElem(Op.HARD_CLIP, totalHardClip))
-      (newElems, readBasesClipped, refBasesClipped, bases.drop(addedHardClip), quals.drop(addedHardClip))
+      (newElems.toIndexedSeq, readBasesClipped, refBasesClipped, bases.drop(addedHardClip), quals.drop(addedHardClip))
     }
     else {
       val addedSoftClip = readBasesClipped
@@ -368,7 +368,7 @@ class SamRecordClipper(val mode: ClippingMode, val autoClipAttributes: Boolean) 
       newElems.prepend(CigarElem(Op.SOFT_CLIP, totalSoftClip))
       if (existingHardClip > 0) newElems.prepend(CigarElem(Op.HARD_CLIP, existingHardClip))
       if (mode == ClippingMode.SoftWithMask) hardMaskStartOfRead(bases, quals, totalSoftClip)
-      (newElems, readBasesClipped, refBasesClipped, bases, quals)
+      (newElems.toIndexedSeq, readBasesClipped, refBasesClipped, bases, quals)
     }
   }
 
@@ -388,7 +388,7 @@ class SamRecordClipper(val mode: ClippingMode, val autoClipAttributes: Boolean) 
       rec.attributes.foreach {
         case (tag, s: String)   if s.length == oldLength => rec(tag) = if (fromStart) s.drop(remove) else s.take(newLength)
         case (tag, a: Array[_]) if a.length == oldLength => rec(tag) = if (fromStart) a.drop(remove) else a.take(newLength)
-        case _  => Unit
+        case _  => ()
       }
     }
   }
@@ -425,7 +425,7 @@ class SamRecordClipper(val mode: ClippingMode, val autoClipAttributes: Boolean) 
         case ClippingMode.Hard =>
           bases = bases.drop(lengthToUpgrade)
           quals = quals.drop(lengthToUpgrade)
-          val newElems = ArrayBuffer[CigarElem]()
+          val newElems = IndexedSeq.newBuilder[CigarElem]
 
           elems match {
             case CigarElem(Op.H, h) +: CigarElem(Op.S, s) +: remaining =>
@@ -440,7 +440,7 @@ class SamRecordClipper(val mode: ClippingMode, val autoClipAttributes: Boolean) 
               unreachable(s"Cigar $es doesn't contain soft clipping at the start")
           }
 
-          elems = newElems
+          elems = newElems.result
       }
 
       if (fromStart) {

--- a/src/main/scala/com/fulcrumgenomics/bam/TrimPrimers.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/TrimPrimers.scala
@@ -38,6 +38,8 @@ import htsjdk.samtools._
 import htsjdk.samtools.reference.ReferenceSequenceFileWalker
 import htsjdk.samtools.util._
 
+import scala.collection.BufferedIterator
+
 object TrimPrimers {
   val Headers: Seq[String] = Seq("chrom", "left_start", "left_end", "right_start", "right_end")
   val Seq(hdChrom, hdleftStart, hdLeftEnd, hdRightStart, hdRightEnd) = Headers
@@ -145,7 +147,7 @@ class TrimPrimers
         }
 
         sorter.safelyClose()
-      case _ => Unit
+      case _ => ()
     }
 
     out.close()

--- a/src/main/scala/com/fulcrumgenomics/bam/api/SamRecord.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/api/SamRecord.scala
@@ -60,6 +60,10 @@ class TransientAttrs(private val rec: SamRecord) {
     if (value == null) rec.asSam.removeTransientAttribute(key) else rec.asSam.setTransientAttribute(key, value)
   }
   def get[A](key: Any): Option[A] = Option(apply(key))
+  def getOrElse[A](key: Any, default: => A): A = rec.asSam.getTransientAttribute(key) match {
+    case null => default
+    case value => value.asInstanceOf[A]
+  }
 }
 
 /**

--- a/src/main/scala/com/fulcrumgenomics/bam/api/SamWriter.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/api/SamWriter.scala
@@ -27,7 +27,7 @@ package com.fulcrumgenomics.bam.api
 import java.io.Closeable
 
 import com.fulcrumgenomics.FgBioDef._
-import com.fulcrumgenomics.Writer
+import com.fulcrumgenomics.commons.io.Writer
 import com.fulcrumgenomics.commons.util.LazyLogging
 import com.fulcrumgenomics.util.{ProgressLogger, Sorter}
 import htsjdk.samtools.SAMFileHeader.SortOrder

--- a/src/main/scala/com/fulcrumgenomics/basecalling/ExtractBasecallingParamsForPicard.scala
+++ b/src/main/scala/com/fulcrumgenomics/basecalling/ExtractBasecallingParamsForPicard.scala
@@ -159,7 +159,7 @@ object BasecallingParams {
     Io.writeLines(path=barcodeFile, lines=barcodeLines)
     Io.writeLines(path=libraryParamsFile, lines=libraryParamLines)
 
-    BasecallingParams(lane=lane, barcodeFile=barcodeFile, libraryParamsFile=libraryParamsFile, bams=bams)
+    BasecallingParams(lane=lane, barcodeFile=barcodeFile, libraryParamsFile=libraryParamsFile, bams=bams.toSeq)
   }
 
   /** The lane-specific file containing information necessary to run Picard's ExtractIlluminaBarcodes and

--- a/src/main/scala/com/fulcrumgenomics/cmdline/FgBioMain.scala
+++ b/src/main/scala/com/fulcrumgenomics/cmdline/FgBioMain.scala
@@ -128,7 +128,7 @@ class FgBioMain extends LazyLogging {
     }
 
     val startTime = System.currentTimeMillis()
-    val exit      = Sopt.parseCommandAndSubCommand[FgBioCommonArgs,FgBioTool](name, args, Sopt.find[FgBioTool](packageList)) match {
+    val exit      = Sopt.parseCommandAndSubCommand[FgBioCommonArgs,FgBioTool](name, args.toIndexedSeq, Sopt.find[FgBioTool](packageList)) match {
       case Sopt.Failure(usage) =>
         System.err.print(usage())
         1
@@ -147,7 +147,7 @@ class FgBioMain extends LazyLogging {
             val banner = "#" * ex.message.map(_.length).getOrElse(80)
             logger.fatal(banner)
             logger.fatal("Execution failed!")
-            ex.message.foreach(msg => msg.lines.foreach(logger.fatal))
+            ex.message.foreach(msg => msg.linesIterator.foreach(logger.fatal))
             logger.fatal(banner)
             printEndingLines(startTime, name, false)
             ex.exit

--- a/src/main/scala/com/fulcrumgenomics/cmdline/FgBioMain.scala
+++ b/src/main/scala/com/fulcrumgenomics/cmdline/FgBioMain.scala
@@ -36,6 +36,7 @@ import com.fulcrumgenomics.commons.util.{LazyLogging, LogLevel, Logger}
 import com.fulcrumgenomics.sopt.{Sopt, arg}
 import com.fulcrumgenomics.sopt.cmdline.CommandLineProgramParserStrings
 import com.fulcrumgenomics.util.Io
+import com.fulcrumgenomics.vcf.api.VcfWriter
 import com.intel.gkl.compression.{IntelDeflaterFactory, IntelInflaterFactory}
 import htsjdk.samtools.{SAMFileWriterFactory, ValidationStringency}
 import htsjdk.samtools.util.{BlockCompressedOutputStream, BlockGunzipper, IOUtil, SnappyLoader}
@@ -98,6 +99,7 @@ class FgBioCommonArgs
 
   SamSource.DefaultUseAsyncIo = asyncIo
   SamWriter.DefaultUseAsyncIo = asyncIo
+  VcfWriter.DefaultUseAsyncIo = asyncIo
 
   SamWriter.DefaultCompressionLevel = compression
   BlockCompressedOutputStream.setDefaultCompressionLevel(compression)

--- a/src/main/scala/com/fulcrumgenomics/fastq/DemuxFastqs.scala
+++ b/src/main/scala/com/fulcrumgenomics/fastq/DemuxFastqs.scala
@@ -297,9 +297,7 @@ class DemuxFastqs
  @arg(doc="Platform model to insert into the group header (ex. miseq, hiseq2500, hiseqX)") val platformModel: Option[String] = None,
  @arg(doc="Comment(s) to include in the merged output file's header.", minElements = 0) val comments: List[String] = Nil,
  @arg(doc="Date the run was produced, to insert into the read group header") val runDate: Option[Iso8601Date] = None,
- @arg(doc="The type of outputs to produce.", mutex=Array("outputFastqs")) var outputType: Option[OutputType] = None,
- @deprecated("Use outputType instead.", since="0.5.0")
- @arg(doc="*** Deprecated: use --output-type instead ***. Output gzipped FASTQs (`.fastq.gz`) instead of BAM files", mutex=Array("outputType")) val outputFastqs: Option[Boolean] = None,
+ @arg(doc="The type of outputs to produce.") val outputType: Option[OutputType] = None,
  @arg(doc="Output FASTQs according to Illumina naming standards, for example, for upload to the BaseSpace Sequence Hub") val illuminaStandards: Boolean = false,
  @arg(
    doc=
@@ -315,11 +313,9 @@ class DemuxFastqs
   private[fastq] val metricsPath = metrics.getOrElse(output.resolve(DefaultDemuxMetricsFileName))
 
   // NB: remove me when outputFastqs gets removed and use outputType directly
-  private val _outputType = (this.outputType, this.outputFastqs) match {
-    case (None, None) => OutputType.Bam
-    case (None, Some(fastqs)) => if (fastqs) OutputType.Fastq else OutputType.Bam
-    case (Some(tpe), None) => tpe
-    case _ => unreachable("Bug: outputType and outputFastqs should never be both defined")
+  private val _outputType = this.outputType match {
+    case Some(tpe) => tpe
+    case None      => OutputType.Bam
   }
 
   validate(inputs.length == readStructures.length, "The same number of read structures should be given as FASTQs.")

--- a/src/main/scala/com/fulcrumgenomics/fastq/FastqWriter.scala
+++ b/src/main/scala/com/fulcrumgenomics/fastq/FastqWriter.scala
@@ -26,7 +26,7 @@ package com.fulcrumgenomics.fastq
 import java.io.{BufferedWriter, Closeable}
 import java.nio.file.Path
 
-import com.fulcrumgenomics.Writer
+import com.fulcrumgenomics.commons.io.Writer
 import com.fulcrumgenomics.util.Io
 
 /**
@@ -37,9 +37,9 @@ object FastqWriter {
   def apply(path: Path): FastqWriter = apply(Io.toWriter(path))
 
   /** Constructs a FastqWriter from a Writer. */
-  def apply(writer: java.io.Writer): FastqWriter = {
-    if (writer.isInstanceOf[BufferedWriter]) new FastqWriter(writer.asInstanceOf[BufferedWriter])
-    else new FastqWriter(new BufferedWriter(writer))
+  def apply(writer: java.io.Writer): FastqWriter = writer match {
+    case bw: BufferedWriter => new FastqWriter(bw)
+    case w                  => new FastqWriter(new BufferedWriter(w))
   }
 }
 

--- a/src/main/scala/com/fulcrumgenomics/fastq/SortFastq.scala
+++ b/src/main/scala/com/fulcrumgenomics/fastq/SortFastq.scala
@@ -37,7 +37,7 @@ object SortFastq {
 
     /** Decodes the record from the fastq string. */
     override def decode(bs: Array[Byte], start: Int, length: Int): FastqRecord = {
-      val lines = new String(bs, start, length).lines
+      val lines = new String(bs, start, length).linesIterator
       val name       = lines.next().substring(1)
       val bases      = lines.next()
       val qualHeader = lines.next()

--- a/src/main/scala/com/fulcrumgenomics/internal/BuildToolDocs.scala
+++ b/src/main/scala/com/fulcrumgenomics/internal/BuildToolDocs.scala
@@ -113,7 +113,7 @@ class BuildToolDocs
         a.name,
         a.flag.getOrElse(""),
         a.kind,
-        a.description.lines.mkString(" "),
+        a.description.linesIterator.mkString(" "),
         if (a.minValues == 0) "Optional" else "Required",
         if (a.maxValues == Int.MaxValue) "Unlimited" else a.maxValues,
         a.defaultValues.mkString(", ")

--- a/src/main/scala/com/fulcrumgenomics/internal/FgMetricsDoclet.scala
+++ b/src/main/scala/com/fulcrumgenomics/internal/FgMetricsDoclet.scala
@@ -131,7 +131,7 @@ class FgMetricsDoclet extends Doclet(reporter = new ConsoleReporter(new Settings
 
     // Takes a block element and renders it into MarkDown and writes it into the buffer
     def renderBlock(block: Block, indent: String): Unit = {
-      block match {
+      (block: @unchecked) match {
         case para:  Paragraph      => render(para.text)
         case dlist: DefinitionList => () // TODO
         case hr:    HorizontalRule => () // TODO

--- a/src/main/scala/com/fulcrumgenomics/internal/FgMetricsDoclet.scala
+++ b/src/main/scala/com/fulcrumgenomics/internal/FgMetricsDoclet.scala
@@ -29,9 +29,11 @@ import java.nio.file.Paths
 
 import com.fulcrumgenomics.util.Metric
 
+import scala.tools.nsc.Settings
 import scala.tools.nsc.doc.base.comment._
 import scala.tools.nsc.doc.html.Doclet
 import scala.tools.nsc.doc.model.DocTemplateEntity
+import scala.tools.nsc.reporters.ConsoleReporter
 
 /** Case class to capture information about a field/column in a metrics class/file. */
 case class ColumnDescription(name: String, typ: String, description: String)
@@ -45,7 +47,7 @@ case class MetricDescription(name: String, description: String, columns: Seq[Col
   * Custom scaladoc Doclet for rendering the documentation for [[com.fulcrumgenomics.util.Metric]] classes into
   * MarkDown for display on the fgbio website.
   */
-class FgMetricsDoclet extends Doclet {
+class FgMetricsDoclet extends Doclet(reporter = new ConsoleReporter(new Settings())) {
   /**
     * Main entry point for the doclet.  Scans for documentation for the metrics classes and
     * renders it into MarkDown.
@@ -131,11 +133,11 @@ class FgMetricsDoclet extends Doclet {
     def renderBlock(block: Block, indent: String): Unit = {
       block match {
         case para:  Paragraph      => render(para.text)
-        case dlist: DefinitionList => Unit // TODO
-        case hr:    HorizontalRule => Unit // TODO
-        case olist: OrderedList    => Unit // TODO
+        case dlist: DefinitionList => () // TODO
+        case hr:    HorizontalRule => () // TODO
+        case olist: OrderedList    => () // TODO
         case title: Title          => buffer.append("#" * title.level).append(" "); render(title.text); buffer.append("\n\n")
-        case ulist: UnorderedList  => Unit // TODO
+        case ulist: UnorderedList  => () // TODO
       }
     }
 

--- a/src/main/scala/com/fulcrumgenomics/internal/InternalTools.scala
+++ b/src/main/scala/com/fulcrumgenomics/internal/InternalTools.scala
@@ -38,7 +38,7 @@ trait InternalTool extends LazyLogging {
 object InternalTools {
   def main(args: Array[String]): Unit = {
     val tools = Sopt.find[InternalTool](packages=Seq("com.fulcrumgenomics.internal"))
-    Sopt.parseCommand[InternalTool]("fgbio-internal", args, tools) match {
+    Sopt.parseCommand[InternalTool]("fgbio-internal", args.toIndexedSeq, tools) match {
       case Failure(usage) => {
         System.err.println(usage())
         System.exit(1)

--- a/src/main/scala/com/fulcrumgenomics/personal/nhomer/SplitTag.scala
+++ b/src/main/scala/com/fulcrumgenomics/personal/nhomer/SplitTag.scala
@@ -31,6 +31,8 @@ import com.fulcrumgenomics.commons.io.Io
 import com.fulcrumgenomics.sopt._
 import htsjdk.samtools.util.CloserUtil
 
+import scala.collection.compat._
+
 @clp(
   description = "Splits an optional tag in a SAM or BAM into multiple optional tags.",
   group = ClpGroups.Personal

--- a/src/main/scala/com/fulcrumgenomics/rnaseq/CollectErccMetrics.scala
+++ b/src/main/scala/com/fulcrumgenomics/rnaseq/CollectErccMetrics.scala
@@ -189,7 +189,7 @@ class CollectErccMetrics
 
     // Write the output
     {
-      def f(ext: String): FilePath = PathUtil.pathTo(output + ext)
+      def f(ext: String): FilePath = PathUtil.pathTo(s"${output}${ext}")
 
       val summaryPath  = f(".ercc_summary_metrics.txt")
       val detailedPath = f(".ercc_detailed_metrics.txt")
@@ -218,7 +218,7 @@ class CollectErccMetrics
       else {
         Rscript.execIfAvailable(ScriptPath, detailedPath.toString, plotPath.toString, plotDescription(in, input), minTranscriptCount.toString) match {
           case Failure(e) => logger.warning(s"Generation of PDF plots failed: ${e.getMessage}")
-          case _ => Unit
+          case _ => ()
         }
       }
     }

--- a/src/main/scala/com/fulcrumgenomics/rnaseq/EstimateRnaSeqInsertSize.scala
+++ b/src/main/scala/com/fulcrumgenomics/rnaseq/EstimateRnaSeqInsertSize.scala
@@ -102,7 +102,7 @@ class EstimateRnaSeqInsertSize
 
     recordIterator.foreach { rec =>
       calculateInsertSize(rec=rec) match {
-        case None             => Unit // ignore
+        case None             => () // ignore
         case Some(insertSize) => counters(rec.pairOrientation).count(insertSize)
       }
     }
@@ -138,11 +138,12 @@ class EstimateRnaSeqInsertSize
     }
 
     // Write the metrics
-    val metricPath = PathUtil.pathTo(prefix.getOrElse(PathUtil.removeExtension(input)) + RnaSeqInsertSizeMetricExtension)
+    val actualPrefix = prefix.getOrElse(PathUtil.removeExtension(input))
+    val metricPath = PathUtil.pathTo(s"${actualPrefix}${RnaSeqInsertSizeMetricExtension}")
     Metric.write(metricPath, metrics)
 
     // Write the histogram
-    val histogramPath   = PathUtil.pathTo(prefix.getOrElse(PathUtil.removeExtension(input)) + RnaSeqInsertSizeMetricHistogramExtension)
+    val histogramPath   = PathUtil.pathTo(s"${actualPrefix}${RnaSeqInsertSizeMetricHistogramExtension}")
     val histogramKeys   = pairOrientations.flatMap(counters(_).iterator.map(_._1)).distinct.sorted.toList
     val histogramHeader = ("insert_size" +: pairOrientations.map(_.name().toLowerCase)).mkString("\t")
     val histogramLines  = histogramHeader +: histogramKeys.map { insertSize =>

--- a/src/main/scala/com/fulcrumgenomics/testing/SamBuilder.scala
+++ b/src/main/scala/com/fulcrumgenomics/testing/SamBuilder.scala
@@ -63,7 +63,7 @@ class SamBuilder(val readLength: Int=100,
   { // Build the default dictionary
     val dict: SAMSequenceDictionary = sd.getOrElse {
       val seqs = (Range.inclusive(1, 22) ++ Seq("X", "Y", "M")).map { chr => new SAMSequenceRecord("chr" + chr, 200e6.toInt) }
-      new SAMSequenceDictionary(seqs.toIterator.toJavaList)
+      new SAMSequenceDictionary(seqs.iterator.toJavaList)
     }
     header.setSequenceDictionary(dict)
   }
@@ -111,8 +111,8 @@ class SamBuilder(val readLength: Int=100,
               start2: Int = SAMRecord.NO_ALIGNMENT_START,
               unmapped1: Boolean = false,
               unmapped2: Boolean = false,
-              cigar1: String = readLength + "M",
-              cigar2: String = readLength + "M",
+              cigar1: String = s"${readLength}M",
+              cigar2: String = s"${readLength}M",
               mapq1: Int = 60,
               mapq2: Int = 60,
               strand1: Strand = Plus,
@@ -180,7 +180,7 @@ class SamBuilder(val readLength: Int=100,
               contig: Int = 0,
               start: Int  = SAMRecord.NO_ALIGNMENT_START,
               unmapped: Boolean = false,
-              cigar: String = readLength + "M",
+              cigar: String = s"${readLength}M",
               mapq: Int = 60,
               strand: Strand = Plus,
               attrs: Map[String,Any] = Map.empty) : Option[SamRecord] = {

--- a/src/main/scala/com/fulcrumgenomics/testing/VariantContextSetBuilder.scala
+++ b/src/main/scala/com/fulcrumgenomics/testing/VariantContextSetBuilder.scala
@@ -35,6 +35,7 @@ import htsjdk.variant.variantcontext.writer.{Options, VariantContextWriterBuilde
 import htsjdk.variant.vcf.{VCFFileReader, VCFHeader, VCFHeaderLine}
 
 import scala.collection.mutable.ListBuffer
+import scala.collection.compat._
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 
@@ -87,7 +88,7 @@ class VariantContextSetBuilder(sampleNames: Seq[String] = List("Sample")) extend
     *
     * Genotype attributes may be given with the `genotypeAttributes` parameter.  The value for the `GQ` and `DP`
     * attributes must have type [[Int]].  The value for the `AD` and `PL` attributes must have either type
-    * [[TraversableOnce]] or [[Array]], with each item having type [[Int]].  For example:
+    * [[IterableOnce]] or [[Array]], with each item having type [[Int]].  For example:
     * {{{
     *   val builder = new VariantContextSetBuilder()
     *   builder.addVariant(
@@ -177,10 +178,10 @@ class VariantContextSetBuilder(sampleNames: Seq[String] = List("Sample")) extend
     * or if any element in `v` is not of type `T` .*/
   private def anyToArray[T : ClassTag](k: String, v: Any, typeName: String): Array[T] = {
     val values = v match {
-      case _v: TraversableOnce[_] => _v.toArray[Any]
+      case _v: IterableOnce[_] => _v.iterator.toArray[Any]
       case _v: Array[_]           => _v
       case _                      =>
-        throw new IllegalArgumentException(s"$k attribute value must be an TraversableOnce[$typeName], found ${v.getClass.getSimpleName}")
+        throw new IllegalArgumentException(s"$k attribute value must be an IterableOnce[$typeName], found ${v.getClass.getSimpleName}")
     }
     values.map(anyToType[T](k, _, typeName))
   }

--- a/src/main/scala/com/fulcrumgenomics/testing/VariantContextSetBuilder.scala
+++ b/src/main/scala/com/fulcrumgenomics/testing/VariantContextSetBuilder.scala
@@ -40,7 +40,7 @@ import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 
 object VariantContextSetBuilder {
-  def apply(sampleName: String): VariantContextSetBuilder = {
+  @deprecated def apply(sampleName: String): VariantContextSetBuilder = {
     new VariantContextSetBuilder(List(sampleName))
   }
 }
@@ -50,7 +50,7 @@ object VariantContextSetBuilder {
   *
   * This builder uses the default sequence dictionary from [SamBuilder] by default.
   */
-class VariantContextSetBuilder(sampleNames: Seq[String] = List("Sample")) extends Iterable[VariantContext] {
+@deprecated class VariantContextSetBuilder(sampleNames: Seq[String] = List("Sample")) extends Iterable[VariantContext] {
 
   if (sampleNames.isEmpty) throw new IllegalArgumentException("At least one sample name must be given")
 

--- a/src/main/scala/com/fulcrumgenomics/testing/VariantContextSetBuilder.scala
+++ b/src/main/scala/com/fulcrumgenomics/testing/VariantContextSetBuilder.scala
@@ -40,7 +40,8 @@ import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 
 object VariantContextSetBuilder {
-  @deprecated def apply(sampleName: String): VariantContextSetBuilder = {
+  @deprecated(since="0.9.0", message="Use com.fulcrumgenomics.testing.VcfBuilder instead.")
+  def apply(sampleName: String): VariantContextSetBuilder = {
     new VariantContextSetBuilder(List(sampleName))
   }
 }
@@ -50,7 +51,8 @@ object VariantContextSetBuilder {
   *
   * This builder uses the default sequence dictionary from [SamBuilder] by default.
   */
-@deprecated class VariantContextSetBuilder(sampleNames: Seq[String] = List("Sample")) extends Iterable[VariantContext] {
+@deprecated(since="0.9.0", message="Use com.fulcrumgenomics.testing.VcfBuilder instead.")
+class VariantContextSetBuilder(sampleNames: Seq[String] = List("Sample")) extends Iterable[VariantContext] {
 
   if (sampleNames.isEmpty) throw new IllegalArgumentException("At least one sample name must be given")
 

--- a/src/main/scala/com/fulcrumgenomics/testing/VcfBuilder.scala
+++ b/src/main/scala/com/fulcrumgenomics/testing/VcfBuilder.scala
@@ -46,7 +46,7 @@ object VcfBuilder {
       contigs = contigs,
       infos   = Seq(
         VcfInfoHeader(id="AC",  count=VcfCount.OnePerAltAllele, kind=VcfFieldType.Integer, description="Alternate allele counts in genotypes."),
-        VcfInfoHeader(id="DP",  count=VcfCount.Fixed(1),        kind=VcfFieldType.Integer, description="Depth across all samples."),
+        VcfInfoHeader(id="DP",  count=VcfCount.Fixed(1),        kind=VcfFieldType.Integer, description="Depth across all samples.")
       ),
       formats = Seq(
         VcfFormatHeader(id="GT", count=VcfCount.Fixed(1),       kind=VcfFieldType.String, description="Genotype string."),

--- a/src/main/scala/com/fulcrumgenomics/testing/VcfBuilder.scala
+++ b/src/main/scala/com/fulcrumgenomics/testing/VcfBuilder.scala
@@ -1,0 +1,232 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.fulcrumgenomics.testing
+
+import java.nio.file.Files
+
+import com.fulcrumgenomics.FgBioDef._
+import com.fulcrumgenomics.testing.VcfBuilder.Gt
+import com.fulcrumgenomics.vcf.api.Allele.NoCallAllele
+import com.fulcrumgenomics.vcf.api._
+
+import scala.collection.immutable.ListMap
+import scala.collection.mutable
+import scala.util.Try
+
+object VcfBuilder {
+  /** The default header that is used when making a new VcfBuilder. */
+  val DefaultHeader: VcfHeader = {
+    val contigs = new SamBuilder().dict.getSequences
+      .map(s => VcfContigHeader(s.getSequenceIndex, s.getSequenceName, length=Some(s.getSequenceLength), assembly=Option(s.getAssembly)))
+      .toIndexedSeq
+
+    VcfHeader(
+      contigs = contigs,
+      infos   = Seq(
+        VcfInfoHeader(id="AC",  count=VcfCount.OnePerAltAllele, kind=VcfFieldType.Integer, description="Alternate allele counts in genotypes."),
+        VcfInfoHeader(id="DP",  count=VcfCount.Fixed(1),        kind=VcfFieldType.Integer, description="Depth across all samples."),
+      ),
+      formats = Seq(
+        VcfFormatHeader(id="GT", count=VcfCount.Fixed(1),       kind=VcfFieldType.String, description="Genotype string."),
+        VcfFormatHeader(id="AD", count=VcfCount.OnePerAllele,   kind=VcfFieldType.Integer, description="Depth per allele."),
+        VcfFormatHeader(id="GQ", count=VcfCount.Fixed(1),       kind=VcfFieldType.Integer, description="Genotype quality."),
+        VcfFormatHeader(id="PL", count=VcfCount.OnePerGenotype, kind=VcfFieldType.Integer, description="Phred scaled genotype likelihoods.")
+      ),
+      filters = Seq(
+        VcfFilterHeader(id="LowQD", description="Low Quality/Depth value"),
+        VcfFilterHeader(id="LowAB", description="Low/poor allele balance.")
+      ),
+      others  = Seq(
+        VcfGeneralHeader(headerType="ALT",      id="NON_REF", data=Map("Description" -> "Represents any non-reference allele."))
+      ),
+      samples = IndexedSeq()
+    )
+  }
+
+  /**
+    * Convenience case class used to build up genotypes.
+    *
+    * @param sample the name of the sample being genotyped
+    * @param gt a genotype either in VCF format (e.g. 0/1) or using actual alleles (e.g. A/T)
+    * @param dp optional depth (DP)
+    * @param ad optional set of allele depths (AD)
+    * @param pl optional set of phred-scale genotype likelihoods (PL)
+    * @param attrs extended attributes (must be in FORMAT headers)
+    */
+  case class Gt(sample: String,
+                gt: String,
+                dp: Int = -1,
+                ad: Seq[Int] = Seq.empty,
+                pl: Seq[Int] = Seq.empty,
+                attrs: Map[String,Any] = Map.empty
+               ) {
+
+    def allAttrs: Map[String, Any] = {
+      attrs ++
+        (if (dp < 0) Map.empty else Map("DP" -> dp)) ++
+        (if (ad.isEmpty) Map.empty else Map("AD" -> ad.toIndexedSeq)) ++
+        (if (pl.isEmpty) Map.empty else Map("DP" -> pl.toIndexedSeq))
+    }
+  }
+
+  /** Constructs a VcfBuilder using the supplied header. */
+  def apply(header: VcfHeader): VcfBuilder = new VcfBuilder(header)
+
+  /** Constructs a VcfBuilder using the [[DefaultHeader]] and the set of samples provided. */
+  def apply(samples: Seq[String]): VcfBuilder = {
+    require(samples.distinct.size == samples.size, s"${samples.mkString(",")} contains duplicate sample names.")
+    new VcfBuilder(DefaultHeader.copy(samples=samples.toIndexedSeq))
+  }
+}
+
+/** Class for building VCFs for testing purposes. */
+class VcfBuilder private (initialHeader: VcfHeader) extends Iterable[Variant] {
+  /** Genomic location as (sequence_index, position). */
+  private type Location = (Int, Int)
+  private var _header: VcfHeader = initialHeader
+  private val variants: mutable.Map[Location, Variant] = mutable.TreeMap()
+
+  /** Provides access to the header that will be written to the VCF. */
+  def header: VcfHeader = _header
+
+  /** Adds one or more INFO headers to the VCF Header. */
+  def withInfoHeaders(headers: VcfInfoHeader*): this.type = {
+    this._header = this._header.copy(infos = this._header.infos ++ headers)
+    this
+  }
+
+  /** Adds one or more FORMAT headers to the VCF Header. */
+  def withFormatHeaders(headers: VcfFormatHeader*): this.type = {
+    this._header = this._header.copy(formats = this._header.formats ++ headers)
+    this
+  }
+
+  /** Adds one or more FILTER headers to the VCF Header. */
+  def withFilterHeaders(headers: VcfFilterHeader*): this.type = {
+    this._header = this._header.copy(filters = this._header.filters ++ headers)
+    this
+  }
+
+  /** Adds one or more non-INFO/FORMAT/FILTER headers to the VCF Header. */
+  def withOtherHeaders(headers: VcfGeneralHeader*): this.type = {
+    this._header = this._header.copy(others = this._header.others++ headers)
+    this
+  }
+
+  /** Adds a variant to the set being built.  The variant should contain all information required as it is not
+    * possible to update a variant once added. If a variant already exists at the given position an exception
+    * will be thrown.
+    *
+    * The genotypes are specified using instance of the [[Gt]] helper class.  The genotype strings within the [[Gt]]
+    * objects may be either numeric like in a VCF (e.g. `0/1`) or use allele strings (e.g. `A/T`.)
+    *
+    * The variant must also be valid, e.g. not reference INFO, FILTER or FORMAT fields that are no in the header,
+    * and not have alleles in genotypes that are not in the set of alleles for the variant.
+    *
+    * If the header contains more samples than there are genotype give, simple diploid no-call genotypes will
+    * be inserted for the remaining samples.
+    */
+  def add(chrom: String = this.header.contigs.head.name,
+          pos: Int,
+          id: String = ".",
+          alleles: Seq[String],
+          qual: Int = -1,
+          info: Map[String, Any] = Map.empty,
+          filters: TraversableOnce[String] = Set.empty,
+          gts: Seq[Gt] = Seq.empty
+         ): this.type = {
+
+    require(_header.dict.getSequenceIndex(chrom) >= 0, s"Unknown chrom: $chrom")
+    val key = (_header.dict.getSequenceIndex(chrom), pos)
+
+    // Make sure things are relatively valid
+    require(!variants.contains(key), s"Variant already exists at position $chrom:$pos")
+    require(alleles.nonEmpty, s"Must specify at least one allele.")
+    info.keys.foreach(k => require(this._header.info.contains(k), s"No INFO header for key $k"))
+    filters.foreach(f => require(this._header.filter.contains(f), s"No FILTER header for key $f"))
+    require(gts.map(_.sample).toSet.size == gts.size, s"Non-unique sample names in genotypes.")
+
+    val alleleSet = AlleleSet(alleles:_*)
+
+    val calledGenotypes = gts.map { g =>
+      val phased = g.gt.contains("|")
+      val separator = if (phased) '|' else '/'
+      val calls  = g.gt.split(separator).map(s => toAllele(s, alleleSet)).toIndexedSeq
+
+      Genotype(
+        alleles = alleleSet,
+        sample  = g.sample,
+        calls   = calls,
+        phased  = phased,
+        attrs   = g.allAttrs
+      )
+    }
+
+    val noCalls = _header.samples.diff(calledGenotypes.map(_.sample)).map { s =>
+      Genotype(alleles=alleleSet, sample=s, calls=IndexedSeq(NoCallAllele, NoCallAllele))
+    }
+
+    variants.put(key, Variant(
+      chrom     = chrom,
+      pos       = pos,
+      id        = if (id == ".") None else Some(id),
+      alleles   = alleleSet,
+      qual      = if (qual < 0) None else Some(qual),
+      attrs     = ListMap(info.toSeq:_*),
+      filters   = filters.toSet,
+      genotypes = (calledGenotypes ++ noCalls).map(gt => gt.sample -> gt).toMap
+    ))
+
+    this
+  }
+
+  /** Converts either a numeric index or an allele string into an Allele. */
+  private def toAllele(s: String, alleles: AlleleSet): Allele = {
+    Try { alleles(s.toInt) }
+      .recover { case _ => Allele(s) }
+      .get
+  }
+
+  /** Returns an iterator over the variants in chromosomal order. */
+  def iterator: Iterator[Variant] = this.variants.valuesIterator
+
+  /** Writes the contents of the record set to the provided file path. */
+  def write(path: PathToVcf) : Unit = {
+    val writer = VcfWriter(path, this._header)
+    writer ++= iterator
+    writer.close()
+  }
+
+  /** Writes the contents to a temporary file that will be deleted when the JVM exits. */
+  def toTempFile(deleteOnExit: Boolean = true): PathToVcf = {
+    val path = Files.createTempFile("VcfRecordSet.", ".vcf.gz")
+    if (deleteOnExit) path.toFile.deleteOnExit()
+    write(path)
+    path
+  }
+
+  /** Creates a VcfSource over the records stored in a temporary file. */
+  def toSource: VcfSource = VcfSource(toTempFile())
+}

--- a/src/main/scala/com/fulcrumgenomics/testing/VcfBuilder.scala
+++ b/src/main/scala/com/fulcrumgenomics/testing/VcfBuilder.scala
@@ -31,6 +31,7 @@ import com.fulcrumgenomics.testing.VcfBuilder.Gt
 import com.fulcrumgenomics.vcf.api.Allele.NoCallAllele
 import com.fulcrumgenomics.vcf.api._
 
+import scala.collection.compat._
 import scala.collection.immutable.ListMap
 import scala.collection.mutable
 import scala.util.Try
@@ -154,7 +155,7 @@ class VcfBuilder private (initialHeader: VcfHeader) extends Iterable[Variant] {
           alleles: Seq[String],
           qual: Int = -1,
           info: Map[String, Any] = Map.empty,
-          filters: TraversableOnce[String] = Set.empty,
+          filters: IterableOnce[String] = Set.empty,
           gts: Seq[Gt] = Seq.empty
          ): this.type = {
 
@@ -171,9 +172,9 @@ class VcfBuilder private (initialHeader: VcfHeader) extends Iterable[Variant] {
     val alleleSet = AlleleSet(alleles:_*)
 
     val calledGenotypes = gts.map { g =>
-      val phased = g.gt.contains("|")
+      val phased    = g.gt.contains("|")
       val separator = if (phased) '|' else '/'
-      val calls  = g.gt.split(separator).map(s => toAllele(s, alleleSet)).toIndexedSeq
+      val calls     = g.gt.split(separator).map(s => toAllele(s, alleleSet)).toIndexedSeq
 
       Genotype(
         alleles = alleleSet,

--- a/src/main/scala/com/fulcrumgenomics/umi/CallDuplexConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CallDuplexConsensusReads.scala
@@ -132,7 +132,7 @@ class CallDuplexConsensusReads
       maxReadsPerStrand   = maxReadsPerStrand.getOrElse(VanillaUmiConsensusCallerOptions.DefaultMaxReads)
     )
     val progress = ProgressLogger(logger, unit=1000000)
-    val iterator = new ConsensusCallingIterator(in.toIterator, caller, Some(progress), threads)
+    val iterator = new ConsensusCallingIterator(in.iterator, caller, Some(progress), threads)
     out ++= iterator
     progress.logLast()
 

--- a/src/main/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReads.scala
@@ -163,7 +163,7 @@ class CallMolecularConsensusReads
       rejects        = rej
     )
 
-    val iterator = new ConsensusCallingIterator(in.toIterator, caller, Some(ProgressLogger(logger, unit=5e5.toInt)))
+    val iterator = new ConsensusCallingIterator(in.iterator, caller, Some(ProgressLogger(logger, unit=5e5.toInt)))
     out ++= iterator
 
     in.safelyClose()

--- a/src/main/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReads.scala
@@ -152,7 +152,7 @@ class CallMolecularConsensusReads
       minInputBaseQuality          = minInputBaseQuality,
       minConsensusBaseQuality      = minConsensusBaseQuality,
       minReads                     = minReads,
-      maxReads                     = maxReads.getOrElse(Int.MaxValue),
+      maxReads                     = maxReads.getOrElse(VanillaUmiConsensusCallerOptions.DefaultMaxReads),
       producePerBaseTags           = outputPerBaseTags
     )
 

--- a/src/main/scala/com/fulcrumgenomics/umi/ConsensusCallingIterator.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/ConsensusCallingIterator.scala
@@ -24,6 +24,8 @@
 
 package com.fulcrumgenomics.umi
 
+import java.util.concurrent.ForkJoinPool
+
 import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.bam.api.SamRecord
 import com.fulcrumgenomics.commons.async.AsyncIterator
@@ -31,7 +33,7 @@ import com.fulcrumgenomics.commons.util.LazyLogging
 import com.fulcrumgenomics.umi.UmiConsensusCaller.SimpleRead
 import com.fulcrumgenomics.util.ProgressLogger
 
-import scala.concurrent.forkjoin.ForkJoinPool
+import java.util.concurrent.ForkJoinPool
 
 /**
   * An iterator that consumes from an incoming iterator of [[SamRecord]]s and generates consensus
@@ -55,7 +57,7 @@ class ConsensusCallingIterator[ConsensusRead <: SimpleRead](sourceIterator: Iter
     case None    => sourceIterator
   }
 
-  protected val iterator: Iterator[SamRecord] = {
+  protected val iter: Iterator[SamRecord] = {
     if (threads <= 1) {
       val groupingIterator = new SamRecordGroupedIterator(progressIterator, caller.sourceMoleculeId)
       groupingIterator.flatMap(caller.consensusReadsFromSamRecords)
@@ -99,8 +101,8 @@ class ConsensusCallingIterator[ConsensusRead <: SimpleRead](sourceIterator: Iter
 
     }
   }
-  override def hasNext: Boolean = this.iterator.hasNext
-  override def next(): SamRecord = this.iterator.next
+  override def hasNext: Boolean = this.iter.hasNext
+  override def next(): SamRecord = this.iter.next
 }
 
 // TODO: migrate to the commons version of this class after the next commons release
@@ -115,7 +117,7 @@ private class IterableThreadLocal[A](factory: () => A) extends ThreadLocal[A] wi
   }
 
   /** Care should be taken accessing the iterator since objects may be in use by other threads. */
-  def iterator: Iterator[A] = all.toIterator
+  def iterator: Iterator[A] = all.iterator
 }
 
 

--- a/src/main/scala/com/fulcrumgenomics/umi/CorrectUmis.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CorrectUmis.scala
@@ -150,7 +150,7 @@ class CorrectUmis
     }
 
     // Warn if any of the UMIs are too close together
-    CorrectUmis.findUmiPairsWithinDistance(umiSequences, minDistance-1).foreach { case (umi1, umi2, distance) =>
+    CorrectUmis.findUmiPairsWithinDistance(umiSequences.toSeq, minDistance-1).foreach { case (umi1, umi2, distance) =>
         logger.warning(s"Umis $umi1 and $umi2 are $distance edits apart which is less than the min distance: $minDistance")
     }
 
@@ -173,7 +173,7 @@ class CorrectUmis
           if (missingUmisRecords == 0) logger.warning(s"Read (${rec.name}) detected without UMI in tag $umiTag")
           missingUmisRecords += 1
           rejectOut.foreach(w => w += rec)
-        case Some(umi) =>
+        case Some(umi: String) =>
           val sequences = umi.split('-')
           if (sequences.exists(_.length != umiLength)) {
             if (wrongLengthRecords == 0) logger.warning(s"Read (${rec.name}) detected with unexpected length UMI(s): ${sequences.mkString(" ")}")

--- a/src/main/scala/com/fulcrumgenomics/umi/ExtractUmisFromBam.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/ExtractUmisFromBam.scala
@@ -263,8 +263,8 @@ object ExtractUmisFromBam {
                                              clippingAttribute: Option[String],
                                              readStructure: ReadStructure): Unit = {
     clippingAttribute.map(tag => (tag, record.get[Int](tag))) match {
-      case None => Unit
-      case Some((tag, None)) => Unit
+      case None => ()
+      case Some((tag, None)) => ()
       case Some((tag, Some(clippingPosition))) =>
         val newClippingPosition = readStructure.takeWhile(_.offset < clippingPosition).filter(_.kind == SegmentType.Template).map { t =>
           if (t.length.exists(l => t.offset + l < clippingPosition)) t.length.get

--- a/src/main/scala/com/fulcrumgenomics/umi/ReviewConsensusVariants.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/ReviewConsensusVariants.scala
@@ -171,7 +171,7 @@ class ReviewConsensusVariants
   }
 
   override def execute(): Unit = {
-    def f(ext: String): Path = output.getParent.resolve(output.getFileName + ext)
+    def f(ext: String): Path = output.getParent.resolve(s"${output.getFileName}${ext}")
 
     val consensusIn  = SamSource(consensusBam)
     val groupedIn    = SamSource(groupedBam)

--- a/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
@@ -193,7 +193,7 @@ trait UmiConsensusCaller[ConsensusRead <: SimpleRead] {
   def consensusReadsConstructed: Long = _consensusReadsConstructed
 
   /** Records that the supplied records were rejected, and not used to build a consensus read. */
-  protected def rejectRecords(recs: Traversable[SamRecord], reason: String) : Unit = this._filteredReads.count(reason, recs.size)
+  protected def rejectRecords(recs: Iterable[SamRecord], reason: String) : Unit = this._filteredReads.count(reason, recs.size)
 
   /** Records that the supplied records were rejected, and not used to build a consensus read. */
   protected def rejectRecords(reason: String, rec: SamRecord*) : Unit = rejectRecords(rec, reason)
@@ -257,7 +257,7 @@ trait UmiConsensusCaller[ConsensusRead <: SimpleRead] {
 
     len match {
       case 0 =>
-        rejectRecords(Traversable(rec), FilterLowQuality)
+        rejectRecords(Iterable(rec), FilterLowQuality)
         None
       case n if n == bases.length =>
         Some(SourceRead(sourceMoleculeId(rec), bases, quals, cigar, Some(rec)))
@@ -354,7 +354,8 @@ trait UmiConsensusCaller[ConsensusRead <: SimpleRead] {
         if (bestGroup.contains(i)) keepers += sorted(i)
         else sorted(i).sam.foreach(rejectRecords(FilterMinorityAlignment, _))
       }
-      keepers
+
+      keepers.toIndexedSeq
     }
   }
 

--- a/src/main/scala/com/fulcrumgenomics/util/GeneAnnotations.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/GeneAnnotations.scala
@@ -33,7 +33,7 @@ object GeneAnnotations {
   /** A gene with zero or more transcripts, that all are on the same transcription strand. */
   case class Gene(contig: String, start: Int, end: Int, negativeStrand: Boolean, name: String, transcripts: Seq[Transcript])
     extends Interval(contig, start, end, negativeStrand, name) with Iterable[Transcript] {
-    def iterator: Iterator[Transcript] = transcripts.toIterator
+    def iterator: Iterator[Transcript] = transcripts.iterator
   }
 
   /** A transcript associated with a given gene (which stores the transcription strand).  Contains zero or more exons.
@@ -44,9 +44,9 @@ object GeneAnnotations {
       require(!exonsOverlap, s"exons overlap for transcript: $name")
     }
     /** The order in which exons appear in the transcripts */
-    def transcriptOrder: Iterator[Exon] = exons.toIterator
+    def transcriptOrder: Iterator[Exon] = exons.iterator
     /** The order in which exons appear in the genome */
-    def genomicOrder: Iterator[Exon] = exons.sortBy { exon => (exon.start, exon.end) }.toIterator
+    def genomicOrder: Iterator[Exon] = exons.sortBy { exon => (exon.start, exon.end) }.iterator
   }
 
   /** Defines an exonic sequence within a transcript. */

--- a/src/main/scala/com/fulcrumgenomics/util/Metric.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/Metric.scala
@@ -36,6 +36,7 @@ import com.fulcrumgenomics.commons.util.DelimitedDataParser
 import htsjdk.samtools.util.{FormatUtil, Iso8601Date}
 import com.fulcrumgenomics.commons.io.{Writer => CommonsWriter}
 
+import scala.collection.compat._
 import scala.reflect.runtime.{universe => ru}
 import scala.util.{Failure, Success}
 
@@ -150,16 +151,16 @@ object Metric {
   /** Writes a metric to the given writer.  The first line will be a header with the field names.  Each subsequent
     * line is a single metric.
     */
-  def write[T <: Metric](writer: Writer, metrics: TraversableOnce[T])(implicit tt: ru.TypeTag[T]): Unit = {
+  def write[T <: Metric](writer: Writer, metrics: IterableOnce[T])(implicit tt: ru.TypeTag[T]): Unit = {
     val out = new MetricWriter[T](writer)
-    metrics.foreach(out.write(_))
+    out ++= metrics
     out.close()
   }
 
   /** Writes metrics to the given path.  The first line will be a header with the field names.  Each subsequent
     * line is a single metric.
     */
-  def write[T <: Metric](path: Path, metrics: TraversableOnce[T])(implicit tt: ru.TypeTag[T]): Unit = {
+  def write[T <: Metric](path: Path, metrics: IterableOnce[T])(implicit tt: ru.TypeTag[T]): Unit = {
     val writer = Io.toWriter(path)
     write(writer, metrics)
     writer.close()
@@ -203,7 +204,7 @@ trait Metric extends Product with Iterable[(String,String)] {
   }
 
   /** Gets an iterator over the fields of this metric in the order they were defined.  Returns tuples of names and values */
-  override def iterator: Iterator[(String,String)] = this.names.zip(this.values).toIterator
+  override def iterator: Iterator[(String,String)] = this.names.zip(this.values).iterator
 
   /** @deprecated use [[formatValue]] instead. */
   @deprecated("Use formatValue instead.", since="0.5.0")

--- a/src/main/scala/com/fulcrumgenomics/util/NumericTypes.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/NumericTypes.scala
@@ -27,11 +27,10 @@ package com.fulcrumgenomics.util
 import java.lang.Math.exp
 
 import htsjdk.samtools.SAMUtils
-import net.jafama.FastMath._
+import org.apache.commons.math3.util.FastMath._
 
 /**
-  * Container object for a set of numeric types for working with common probability
-  * scalings.
+  * Container object for a set of numeric types for working with common probability scalings.
   */
 object NumericTypes {
   /** The value of toLogProbability(x) for [0, 1, ..., 10] */

--- a/src/main/scala/com/fulcrumgenomics/util/ReadStructure.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/ReadStructure.scala
@@ -74,7 +74,7 @@ object ReadStructure {
   /** Creates a sequence of read segments from a string. */
   private def segments(rs: String): Seq[ReadSegment] = {
     var i = 0
-    val segs = ArrayBuffer[ReadSegment]()
+    val segs = IndexedSeq.newBuilder[ReadSegment]
     while (i < rs.length) {
       // Stash the beginning position of our parsing so we can highlight what we're having trouble with
       val parsePosition = i
@@ -104,7 +104,7 @@ object ReadStructure {
       }
     }
 
-    segs
+    segs.result
   }
 
   /**

--- a/src/main/scala/com/fulcrumgenomics/util/RefFlatSource.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/RefFlatSource.scala
@@ -144,7 +144,7 @@ class RefFlatSource private(lines: Iterator[String],
           end      = row[Int]("txEnd"),
           cdsStart = row[Int]("cdsStart") + 1,
           cdsEnd   = row[Int]("cdsEnd"),
-          exons    = exonStarts.zip(exonEnds).map { case (s, e) => Exon(start=s + 1, end=e) }
+          exons    = exonStarts.iterator.zip(exonEnds.iterator).map { case (s, e) => Exon(start=s + 1, end=e) }.toIndexedSeq
         )
 
         val gene = Gene(
@@ -203,7 +203,7 @@ class RefFlatSource private(lines: Iterator[String],
     _genes
   }
 
-  def iterator: Iterator[Gene] = this.genes.toIterator
+  def iterator: Iterator[Gene] = this.genes.iterator
 
   /** Closes the underlying reader; only necessary if EOF hasn't been reached. */
   override def close(): Unit = this.source.foreach(_.close())

--- a/src/main/scala/com/fulcrumgenomics/util/Rscript.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/Rscript.scala
@@ -53,11 +53,11 @@ object Rscript extends LazyLogging {
 
   /** Executes an Rscript from the classpath if Rscript is available. */
   def execIfAvailable(scriptResource: String, args: String*): Try[Unit] =
-    if (Available) exec(scriptResource, args:_*) else Success(Unit)
+    if (Available) exec(scriptResource, args:_*) else Success(())
 
   /** Executes an Rscript from a script stored at a Path if Rscript is available. */
   def execIfAvailable(script: Path, args: String*): Try[Unit] =
-    if (Available) exec(script, args:_*) else Success(Unit)
+    if (Available) exec(script, args:_*) else Success(())
 
   /** Executes an Rscript from the classpath. */
   def exec(scriptResource: String, args: String*): Try[Unit] =

--- a/src/main/scala/com/fulcrumgenomics/util/Sorter.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/Sorter.scala
@@ -29,7 +29,7 @@ import java.nio.file.{Files, Path}
 import java.util
 
 import com.fulcrumgenomics.FgBioDef._
-import com.fulcrumgenomics.Writer
+import com.fulcrumgenomics.commons.io.Writer
 import com.fulcrumgenomics.commons.collection.SelfClosingIterator
 import com.fulcrumgenomics.util.Sorter.{Codec, SortEntry}
 import htsjdk.samtools.util.TempStreamFactory
@@ -216,7 +216,7 @@ class Sorter[A,B <: Ordered[B]](val maxObjectsInRam: Int,
      */
   def iterator: SelfClosingIterator[A] = {
     spill()
-    val streams = files.map(f => _tmpStreamFactory.wrapTempInputStream(Io.toInputStream(f), Io.bufferSize))
+    val streams = files.iterator.map(f => _tmpStreamFactory.wrapTempInputStream(Io.toInputStream(f), Io.bufferSize)).toSeq
     val mergingIterator = new MergingIterator(streams)
     new SelfClosingIterator(mergingIterator, () => mergingIterator.close())
   }

--- a/src/main/scala/com/fulcrumgenomics/vcf/HapCutToVcf.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/HapCutToVcf.scala
@@ -302,7 +302,7 @@ private class HapCutAndVcfMergingIterator(hapCutPath: FilePath,
   extends Iterator[VariantContext] with Closeable {
   import HapCutType.HapCutType
 
-  private val sourceIterator = vcfReader.toStream.zipWithIndex.iterator.buffered
+  private val sourceIterator = vcfReader.iterator.zipWithIndex.buffered
   private val hapCutReader   = HapCutReader(path=hapCutPath)
   private val sampleName     = vcfReader.getFileHeader.getSampleNamesInOrder.iterator().next()
 

--- a/src/main/scala/com/fulcrumgenomics/vcf/MakeTwoSampleMixtureVcf.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/MakeTwoSampleMixtureVcf.scala
@@ -154,7 +154,7 @@ class MakeTwoSampleMixtureVcf
         if (isMultiAllelic) filters += MultiAllelicFilter
         if (!tumorOnly && !oldNormalGt.isHomRef) filters += GermlineFilter
         if (newTumorGt.isNoCall) filters += UnknownGtFilter
-        if (filters.nonEmpty) builder.filters(filters: _*) else builder.passFilters()
+        if (filters.nonEmpty) builder.filters(filters.iterator.toJavaSet) else builder.passFilters()
         out.add(builder.make())
       }
     }

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/Allele.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/Allele.scala
@@ -1,0 +1,60 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.fulcrumgenomics.vcf.api
+
+import com.fulcrumgenomics.FgBioDef._
+import htsjdk.samtools.util.SequenceUtil
+
+sealed trait Allele { }
+
+object Allele {
+  // TODO: have optimized lookup for base A/C/G/T and maybe dinuc alleles?
+  def apply(value: String): Allele = value match {
+    case "." => NoCallAllele
+    case "*" => SpannedAllele
+    case v if v.forall(ch => SequenceUtil.isUpperACGTN(ch.toUpper.toByte)) => SimpleAllele(v)
+    case v if v.startsWith("<") && v.endsWith(">") => SymbolicAllele(v)
+    case v => throw new NotImplementedError(s"Oops, should probably handle allele: $v")
+  }
+
+  case object NoCallAllele extends Allele {
+    override def toString: String = "."
+  }
+
+  case object SpannedAllele extends Allele  {
+    override def toString: String = "*"
+  }
+
+  case class SimpleAllele private[Allele](bases: String) extends Allele {
+    def length: Int = bases.length
+    override def toString: String = bases
+  }
+
+  case class SymbolicAllele(id: String) extends Allele {
+    override def toString: String = id
+  }
+
+  case class BreakendAllele() // TODO: what does this need to have
+}

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/AlleleSet.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/AlleleSet.scala
@@ -64,7 +64,7 @@ object AlleleSet {
     *            will be thrown. The parameter type is [[Allele]] to avoid callers having to cast.
     * @param alts zero or more alternative alleles
     */
-  def apply(ref: Allele, alts: Traversable[Allele] = NoAlts): AlleleSet = ref match {
+  def apply(ref: Allele, alts: Iterable[Allele]): AlleleSet = ref match {
     case r: SimpleAllele => AlleleSet(r, alts.toIndexedSeq)
     case _ => throw new IllegalArgumentException(s"Cannot have a non-simple ref allele: $ref")
   }

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/AlleleSet.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/AlleleSet.scala
@@ -55,8 +55,12 @@ case class AlleleSet(ref: SimpleAllele, alts: IndexedSeq[Allele]) extends Iterab
 }
 
 object AlleleSet {
-  def apply(ref: Allele, alts: Traversable[Allele]): AlleleSet = ref match {
+  private val NoAlts: IndexedSeq[Allele] = IndexedSeq.empty
+
+  def apply(ref: Allele, alts: Traversable[Allele] = NoAlts): AlleleSet = ref match {
     case r: SimpleAllele => AlleleSet(r, alts.toIndexedSeq)
     case _ => throw new IllegalArgumentException(s"Cannot have a non-simple ref allele: $ref")
   }
+
+  def apply(ref: Allele, alts: Allele*): AlleleSet = apply(ref, alts)
 }

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/AlleleSet.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/AlleleSet.scala
@@ -57,10 +57,24 @@ case class AlleleSet(ref: SimpleAllele, alts: IndexedSeq[Allele]) extends Iterab
 object AlleleSet {
   private val NoAlts: IndexedSeq[Allele] = IndexedSeq.empty
 
+  /**
+    * Generates an AlleleSet from a reference allele and zero or more alternative alleles.
+    *
+    * @param ref the reference allele; if this is not a [[SimpleAllele]] an [[IllegalArgumentException]]
+    *            will be thrown. The parameter type is [[Allele]] to avoid callers having to cast.
+    * @param alts zero or more alternative alleles
+    */
   def apply(ref: Allele, alts: Traversable[Allele] = NoAlts): AlleleSet = ref match {
     case r: SimpleAllele => AlleleSet(r, alts.toIndexedSeq)
     case _ => throw new IllegalArgumentException(s"Cannot have a non-simple ref allele: $ref")
   }
 
+  /**
+    * Generates an AlleleSet from a reference allele and zero or more alternative alleles.
+    *
+    * @param ref the reference allele; if this is not a [[SimpleAllele]] an [[IllegalArgumentException]]
+    *            will be thrown. The parameter type is [[Allele]] to avoid callers having to cast.
+    * @param alts zero or more alternative alleles
+    */
   def apply(ref: Allele, alts: Allele*): AlleleSet = apply(ref, alts)
 }

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/AlleleSet.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/AlleleSet.scala
@@ -77,4 +77,15 @@ object AlleleSet {
     * @param alts zero or more alternative alleles
     */
   def apply(ref: Allele, alts: Allele*): AlleleSet = apply(ref, alts)
+
+  /**
+    * Generates an AlleleSet from one or more String alleles. The first allele will be the reference
+    * allele and must be composed of regular bases.
+    *
+    * @param alleles one or more allele strings
+    */
+  def apply(alleles: String*): AlleleSet = {
+    require(alleles.nonEmpty, "Must provide at least one allele.")
+    AlleleSet(Allele(alleles.head), alleles.drop(1).map(s => Allele(s)))
+  }
 }

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/AlleleSet.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/AlleleSet.scala
@@ -27,12 +27,31 @@ package com.fulcrumgenomics.vcf.api
 import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.vcf.api.Allele.SimpleAllele
 
+/**
+  * Simple class to encapsulate a set of alleles where one allele represents the allele
+  * that is present in the reference genome, and the remainder represent alternative alleles.
+  *
+  * @param ref the reference allele
+  * @param alts the ordered list of alternate alleles
+  */
 case class AlleleSet(ref: SimpleAllele, alts: IndexedSeq[Allele]) extends Iterable[Allele] {
+  /** Provides an iterator over all the alleles. */
   override def iterator: Iterator[Allele] = Iterator(ref) ++ alts.iterator
 
+  /** Retrives the allele at `index`.  The reference allele is given index 0, and alternate
+    * alleles are indexed starting at 1.  Requesting an index  `< 1` or `> size-1` will result
+    *  in a [[IndexOutOfBoundsException]].
+    *
+    * @param index The index of the allele to return
+    * @return the allele present at the index
+    */
   def apply(index: Int): Allele = if (index == 0) ref else alts(index-1)
 
+  /** Returns the position of the given allele within the allele set. */
   def indexOf(a: Allele): Int = if (a == ref) 0 else alts.indexOf(a) + 1
+
+  /** The number of alleles, including reference, in the set. */
+  override def size: Int = alts.size + 1
 }
 
 object AlleleSet {

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/AlleleSet.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/AlleleSet.scala
@@ -1,0 +1,43 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.fulcrumgenomics.vcf.api
+
+import com.fulcrumgenomics.FgBioDef._
+import com.fulcrumgenomics.vcf.api.Allele.SimpleAllele
+
+case class AlleleSet(ref: SimpleAllele, alts: IndexedSeq[Allele]) extends Iterable[Allele] {
+  override def iterator: Iterator[Allele] = Iterator(ref) ++ alts.iterator
+
+  def apply(index: Int): Allele = if (index == 0) ref else alts(index-1)
+
+  def indexOf(a: Allele): Int = if (a == ref) 0 else alts.indexOf(a) + 1
+}
+
+object AlleleSet {
+  def apply(ref: Allele, alts: Traversable[Allele]): AlleleSet = ref match {
+    case r: SimpleAllele => AlleleSet(r, alts.toIndexedSeq)
+    case _ => throw new IllegalArgumentException(s"Cannot have a non-simple ref allele: $ref")
+  }
+}

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/ArrayAttr.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/ArrayAttr.scala
@@ -26,11 +26,12 @@ package com.fulcrumgenomics.vcf.api
 
 import com.fulcrumgenomics.FgBioDef._
 
+import scala.collection.compat._
 import scala.reflect.ClassTag
 
 object ArrayAttr {
   /** Constructs an instance with the values supplied. */
-  def apply[A : ClassTag](values: TraversableOnce[A]): ArrayAttr[A] = {
+  def apply[A : ClassTag](values: IterableOnce[A]): ArrayAttr[A] = {
     new ArrayAttr[A](values.toArray)
   }
 

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/ArrayAttr.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/ArrayAttr.scala
@@ -1,0 +1,82 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.fulcrumgenomics.vcf.api
+
+import com.fulcrumgenomics.FgBioDef._
+
+import scala.reflect.ClassTag
+
+object ArrayAttr {
+  /** Constructs an instance with the values supplied. */
+  def apply[A : ClassTag](values: TraversableOnce[A]): ArrayAttr[A] = {
+    new ArrayAttr[A](values.toArray)
+  }
+
+  /** Apply method that re-uses the supplied array.  Should only be used from within the `api` package
+    * and only when it can be guaranteed no other references to the array exist and no other caller
+    * can modify the values.
+    */
+  private[api] def apply[A](values: Array[A]): ArrayAttr[A] = new ArrayAttr[A](values)
+}
+
+
+/**
+  * Class that is used to store multi-valued attributes from a VCF (e.g. `AD=10,20`) and correctly
+  * handle missing values.
+  *
+  * It is possible for one or all values in the collection to be missing. If accessed directly, e.g. by index
+  * or by iteration, missing values will return one of the following based on the type of the attribute:
+  *   - [[Variant.Missing]] for Strings
+  *   - [[Variant.MissingInt]] for Ints
+  *   - [[Variant.MissingFloat]] for Floating point numbers
+  *
+  * If you need to deal with the possibility of missing values it is strongly recommended that you use
+  * the [[isMissing()]] and/or [[isDefined()]] methods or use the [[get()]] which returns an option type.
+  *
+  * @param values the values stored in the collection
+  * @tparam A the type of values stored in the collection
+  */
+class ArrayAttr[A] private(private val values: Array[A]) extends IndexedSeq[A] {
+  /** True if there are any missing values in the collection. */
+  def hasMissingValues: Boolean = values.exists(Variant.isMissingValue)
+
+  /** True if the element at the index is missing, false otherwise. */
+  def isMissing(idx: Int): Boolean = Variant.isMissingValue(values(idx))
+
+  /** True if the element at the index is not missing, false otherwise. */
+  def isDefined(idx: Int): Boolean = !isMissing(idx)
+
+  /** The number of elements (including missing) in the collection. */
+  override def length: Int = values.length
+
+  /** Accesses the value at the specified index. May return a Missing value if no value is defined at the index.
+    * To avoid dealing with Missing values use [[isMissing(idx)]] or [[isDefined(idx)]] prior to accessing the
+    * element, or use [[get()]] instead.
+    */
+  override def apply(idx: Int): A = this.values(idx)
+
+  def get(idx: Int): Option[A] = if (isDefined(idx)) Some(apply(idx)) else None
+}
+

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/Genotype.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/Genotype.scala
@@ -1,0 +1,91 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.fulcrumgenomics.vcf.api
+
+import com.fulcrumgenomics.vcf.api.Allele.{NoCallAllele, SpannedAllele}
+
+/** A genotype for a variant.
+  *
+  * @param alleles the set of alleles for the variant
+  * @param sample the name of the sample for which this is a genotype
+  * @param calls the called alleles for the sample
+  * @param phased whether or not the calls are phased
+  */
+final case class Genotype(alleles: AlleleSet,
+                          sample: String,
+                          calls: IndexedSeq[Allele],
+                          phased: Boolean = false,
+                          attrs: Map[String, Any] = Variant.EmptyGtAttrs
+                         ) {
+  require(calls.nonEmpty, "Genotype must have ploidy of at least 1!.")
+
+  /** The indices of the calls within the AlleleSet. If any allele is no-called, that is returned as -1. */
+  val callIndices: IndexedSeq[Int] = calls.map(c => if (c == NoCallAllele) -1 else alleles.indexOf(c))
+
+  /** Returns the separator that should be used between alleles when displaying the genotype. */
+  private def separator: String = if (phased) "|" else "/"
+
+  /** Returns the set of alleles for the genotype filtering out no-calls and spanned alleles. */
+  private def calledAlleles: Seq[Allele] = calls.filter(a => a != NoCallAllele && a != SpannedAllele)
+
+  /** The ploidy of the called genotype - equal to calls.length. */
+  def ploidy: Int = calls.length
+
+  /** True if all [[calls]] are no-call alleles. */
+  def isNoCall: Boolean = calls.forall(_ == Allele.NoCallAllele)
+
+  /** True if none of [[calls]] are no-call alleles. */
+  def isFullyCalled: Boolean = !calls.contains(Allele.NoCallAllele)
+
+  /** True if all [[calls]] are the reference allele. */
+  def isHomRef: Boolean = calls.forall(_ == alleles.ref)
+
+  /** True if all [[calls]] are the same non-reference allele. */
+  def isHomVar: Boolean = isFullyCalled && calls(0) != alleles.ref && calls.forall(_ == calls(0))
+
+  /** True if the genotype contains at least two called alleles that are different from one another. */
+  def isHet: Boolean = {
+    val actuallyCalled = calledAlleles
+    actuallyCalled.exists(_ != actuallyCalled.head)
+  }
+
+  /** True if the genotype is fully called, the genotype is heterozygous and none of the called alleles are the reference. */
+  def isHetNonRef: Boolean = isHet && !calls.contains(alleles.ref)
+
+  /** Retrieves a value from the INFO map.  Will throw an exception if the key does not exist. */
+  def apply[A](key: String): A = attrs(key).asInstanceOf[A]
+
+  /** Retrieves an optional value from the INFO map.  Will return [[None]] if the key does not exist. */
+  def get[A](key: String): Option[A] = attrs.get(key).asInstanceOf[Option[A]]
+
+  /** Retrieves an optional value from the INFO map.  Will return `default` if the key does not exist. */
+  def getOrElse[A](key: String, default: => A): Option[A] = attrs.getOrElse(key, default).asInstanceOf[Option[A]]
+
+  /** Yields a genotype string using bases, e.g. A/C, or CTTT|C. */
+  def gtWithBases: String = calls.map(_.toString).mkString(separator)
+
+  /** Yields a genotype string using allele indices, e.g. 0/1. */
+  def gtVcfStyle: String = callIndices.iterator.map(i => if (i >= 0) i.toString else ".").mkString(separator)
+}

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/Genotype.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/Genotype.scala
@@ -80,8 +80,8 @@ final case class Genotype(alleles: AlleleSet,
   /** Retrieves an optional value from the INFO map.  Will return [[None]] if the key does not exist. */
   def get[A](key: String): Option[A] = attrs.get(key).asInstanceOf[Option[A]]
 
-  /** Retrieves an optional value from the INFO map.  Will return `default` if the key does not exist. */
-  def getOrElse[A](key: String, default: => A): Option[A] = attrs.getOrElse(key, default).asInstanceOf[Option[A]]
+  /** Retrieves an optional attribute.  Will return `default` if the key does not exist. */
+  def getOrElse[A](key: String, default: => A): A = attrs.getOrElse(key, default).asInstanceOf[A]
 
   /** Yields a genotype string using bases, e.g. A/C, or CTTT|C. */
   def gtWithBases: String = calls.map(_.toString).mkString(separator)

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/Genotype.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/Genotype.scala
@@ -42,7 +42,7 @@ final case class Genotype(alleles: AlleleSet,
   require(calls.nonEmpty, "Genotype must have ploidy of at least 1!.")
 
   /** The indices of the calls within the AlleleSet. If any allele is no-called, that is returned as -1. */
-  val callIndices: IndexedSeq[Int] = calls.map(c => if (c == NoCallAllele) -1 else alleles.indexOf(c))
+  private [api] val callIndices: IndexedSeq[Int] = calls.map(c => if (c == NoCallAllele) -1 else alleles.indexOf(c))
 
   /** Returns the separator that should be used between alleles when displaying the genotype. */
   private def separator: String = if (phased) "|" else "/"

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/RewriteVcf.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/RewriteVcf.scala
@@ -45,6 +45,7 @@ class RewriteVcf
     var n = 0L
     in.foreach { variant =>
       n += 1
+      println(variant.INFO.DP)
       out.write(variant)
     }
 

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/RewriteVcf.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/RewriteVcf.scala
@@ -1,0 +1,54 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.fulcrumgenomics.vcf.api
+
+import com.fulcrumgenomics.FgBioDef._
+import com.fulcrumgenomics.cmdline.{ClpGroups, FgBioTool}
+import com.fulcrumgenomics.commons.io.Io
+import com.fulcrumgenomics.sopt.{arg, clp}
+
+@clp(group=ClpGroups.VcfOrBcf, description="Reads in a VCF and writes it back out - how boring!")
+class RewriteVcf
+( @arg(flag='i', doc="Input VCF") val input: PathToVcf,
+  @arg(flag='o', doc="Output VCF") val output: PathToVcf
+) extends FgBioTool {
+
+  Io.assertReadable(input)
+  Io.assertCanWriteFile(output)
+
+  override def execute(): Unit = {
+    val in  = VariantSource(input)
+    val out = VariantWriter(output, in.header)
+
+    var n = 0L
+    in.foreach { variant =>
+      n += 1
+      out.write(variant)
+    }
+
+    in.close()
+    out.close()
+  }
+}

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/RewriteVcf.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/RewriteVcf.scala
@@ -45,7 +45,6 @@ class RewriteVcf
     var n = 0L
     in.foreach { variant =>
       n += 1
-      println(variant.INFO.DP)
       out.write(variant)
     }
 

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
@@ -84,5 +84,5 @@ final case class Variant(chrom: String,
   def get[A](key: String): Option[A] = attrs.get(key).asInstanceOf[Option[A]]
 
   /** Retrieves an optional value from the INFO map.  Will return `default` if the key does not exist. */
-  def getOrElse[A](key: String, default: => A): Option[A] = attrs.getOrElse(key, default).asInstanceOf[Option[A]]
+  def getOrElse[A](key: String, default: => A): A = attrs.getOrElse(key, default).asInstanceOf[A]
 }

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
@@ -46,6 +46,7 @@ object Variant {
     JFloat.intBitsToFloat(l.intValue())
   }
 
+  /** Used in comparisons in [[isMissingValue()]] since we can't compare NaNs using == or .equals(). */
   private val MissingFloatIntBits: Int = java.lang.Float.floatToRawIntBits(MissingFloat)
 
   /** Returns true if the passed value is one of the missing values. */

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
@@ -1,0 +1,81 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.fulcrumgenomics.vcf.api
+
+import scala.collection.immutable.ListMap
+
+case class Variant(chrom: String,
+                   pos: Int,
+                   id: Option[String],
+                   alleles: AlleleSet,
+                   qual: Option[Double],
+                   filter: Seq[String],
+                   info: ListMap[String,Any],
+                   genotypes: Map[String, Genotype]
+                  ) {
+
+  val end: Int = get[Int]("END").getOrElse(pos + alleles.ref.length - 1)
+
+  def apply[A](key: String): A = info(key).asInstanceOf[A]
+  def get[A](key: String): Option[A] = info.get(key).asInstanceOf[Option[A]]
+  def getOrElse[A](key: String, default: => A): Option[A] = info.getOrElse(key, default).asInstanceOf[Option[A]]
+}
+
+
+/** A genotype for a variant.
+  *
+  * @param alleles the set of alleles for the variant
+  * @param sample the name of the sample for which this is a genotype
+  * @param calls the called alleles for the sample
+  * @param phased whether or not the calls are phased
+  */
+case class Genotype(alleles: AlleleSet,
+                    sample: String,
+                    calls: IndexedSeq[Allele],
+                    phased: Boolean = false,
+                    attributes: Map[String, Any]
+                   ) {
+  require(calls.nonEmpty, "Genotype must have ploidy of at least 1!.")
+
+  val callIndices: IndexedSeq[Int] = calls.map(alleles.indexOf)
+
+  def ploidy: Int = calls.length
+  def isNoCall   : Boolean = calls.forall(_ == Allele.NoCallAllele)
+  def isHomRef   : Boolean = calls.forall(_ == alleles.ref)
+  def inHomVar   : Boolean = calls(0) != alleles.ref && calls.forall(_ == calls(0))
+  def isHet      : Boolean = calls.exists(_ != calls(0))
+  def isHetNonRef: Boolean = isHet && !calls.contains(alleles.ref)
+
+  def apply[A](key: String): A = attributes(key).asInstanceOf[A]
+  def get[A](key: String): Option[A] = attributes.get(key).asInstanceOf[Option[A]]
+  def getOrElse[A](key: String, default: => A): Option[A] = attributes.getOrElse(key, default).asInstanceOf[Option[A]]
+
+  // Would be nice to have typed accessors for common, spec-defined attributes, but how to deal with optionality?
+  def dp: Option[Int] = get[Int]("DP")
+  def DP: Int = apply[Int]("DP")
+}
+
+
+

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
@@ -82,26 +82,6 @@ case class Variant(chrom: String,
 
   /** Retrieves an optional value from the INFO map.  Will return `default` if the key does not exist. */
   def getOrElse[A](key: String, default: => A): Option[A] = attributes.getOrElse(key, default).asInstanceOf[Option[A]]
-
-  /** Object that provides convenient accessors to common, spec-defined, attributes from the INFO field.
-    * Methods on this object return the expected type directly and will throw exceptions if the keys
-    * do not exist in the info map.
-    */
-  final object INFO {
-    @inline def AC: ArrayAttribute[Int] = apply[ArrayAttribute[Int]]("AC")
-    @inline def DP: Int = apply[Int]("DP")
-
-    @inline def STR: Boolean = attributes.contains("STR")
-  }
-
-  /** Object that provides convenient accessors to common, spec-defined, attributes from the INFO field.
-    * Methods on this object return [[Option]]s, and will return `None` when the specified key does not
-    * exist in the info map.
-    */
-  final object info {
-    @inline def AC: Option[ArrayAttribute[Int]] = get[ArrayAttribute[Int]]("AC")
-    @inline def DP: Option[Int] = get[Int]("DP")
-  }
 }
 
 
@@ -152,30 +132,6 @@ case class Genotype(alleles: AlleleSet,
 
   /** Retrieves an optional value from the INFO map.  Will return `default` if the key does not exist. */
   def getOrElse[A](key: String, default: => A): Option[A] = attributes.getOrElse(key, default).asInstanceOf[Option[A]]
-
-  /** Object that provides convenient accessors to common attributes from the genotype field.
-    * Methods on this object return the expected type directly and will throw exceptions if the keys
-    * do not exist in the info map.
-    */
-  final object ATTRS {
-    @inline def AD: ArrayAttribute[Int] = apply[ArrayAttribute[Int]]("AD")
-    @inline def DP: Int                 = apply[Int]("DP")
-    @inline def GQ: Int                 = apply[Int]("GQ")
-    @inline def PL: ArrayAttribute[Int] = apply[ArrayAttribute[Int]]("PL")
-    @inline def PS: String              = apply[String]("PS")
-  }
-
-  /** Object that provides convenient accessors to common attributes from the genotype field.
-    * Methods on this object return [[Option]]s, and will return `None` when the specified key does not
-    * exist in the info map.
-    */
-  final object attrs {
-    @inline def AD: Option[ArrayAttribute[Int]] = get[ArrayAttribute[Int]]("AD")
-    @inline def DP: Option[Int ]                = get[Int]("DP")
-    @inline def GQ: Option[Int]                 = get[Int]("GQ")
-    @inline def PL: Option[ArrayAttribute[Int]] = get[ArrayAttribute[Int]]("PL")
-    @inline def PS: Option[String]              = get[String]("PS")
-  }
 }
 
 

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
@@ -85,4 +85,10 @@ final case class Variant(chrom: String,
 
   /** Retrieves an optional value from the INFO map.  Will return `default` if the key does not exist. */
   def getOrElse[A](key: String, default: => A): A = attrs.getOrElse(key, default).asInstanceOf[A]
+
+  /** Convenience method to get a single sample's genotype. */
+  def gt(sample: String): Genotype = this.genotypes(sample)
+
+  /** Returns an iterator over the genotypes for this variant. */
+  def gts: Iterator[Genotype] = this.genotypes.valuesIterator
 }

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/VariantSource.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/VariantSource.scala
@@ -1,0 +1,60 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.fulcrumgenomics.vcf.api
+
+import java.io.Closeable
+
+import com.fulcrumgenomics.FgBioDef._
+import com.fulcrumgenomics.commons.collection.SelfClosingIterator
+import htsjdk.samtools.util.CloseableIterator
+import htsjdk.variant.variantcontext.VariantContext
+import htsjdk.variant.vcf.VCFFileReader
+
+import scala.collection.IterableView
+
+// class SamSource private(private val reader: SamReader) extends IterableView[SamRecord, SamSource] with HeaderHelper with Closeable {
+class VariantSource private (private val reader: VCFFileReader) extends IterableView[Variant, VariantSource] with Closeable {
+  val header: VcfHeader = VcfConversions.toScalaHeader(reader.getFileHeader)
+  type VariantIterator = SelfClosingIterator[Variant]
+
+  override def close(): Unit = this.reader.safelyClose()
+  override protected def underlying: VariantSource = this
+  private def wrap(it: CloseableIterator[VariantContext]): VariantIterator = {
+    new SelfClosingIterator(
+      iter   = it.map(vc => VcfConversions.toScalaVariant(vc, header)),
+      closer = () => it.close())
+  }
+
+  override def iterator: VariantIterator = wrap(reader.iterator())
+  def query(chrom: String, start: Int, end: Int): Iterator[Variant] = wrap(reader.query(chrom, start, end))
+}
+
+object VariantSource {
+  def apply(path: PathToVcf): VariantSource = {
+    val reader = new VCFFileReader(path, false)
+    new VariantSource(reader)
+  }
+}
+

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/VariantWriter.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/VariantWriter.scala
@@ -1,0 +1,51 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.fulcrumgenomics.vcf.api
+
+import com.fulcrumgenomics.FgBioDef._
+import com.fulcrumgenomics.commons.io.Writer
+import htsjdk.variant.variantcontext.writer.{Options, VariantContextWriter, VariantContextWriterBuilder}
+
+class VariantWriter private (private val writer: VariantContextWriter, val header: VcfHeader) extends Writer[Variant] {
+  override def write(variant: Variant): Unit = writer.add(VcfConversions.toJavaVariant(variant, header))
+  override def close(): Unit = writer.close()
+}
+
+object VariantWriter {
+  def apply(path: PathToVcf, header: VcfHeader): VariantWriter = {
+    val javaHeader = VcfConversions.toJavaHeader(header)
+
+    val writer = new VariantContextWriterBuilder()
+      .setOutputFile(path.toFile)
+      .setOption(Options.INDEX_ON_THE_FLY)
+      .setReferenceDictionary(header.dict)
+      .setOption(Options.ALLOW_MISSING_FIELDS_IN_HEADER)  // TODO: do we want to do this?
+      .build()
+
+    writer.writeHeader(javaHeader)
+
+    new VariantWriter(writer, header)
+  }
+}

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/VariantWriter.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/VariantWriter.scala
@@ -28,12 +28,29 @@ import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.commons.io.Writer
 import htsjdk.variant.variantcontext.writer.{Options, VariantContextWriter, VariantContextWriterBuilder}
 
+/**
+  * Writes [[Variant]]s to a file or other storage mechanism.
+  *
+  * @param writer the underlying HTSJDK writer
+  * @param header the header of the VCF
+  */
 class VariantWriter private (private val writer: VariantContextWriter, val header: VcfHeader) extends Writer[Variant] {
   override def write(variant: Variant): Unit = writer.add(VcfConversions.toJavaVariant(variant, header))
   override def close(): Unit = writer.close()
 }
 
+
 object VariantWriter {
+  /**
+    * Creates a [[VariantWriter]] that will write to the give path.  The path must end in either
+    *   - `.vcf` to create an uncompressed VCF file
+    *   - `.vcf.gz` to create a block-gzipped VCF file
+    *   - `.bcf` to create a binary BCF file
+    *
+    * @param path the path to write to
+    * @param header the header of the VCF
+    * @return a VariantWriter to write to the given path
+    */
   def apply(path: PathToVcf, header: VcfHeader): VariantWriter = {
     val javaHeader = VcfConversions.toJavaHeader(header)
 

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/VcfConversions.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/VcfConversions.scala
@@ -281,9 +281,9 @@ private[api] object VcfConversions {
     case (_, VcfFieldType.Flag, _       )              => Some(Variant.FlagValue)
     case (_, _,                 Fixed(0))              => Some(Variant.FlagValue)
     case (s: String, _,         Fixed(1))              => if (s == ".") None else Some(kind.parse(s))
-    case (s: String, _,         _       )              => val xs = s.split(","); if (xs.forall(_ == ".")) None else Some(Variant.toArrayAttribute(xs.map(kind.parse)))
+    case (s: String, _,         _       )              => val xs = s.split(","); if (xs.forall(_ == ".")) None else Some(ArrayAttr(xs.map(kind.parse)))
     case (l: JavaList[String @unchecked], _, Fixed(1)) => if (l.get(0) == ".") None else Some(kind.parse(l.get(0)))
-    case (l: JavaList[String @unchecked], _, _)        => if (l.forall(_ == ".")) None else Some(Variant.toArrayAttribute(l.map(kind.parse)))
+    case (l: JavaList[String @unchecked], _, _)        => if (l.forall(_ == ".")) None else Some(ArrayAttr(l.map(kind.parse)))
   }
 
   /**

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/VcfConversions.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/VcfConversions.scala
@@ -268,7 +268,7 @@ private[api] object VcfConversions {
     * @param count the scala [[VcfCount]] describing how many values are expected
     * @return either a String/Float/Int/Char or an IndexedSeq of one of those types
     */
-  private def toTypedValue(value: Any, kind: VcfFieldType, count: VcfCount): Any = (value, kind, count) match {
+  private def toTypedValue(value: Any, kind: VcfFieldType, count: VcfCount): Any = ((value, kind, count): @unchecked) match {
     case (_, VcfFieldType.Flag, _       )              => Variant.FlagValue
     case (_, _,                 Fixed(0))              => Variant.FlagValue
     case (s: String, _,         Fixed(1))              => kind.parse(s)

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/VcfConversions.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/VcfConversions.scala
@@ -1,0 +1,264 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.fulcrumgenomics.vcf.api
+
+import java.util
+import java.util.{List => JavaList}
+
+import com.fulcrumgenomics.FgBioDef._
+import com.fulcrumgenomics.vcf.api.VcfCount.Fixed
+import htsjdk.samtools.SAMSequenceRecord
+import htsjdk.variant.variantcontext.{GenotypeBuilder, VariantContext, VariantContextBuilder, Allele => JavaAllele}
+import htsjdk.variant.vcf._
+
+import scala.collection.JavaConverters.mapAsJavaMap
+import scala.collection.immutable.ListMap
+import scala.collection.mutable.ArrayBuffer
+
+/**
+  * Object that provides methods for converting from fgbio's scala VCF classes to HTSJDK's
+  * Java VCF-related classes and vice-versa.
+  */
+private[api] object VcfConversions {
+  /** Value used in VCF for values that are missing. */
+  val Missing: String = "."
+
+  /** Converts a String into Option[String] accounting for various empty/missing values. */
+  private def opt(value: String): Option[String] = {
+    if (value == null || value.isEmpty || value == Missing) None else Some(value)
+  }
+
+  /** Converts a Java VCF header into a scala VCF header. */
+  def toScalaHeader(in: VCFHeader): VcfHeader = {
+    val contigs = in.getContigLines.map { c =>
+      val rec = c.getSAMSequenceRecord
+      val length = if (rec.getSequenceLength == SAMSequenceRecord.UNKNOWN_SEQUENCE_LENGTH) None else Some(rec.getSequenceLength)
+      VcfContigHeader(rec.getSequenceIndex, rec.getSequenceName, length, Option(rec.getAssembly))
+    }.toIndexedSeq
+
+    val infos = in.getInfoHeaderLines.toIndexedSeq.sortBy(_.getID).map { i =>
+      VcfInfoHeader(i.getID, toScalaCount(i), toScalaKind(i.getType), i.getDescription, opt(i.getSource), opt(i.getVersion))
+    }
+
+    val formats = in.getFormatHeaderLines.toIndexedSeq.sortBy(_.getID).map { f =>
+      VcfFormatHeader(f.getID, toScalaCount(f), toScalaKind(f.getType), f.getDescription)
+    }
+
+    val others = in.getOtherHeaderLines.map {
+      case line: VCFSimpleHeaderLine =>
+        val attrs = line.getGenericFields.entrySet().map { entry => entry.getKey -> entry.getValue }.toMap
+        VcfGeneralHeader(line.getKey, line.getID, attrs)
+      case line: VCFHeaderLine =>
+        VcfGeneralHeader(line.getKey, line.getValue, Map.empty)
+    }.toIndexedSeq
+
+    VcfHeader(
+      contigs = contigs,
+      infos   = infos,
+      formats = formats,
+      filters = in.getFilterLines.toIndexedSeq.sortBy(_.getID).map(f => VcfFilterHeader(f.getID, f.getDescription)),
+      other   = others,
+      samples = in.getSampleNamesInOrder.toIndexedSeq
+    )
+  }
+
+
+  /** Converts the scala VCF header back into a Java VCF header. */
+  def toJavaHeader(in: VcfHeader): VCFHeader = {
+    val out = new VCFHeader(new java.util.HashSet[VCFHeaderLine](), in.samples.iterator.toJavaList)
+
+    in.infos.foreach { i =>
+      val j = toJavaCount(i.count) match {
+        case Left(countType) => new VCFInfoHeaderLine(i.id, countType, toJavaKind(i.kind), i.description, i.source.orNull, i.version.orNull)
+        case Right(intCount) => new VCFInfoHeaderLine(i.id, intCount,  toJavaKind(i.kind), i.description, i.source.orNull, i.version.orNull)
+      }
+      out.addMetaDataLine(j)
+    }
+
+    in.formats.foreach { i =>
+      val j = toJavaCount(i.count) match {
+        case Left(countType) => new VCFFormatHeaderLine(i.id, countType, toJavaKind(i.kind), i.description)
+        case Right(intCount) => new VCFFormatHeaderLine(i.id, intCount,  toJavaKind(i.kind), i.description)
+      }
+      out.addMetaDataLine(j)
+    }
+
+    in.filters.foreach { i =>  out.addMetaDataLine(new VCFFilterHeaderLine(i.id, i.description)) }
+
+    in.other.foreach { i =>
+      val j = if (i.data.isEmpty) new VCFHeaderLine(i.headerType, i.id) else {
+        new VCFSimpleHeaderLine(i.headerType, mapAsJavaMap(i.data ++ Map("ID" -> i.id)))
+      }
+      out.addMetaDataLine(j)
+    }
+
+    in.contigs.foreach { i =>
+      val fields = new util.HashMap[String,String]()
+      fields.put("ID", i.name)
+      i.assembly.foreach(a => fields.put("assembly", a))
+      out.addMetaDataLine(new VCFContigHeaderLine(fields, i.index))
+    }
+
+    out
+  }
+
+  def toScalaCount(in: VCFCompoundHeaderLine): VcfCount = {
+    in.getCountType match {
+      case VCFHeaderLineCount.A         => VcfCount.OnePerAltAllele
+      case VCFHeaderLineCount.G         => VcfCount.OnePerGenotype
+      case VCFHeaderLineCount.R         => VcfCount.OnePerAllele
+      case VCFHeaderLineCount.UNBOUNDED => VcfCount.Unknown
+      case VCFHeaderLineCount.INTEGER   => VcfCount.Fixed(in.getCount)
+    }
+  }
+
+  def toScalaKind(in: VCFHeaderLineType): VcfFieldType = in match {
+    case VCFHeaderLineType.Character => VcfFieldType.Character
+    case VCFHeaderLineType.Flag      => VcfFieldType.Flag
+    case VCFHeaderLineType.Float     => VcfFieldType.Float
+    case VCFHeaderLineType.Integer   => VcfFieldType.Integer
+    case VCFHeaderLineType.String    => VcfFieldType.String
+  }
+
+  def toJavaCount(in: VcfCount): Either[VCFHeaderLineCount, Int] = {
+    in match {
+      case VcfCount.OnePerAltAllele    => Left(VCFHeaderLineCount.A)
+      case VcfCount.OnePerGenotype     => Left(VCFHeaderLineCount.G)
+      case VcfCount.OnePerAllele       => Left(VCFHeaderLineCount.R)
+      case VcfCount.Unknown            => Left(VCFHeaderLineCount.UNBOUNDED)
+      case VcfCount.Fixed(n)           => Right(n)
+    }
+  }
+
+  def toJavaKind(in: VcfFieldType ): VCFHeaderLineType= in match {
+    case VcfFieldType.Character => VCFHeaderLineType.Character
+    case VcfFieldType.Flag      => VCFHeaderLineType.Flag
+    case VcfFieldType.Float     => VCFHeaderLineType.Float
+    case VcfFieldType.Integer   => VCFHeaderLineType.Integer
+    case VcfFieldType.String    => VCFHeaderLineType.String
+  }
+
+  def toScalaVariant(in: VariantContext, header: VcfHeader): Variant = {
+    // Build up the allele set
+    val ref  = Allele(in.getReference.getDisplayString)
+    val alts = in.getAlternateAlleles.map(a => Allele(a.getDisplayString)).toIndexedSeq
+    val alleles = AlleleSet(ref, alts)
+    val alleleMap = alleles.map(a => a.toString -> a).toMap
+
+    // Build up the genotypes
+    val gts = in.getGenotypes.map { g =>
+      val calls = g.getAlleles.map(a => alleleMap(a.getDisplayString)).toIndexedSeq
+      val attrs = {
+        val buffer = new ArrayBuffer[(String,Any)](g.getExtendedAttributes.size() + 4)
+        if (g.hasAD) buffer.append("AD" -> g.getAD.toIndexedSeq)
+        if (g.hasDP) buffer.append("DP" -> g.getDP)
+        if (g.hasGQ) buffer.append("GQ" -> g.getGQ)
+        if (g.hasPL) buffer.append("PL" -> g.getPL.toIndexedSeq)
+
+        g.getExtendedAttributes.keySet().foreach { key =>
+          val value = g.getExtendedAttribute(key)
+
+          header.format.get(key) match {
+            case Some(hd) => buffer.append(key -> toTypedValue(value, hd.kind, hd.count))
+            case None     => throw new IllegalStateException(s"Format field $key not described in header.")
+          }
+        }
+
+        buffer.toMap
+      }
+
+      Genotype(alleles, g.getSampleName, calls, g.isPhased, attrs)
+    }.toIndexedSeq
+
+    // Build up the variant
+    val info = in.getAttributes.entrySet().map { entry =>
+      val key   = entry.getKey
+      val value = entry.getValue
+      header.info.get(key) match {
+        case Some(hd) => key -> toTypedValue(value, hd.kind, hd.count)
+        case None     => throw new IllegalStateException(s"INFO field $key not described in header.")
+      }
+    }.toSeq
+
+    Variant(
+      chrom     = in.getContig,
+      pos       = in.getStart,
+      id        = Option(if (in.getID == Missing) null else in.getID),
+      alleles   = alleles,
+      qual      = if (in.hasLog10PError) Some(in.getPhredScaledQual) else None,
+      filter    = in.getFilters.toIndexedSeq,
+      info      = ListMap(info:_*),
+      genotypes = gts.iterator.map(g => g.sample -> g).toMap
+    )
+  }
+
+  def toTypedValue(value: Any, kind: VcfFieldType, count: VcfCount): Any = (value, kind, count) match {
+    case (_, VcfFieldType.Flag, _       )   => None
+    case (_, _,                 Fixed(0))   => None
+    case (s: String, _,         Fixed(1))   => kind.parse(s)
+    case (s: String, _,         _       )   => s.split(',').map(kind.parse).toIndexedSeq
+    case (l: JavaList[String], _, Fixed(1)) => kind.parse(l.get(0))
+    case (l: JavaList[String], _, _)        => l.map(kind.parse).toIndexedSeq
+  }
+
+  def toJavaVariant(in: Variant, header: VcfHeader): VariantContext = {
+    val alleles   = in.alleles.iterator.map { a => JavaAllele.create(a.toString, a eq in.alleles.ref) }.toJavaList
+    val builder = new VariantContextBuilder(null, in.chrom, in.pos, in.end, alleles)
+    in.id.foreach(i => builder.id(i))
+    in.qual.foreach(q => builder.log10PError(q / -10 ))
+    if (in.filter.isEmpty) builder.unfiltered() else builder.filters(in.filter.iterator.toJavaSet)
+    builder.attributes(toJavaAttributeMap(in.info))
+
+    val genotypes = header.samples.iterator.map { s =>
+      val sgt = in.genotypes(s)
+      val jgt = new GenotypeBuilder(s, sgt.callIndices.iterator.map(i => alleles.get(i)).toJavaList)
+      jgt.phased(sgt.phased)
+
+      sgt.attributes.foreach {
+        case ("GQ", value: Int)         => jgt.GQ(value)
+        case ("DP", value: Int)         => jgt.DP(value)
+        case ("AD", value: Seq[Int])    => jgt.AD(value.toArray)
+        case ("PL", value: Seq[Int])    => jgt.PL(value.toArray)
+        case ("FT", value: Seq[String]) => value.foreach(f => jgt.filter(f))
+        case (key, value: Seq[Any])     => jgt.attribute(key, value.toArray)
+        case (key, value: Any)          => jgt.attribute(key, value)
+      }
+
+      jgt.make()
+    }.toJavaList
+
+    builder.genotypes(genotypes).make()
+  }
+
+  def toJavaAttributeMap(attrs: Map[String,Any]): java.util.LinkedHashMap[String,Any] = {
+    val out = new util.LinkedHashMap[String,Any]()
+    attrs.foreach {
+      case (key, value: Seq[Any]) => out.put(key, value.toArray)
+      case (key, value)           => out.put(key, value)
+    }
+
+    out
+  }
+}

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/VcfConversions.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/VcfConversions.scala
@@ -200,9 +200,9 @@ private[api] object VcfConversions {
     */
   def toScalaVariant(in: VariantContext, header: VcfHeader): Variant = try {
     // Build up the allele set
-    val ref  = Allele(in.getReference.getDisplayString)
-    val alts = in.getAlternateAlleles.map(a => Allele(a.getDisplayString)).toIndexedSeq
-    val alleles = AlleleSet(ref, alts)
+    val ref       = Allele(in.getReference.getDisplayString)
+    val alts      = in.getAlternateAlleles.map(a => Allele(a.getDisplayString)).toIndexedSeq
+    val alleles   = AlleleSet(ref, alts)
     val alleleMap = alleles.map(a => a.toString -> a).toMap
 
     // Build up the genotypes
@@ -232,17 +232,17 @@ private[api] object VcfConversions {
 
     // Build up the variant
     val info = {
-      val buffer = new ArrayBuffer[(String,Any)](in.getAttributes.size())
+      val buffer = IndexedSeq.newBuilder[(String,Any)]
       in.getAttributes.entrySet().foreach { entry =>
         val key   = entry.getKey
         val value = entry.getValue
         header.info.get(key) match {
-          case Some(hd) => toTypedValue(value, hd.kind, hd.count).foreach(v => buffer.append(key -> v))
+          case Some(hd) => toTypedValue(value, hd.kind, hd.count).foreach(v => buffer += (key -> v))
           case None     => throw new IllegalStateException(s"INFO field $key not described in header.")
         }
       }
 
-      buffer
+      buffer.result()
     }
 
     Variant(

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/VcfHeader.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/VcfHeader.scala
@@ -71,6 +71,7 @@ object VcfFieldType extends FgBioEnum[VcfFieldType] {
 /** Trait representing an entry/line in a VCF header. */
 sealed trait VcfHeaderEntry {}
 
+// TODO add subclasses for ALT and PEDIGREE lines
 
 /** A contig line/entry in the VCF header.
   *
@@ -129,7 +130,7 @@ case class VcfFilterHeader(id: String, description: String) extends VcfHeaderEnt
 
 
 /** Catch all for header line types we don't care enough to have specific implementations of. */
-case class VcfGeneralHeader(headerType: String, id: String, data: Map[String, String]) extends VcfHeaderEntry
+case class VcfGeneralHeader(headerType: String, id: String, data: Map[String, String] = Map.empty) extends VcfHeaderEntry
 
 
 /** The header of a VCF file.
@@ -168,4 +169,7 @@ case class VcfHeader(contigs: IndexedSeq[VcfContigHeader],
 
   /** Returns an iterator over all entries in the header. */
   def entries: Iterator[VcfHeaderEntry] = contigs.iterator ++ infos.iterator ++ formats.iterator ++ filters.iterator ++ others.iterator
+
+  /** How many lines total are in the header. */
+  def size: Int = entries.size
 }

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/VcfHeader.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/VcfHeader.scala
@@ -30,41 +30,72 @@ import htsjdk.samtools.{SAMSequenceDictionary, SAMSequenceRecord}
 
 import scala.collection.immutable
 
+/** Trait used to represent how many instances of an attribute are to be expected in a VCFs INFO or genotype fields.*/
 sealed trait VcfCount { }
 
 object VcfCount {
+  /** VcfCount that indicates there should be exactly one value per alternate allele on the Variant. */
   case object OnePerAltAllele  extends VcfCount
+  /** VcfCount that indicates there should be exactly one value per allele, including reference, on the Variant. */
   case object OnePerAllele     extends VcfCount
+  /** VcfCount that indicates there should be exactly one value per possible genotype.  E.g. for a variant with a
+    * ref allele and one alt allele, and a diploid sample, there would be three values. */
   case object OnePerGenotype   extends VcfCount
+  /** The attribute may have any number of values. */
   case object Unknown          extends VcfCount
+  /** The attribute must have a fixed number of values, indicated by `count`. */
   case class Fixed(count: Int) extends VcfCount
 }
 
-
+/** Trait for the set of acceptable atomic types that can appear in VCF's INFO and genotype fields. */
 sealed trait VcfFieldType extends EnumEntry {
   /** Must parse a String into a single value of the type given. */
   def parse(s: String): Any
 }
 
 object VcfFieldType extends FgBioEnum[VcfFieldType] {
+  /** Integer field type, represented internally as [[Int]]. */
   case object Integer   extends VcfFieldType { override def parse(s: String): Any = s.toInt }
+  /** Floating point number field type, represented internally as [[Float]]. */
   case object Float     extends VcfFieldType { override def parse(s: String): Any = s.toFloat }
+  /** String field type, represented internally as [[String]]. */
   case object String    extends VcfFieldType { override def parse(s: String): Any = s }
+  /** Character field type, represented internally as [[Char]]. */
   case object Character extends VcfFieldType { override def parse(s: String): Any = s.charAt(0) }
+  /** Character field type, represented internally as [[Char]]. */
   case object Flag      extends VcfFieldType { override def parse(s: String): Any = "." }
 
   override def values: immutable.IndexedSeq[VcfFieldType] = findValues
 }
 
-
+/** Trait representing an entry/line in a VCF header. */
 sealed trait VcfHeaderEntry {}
 
+
+/** A contig line/entry in the VCF header.
+  *
+  * @param index the index of the contig in the list of contigs
+  * @param name the name of the contig
+  * @param length the length of the contig in bases, optional
+  * @param assembly the optional name of the assembly from which the contig is drawn
+  */
 case class VcfContigHeader(index: Int,
                            name: String,
                            length: Option[Int] = None,
                            assembly: Option[String] = None
                           ) extends VcfHeaderEntry
 
+
+/**
+  * An entry in the VCF header describing an INFO field.
+  *
+  * @param id the ID of the INFO field, i.e. the value that precedes the `=` in the INFO field
+  * @param count the expected count of values for the field
+  * @param kind the atomic type of values for the field
+  * @param description a description of the field, intended for people not for parsing
+  * @param source an optional source describing where the field came from
+  * @param version an optional version for the INFO field
+  */
 case class VcfInfoHeader(id: String,
                          count: VcfCount,
                          kind: VcfFieldType,
@@ -73,21 +104,48 @@ case class VcfInfoHeader(id: String,
                          version: Option[String] = None
                         ) extends VcfHeaderEntry {}
 
+
+/**
+  * An entry in the VCF header describing a FORMAT field whose values appear in each genotype.
+  *
+  * @param id the ID of the fields (i.e. the string that appears in the FORMAT field)
+  * @param count the expected count of values per sample
+  * @param kind the atomic type of each value
+  * @param description a human readable description of the field
+  */
 case class VcfFormatHeader(id: String,
                            count: VcfCount,
                            kind: VcfFieldType,
                            description: String) extends VcfHeaderEntry {}
 
+
+/**
+  * An entry describing a filter used in either the FILTER field or samples' FT field.
+  *
+  * @param id the name of the filter as it will appear in the FILTER or FT fields
+  * @param description a human readable description of the filter
+  */
 case class VcfFilterHeader(id: String, description: String) extends VcfHeaderEntry {}
 
-/** Catch all for header line types we don't care enough to have specific implementations of. */
-case class VcfGeneralHeader(headerType: String, id: String, data: Map[String, String])
 
+/** Catch all for header line types we don't care enough to have specific implementations of. */
+case class VcfGeneralHeader(headerType: String, id: String, data: Map[String, String]) extends VcfHeaderEntry
+
+
+/** The header of a VCF file.
+  *
+  * @param contigs the ordered list of contig entries in the VCF header (may be empty)
+  * @param infos the list of INFO entries in the header
+  * @param formats the list of FORMAT entries in the header
+  * @param filters the list of FILTER entries in the header
+  * @param others the list of all other header entries
+  * @param samples the ordered list of samples that appear in the VCF
+  */
 case class VcfHeader(contigs: IndexedSeq[VcfContigHeader],
                      infos: Seq[VcfInfoHeader],
                      formats: Seq[VcfFormatHeader],
                      filters: Seq[VcfFilterHeader],
-                     other: Seq[VcfGeneralHeader],
+                     others: Seq[VcfGeneralHeader],
                      samples: IndexedSeq[String]
                     ) {
 
@@ -99,9 +157,15 @@ case class VcfHeader(contigs: IndexedSeq[VcfContigHeader],
     d
   }
 
+  /** The INFO entries organized as a map where the key is the ID of the INFO field. */
   val info: Map[String, VcfInfoHeader]     = infos.map(i => i.id -> i).toMap
+
+  /** The FORMAT entries organized as a map where the key is the ID of the FORMAT field. */
   val format: Map[String, VcfFormatHeader] = formats.map(f => f.id -> f).toMap
+
+  /** The FILTER entries organized as a map where the key is the ID of the FILTER. */
   val filter: Map[String, VcfFilterHeader] = filters.map(f => f.id -> f).toMap
+
+  /** Returns an iterator over all entries in the header. */
+  def entries: Iterator[VcfHeaderEntry] = contigs.iterator ++ infos.iterator ++ formats.iterator ++ filters.iterator ++ others.iterator
 }
-
-

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/VcfHeader.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/VcfHeader.scala
@@ -55,9 +55,9 @@ sealed trait VcfFieldType extends EnumEntry {
 
 object VcfFieldType extends FgBioEnum[VcfFieldType] {
   /** Integer field type, represented internally as [[Int]]. */
-  case object Integer   extends VcfFieldType { override def parse(s: String): Any = if (s == ".") -1 else s.toInt }
+  case object Integer   extends VcfFieldType { override def parse(s: String): Any = if (s == ".") Variant.MissingInt else s.toInt }
   /** Floating point number field type, represented internally as [[Float]]. */
-  case object Float     extends VcfFieldType { override def parse(s: String): Any = if (s == ".") scala.Float.NaN  else s.toFloat }
+  case object Float     extends VcfFieldType { override def parse(s: String): Any = if (s == ".") Variant.MissingFloat else s.toFloat }
   /** String field type, represented internally as [[String]]. */
   case object String    extends VcfFieldType { override def parse(s: String): Any = s }
   /** Character field type, represented internally as [[Char]]. */

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/VcfHeader.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/VcfHeader.scala
@@ -55,9 +55,9 @@ sealed trait VcfFieldType extends EnumEntry {
 
 object VcfFieldType extends FgBioEnum[VcfFieldType] {
   /** Integer field type, represented internally as [[Int]]. */
-  case object Integer   extends VcfFieldType { override def parse(s: String): Any = s.toInt }
+  case object Integer   extends VcfFieldType { override def parse(s: String): Any = if (s == ".") -1 else s.toInt }
   /** Floating point number field type, represented internally as [[Float]]. */
-  case object Float     extends VcfFieldType { override def parse(s: String): Any = s.toFloat }
+  case object Float     extends VcfFieldType { override def parse(s: String): Any = if (s == ".") scala.Float.NaN  else s.toFloat }
   /** String field type, represented internally as [[String]]. */
   case object String    extends VcfFieldType { override def parse(s: String): Any = s }
   /** Character field type, represented internally as [[Char]]. */

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/VcfHeader.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/VcfHeader.scala
@@ -1,0 +1,107 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.fulcrumgenomics.vcf.api
+
+import com.fulcrumgenomics.FgBioDef._
+import enumeratum.EnumEntry
+import htsjdk.samtools.{SAMSequenceDictionary, SAMSequenceRecord}
+
+import scala.collection.immutable
+
+sealed trait VcfCount { }
+
+object VcfCount {
+  case object OnePerAltAllele  extends VcfCount
+  case object OnePerAllele     extends VcfCount
+  case object OnePerGenotype   extends VcfCount
+  case object Unknown          extends VcfCount
+  case class Fixed(count: Int) extends VcfCount
+}
+
+
+sealed trait VcfFieldType extends EnumEntry {
+  /** Must parse a String into a single value of the type given. */
+  def parse(s: String): Any
+}
+
+object VcfFieldType extends FgBioEnum[VcfFieldType] {
+  case object Integer   extends VcfFieldType { override def parse(s: String): Any = s.toInt }
+  case object Float     extends VcfFieldType { override def parse(s: String): Any = s.toFloat }
+  case object String    extends VcfFieldType { override def parse(s: String): Any = s }
+  case object Character extends VcfFieldType { override def parse(s: String): Any = s.charAt(0) }
+  case object Flag      extends VcfFieldType { override def parse(s: String): Any = "." }
+
+  override def values: immutable.IndexedSeq[VcfFieldType] = findValues
+}
+
+
+sealed trait VcfHeaderEntry {}
+
+case class VcfContigHeader(index: Int,
+                           name: String,
+                           length: Option[Int] = None,
+                           assembly: Option[String] = None
+                          ) extends VcfHeaderEntry
+
+case class VcfInfoHeader(id: String,
+                         count: VcfCount,
+                         kind: VcfFieldType,
+                         description: String,
+                         source: Option[String] = None,
+                         version: Option[String] = None
+                        ) extends VcfHeaderEntry {}
+
+case class VcfFormatHeader(id: String,
+                           count: VcfCount,
+                           kind: VcfFieldType,
+                           description: String) extends VcfHeaderEntry {}
+
+case class VcfFilterHeader(id: String, description: String) extends VcfHeaderEntry {}
+
+/** Catch all for header line types we don't care enough to have specific implementations of. */
+case class VcfGeneralHeader(headerType: String, id: String, data: Map[String, String])
+
+case class VcfHeader(contigs: IndexedSeq[VcfContigHeader],
+                     infos: Seq[VcfInfoHeader],
+                     formats: Seq[VcfFormatHeader],
+                     filters: Seq[VcfFilterHeader],
+                     other: Seq[VcfGeneralHeader],
+                     samples: IndexedSeq[String]
+                    ) {
+
+  /** The contig lines represented as a SAM sequence dictionary. */
+  val dict: SAMSequenceDictionary = {
+    val d = new SAMSequenceDictionary()
+    contigs.map { c => new SAMSequenceRecord(c.name, c.length.getOrElse(SAMSequenceRecord.UNKNOWN_SEQUENCE_LENGTH))}
+      .foreach(r => d.addSequence(r))
+    d
+  }
+
+  val info: Map[String, VcfInfoHeader]     = infos.map(i => i.id -> i).toMap
+  val format: Map[String, VcfFormatHeader] = formats.map(f => f.id -> f).toMap
+  val filter: Map[String, VcfFilterHeader] = filters.map(f => f.id -> f).toMap
+}
+
+

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/VcfSource.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/VcfSource.scala
@@ -25,18 +25,15 @@
 package com.fulcrumgenomics.vcf.api
 
 import java.io.Closeable
-import java.nio.file.Path
 
 import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.commons.collection.SelfClosingIterator
 import com.fulcrumgenomics.commons.io.PathUtil
 import htsjdk.samtools.util.CloseableIterator
-import htsjdk.tribble.{AbstractFeatureCodec, AbstractFeatureReader}
+import htsjdk.tribble.AbstractFeatureReader
 import htsjdk.variant.bcf2.BCF2Codec
 import htsjdk.variant.variantcontext.VariantContext
 import htsjdk.variant.vcf.{VCFCodec, VCFFileReader, VCFHeader}
-
-import scala.collection.IterableView
 
 /**
   * Provides a reader over a source of VCF-like data that could be a VCF file or a BCF file. Has facilities
@@ -45,7 +42,7 @@ import scala.collection.IterableView
   *
   * @param reader the underlying HTSJDK [[VCFFileReader]]
   */
-class VcfSource private(private val reader: AbstractFeatureReader[VariantContext, _]) extends IterableView[Variant, VcfSource] with Closeable {
+class VcfSource private(private val reader: AbstractFeatureReader[VariantContext, _]) extends View[Variant] with Closeable {
   /** The header associated with the VCF being read. */
   val header: VcfHeader = VcfConversions.toScalaHeader(reader.getHeader.asInstanceOf[VCFHeader])
 
@@ -85,8 +82,8 @@ class VcfSource private(private val reader: AbstractFeatureReader[VariantContext
   /** Closes the underlying reader. */
   override def close(): Unit = this.reader.safelyClose()
 
-  /** Required by [[scala.collection.IterableView]]. */
-  override protected def underlying: VcfSource = this
+  /** Required for 2.12 compat. */
+  protected def underlying: VcfSource = this
 }
 
 object VcfSource {

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/VcfSource.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/VcfSource.scala
@@ -41,7 +41,7 @@ import scala.collection.IterableView
   *
   * @param reader the underlying HTSJDK [[VCFFileReader]]
   */
-class VariantSource private (private val reader: VCFFileReader) extends IterableView[Variant, VariantSource] with Closeable {
+class VcfSource private(private val reader: VCFFileReader) extends IterableView[Variant, VcfSource] with Closeable {
   /** The header associated with the VCF being read. */
   val header: VcfHeader = VcfConversions.toScalaHeader(reader.getFileHeader)
 
@@ -62,7 +62,7 @@ class VariantSource private (private val reader: VCFFileReader) extends Iterable
   /**
     * Returns an iterator over the entire stream of variants. The returned iterator may be be closed by invoking
     * `close()` on it, and will automatically close itself when exhausted.  Only a single iterator at a time
-    * is supported per [[VariantSource]], including iterators returned from [[query()]].
+    * is supported per [[VcfSource]], including iterators returned from [[query()]].
     */
   override def iterator: VariantIterator = wrap(reader.iterator())
 
@@ -70,7 +70,7 @@ class VariantSource private (private val reader: VCFFileReader) extends Iterable
     * Returns an iterator over variants overlapping the specified genomic region.
     *
     * The returned iterator may be be closed by invoking `close()` on it, and will automatically close itself
-    * when exhausted.  Only a single iterator at a time is supported per [[VariantSource]], including iterators
+    * when exhausted.  Only a single iterator at a time is supported per [[VcfSource]], including iterators
     * returned from [[iterator()]].
     */
   def query(chrom: String, start: Int, end: Int): Iterator[Variant] = wrap(reader.query(chrom, start, end))
@@ -79,10 +79,10 @@ class VariantSource private (private val reader: VCFFileReader) extends Iterable
   override def close(): Unit = this.reader.safelyClose()
 
   /** Required by [[scala.collection.IterableView]]. */
-  override protected def underlying: VariantSource = this
+  override protected def underlying: VcfSource = this
 }
 
-object VariantSource {
+object VcfSource {
   /**
     * Manufactures a variant source for reading from the specified path.  The index, if one exists, will be
     * auto-discovered based on the path to the VCF.
@@ -90,9 +90,9 @@ object VariantSource {
     * @param path the path to a VCF, gzipped VCF or BCF file
     * @return a VariantSource for reading from the path given
     */
-  def apply(path: PathToVcf): VariantSource = {
+  def apply(path: PathToVcf): VcfSource = {
     val reader = new VCFFileReader(path, false)
-    new VariantSource(reader)
+    new VcfSource(reader)
   }
 }
 

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/VcfSource.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/VcfSource.scala
@@ -66,11 +66,14 @@ class VcfSource private(private val reader: VCFFileReader) extends IterableView[
     */
   override def iterator: VariantIterator = wrap(reader.iterator())
 
+  /** True if the VCF is sorted and indexed such that queries can be executed, false otherwise. */
+  def isQueryable: Boolean = this.reader.isQueryable
+
   /**
     * Returns an iterator over variants overlapping the specified genomic region.
     *
     * The returned iterator may be be closed by invoking `close()` on it, and will automatically close itself
-    * when exhausted.  Only a single iterator at a time is supported per [[VcfSource]], including iterators
+    * when exhausted.  Only a single iterator at a time is supported per [[com.fulcrumgenomics.vcf.api.VcfSource]], including iterators
     * returned from [[iterator()]].
     */
   def query(chrom: String, start: Int, end: Int): Iterator[Variant] = wrap(reader.query(chrom, start, end))

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/VcfWriter.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/VcfWriter.scala
@@ -34,15 +34,15 @@ import htsjdk.variant.variantcontext.writer.{Options, VariantContextWriter, Vari
   * @param writer the underlying HTSJDK writer
   * @param header the header of the VCF
   */
-class VariantWriter private (private val writer: VariantContextWriter, val header: VcfHeader) extends Writer[Variant] {
+class VcfWriter private(private val writer: VariantContextWriter, val header: VcfHeader) extends Writer[Variant] {
   override def write(variant: Variant): Unit = writer.add(VcfConversions.toJavaVariant(variant, header))
   override def close(): Unit = writer.close()
 }
 
 
-object VariantWriter {
+object VcfWriter {
   /**
-    * Creates a [[VariantWriter]] that will write to the give path.  The path must end in either
+    * Creates a [[VcfWriter]] that will write to the give path.  The path must end in either
     *   - `.vcf` to create an uncompressed VCF file
     *   - `.vcf.gz` to create a block-gzipped VCF file
     *   - `.bcf` to create a binary BCF file
@@ -51,7 +51,7 @@ object VariantWriter {
     * @param header the header of the VCF
     * @return a VariantWriter to write to the given path
     */
-  def apply(path: PathToVcf, header: VcfHeader): VariantWriter = {
+  def apply(path: PathToVcf, header: VcfHeader): VcfWriter = {
     val javaHeader = VcfConversions.toJavaHeader(header)
 
     val writer = new VariantContextWriterBuilder()
@@ -63,6 +63,6 @@ object VariantWriter {
 
     writer.writeHeader(javaHeader)
 
-    new VariantWriter(writer, header)
+    new VcfWriter(writer, header)
   }
 }

--- a/src/main/scala/com/fulcrumgenomics/vcf/filtration/EndRepairArtifactLikelihoodFilter.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/filtration/EndRepairArtifactLikelihoodFilter.scala
@@ -55,8 +55,8 @@ class EndRepairArtifactLikelihoodFilter(val distance: Int = 2,
   val FilterKey         = "EndRepairArtifact"
   val FilterDescription = "Variant is likely an artifact caused by end-repair and A-base addition."
 
-  override val VcfInfoLines: Traversable[VCFInfoHeaderLine]     = Seq(vcfInfoLine(InfoKey, InfoDescription))
-  override val VcfFilterLines: Traversable[VCFFilterHeaderLine] = Seq(vcfFilterLine(FilterKey, FilterDescription))
+  override val VcfInfoLines: Iterable[VCFInfoHeaderLine]     = Seq(vcfInfoLine(InfoKey, InfoDescription))
+  override val VcfFilterLines: Iterable[VCFFilterHeaderLine] = Seq(vcfFilterLine(FilterKey, FilterDescription))
 
   /** Only applies to het SNVs where the alt allele is A or T. */
   override def appliesTo(gt: Genotype): Boolean = {
@@ -210,7 +210,7 @@ class EndRepairArtifactLikelihoodFilter(val distance: Int = 2,
   /** Applies a single filter if a) a threshold was provided at construction, b) the computed
     * pvalue is present in the annotations, and c) the pvalue <= threshold.
     */
-  override def filters(annotations: Map[String, Any]): Traversable[String] = {
+  override def filters(annotations: Map[String, Any]): Iterable[String] = {
     (this.pValueThreshold, annotations.get(InfoKey).map(_.asInstanceOf[Double])) match {
       case (Some(threshold), Some(pvalue)) if pvalue <= threshold => List(FilterKey)
       case _ => Nil

--- a/src/main/scala/com/fulcrumgenomics/vcf/filtration/EndRepairArtifactLikelihoodFilter.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/filtration/EndRepairArtifactLikelihoodFilter.scala
@@ -29,12 +29,8 @@ import java.lang.Math.{min, pow}
 import com.fulcrumgenomics.bam.{Bams, BaseEntry, Pileup, PileupEntry}
 import com.fulcrumgenomics.commons.util.LazyLogging
 import com.fulcrumgenomics.util.NumericTypes.{LogProbability => LnProb}
-import com.fulcrumgenomics.vcf.api.{VcfCount, VcfFieldType, VcfInfoHeader}
-import htsjdk.samtools.util.SequenceUtil
-import htsjdk.variant.variantcontext.Genotype
-import htsjdk.variant.vcf.{VCFFilterHeaderLine, VCFInfoHeaderLine}
 import com.fulcrumgenomics.util.Sequences
-import com.fulcrumgenomics.vcf.api._
+import com.fulcrumgenomics.vcf.api.{VcfCount, VcfFieldType, VcfInfoHeader, _}
 
 /**
   * Filter that examines SNVs with the alt allele being A or T to see if they are likely the result
@@ -66,7 +62,7 @@ class EndRepairArtifactLikelihoodFilter(val distance: Int = 2,
   /** Only applies to het SNVs where the alt allele is A or T. */
   override def appliesTo(gt: Genotype): Boolean = {
     gt.isHet && !gt.isHetNonRef && gt.calls.forall(_.value.length == 1) &&
-      gt.calls.exists(a => a != gt.alleles.ref && a.value.equalsIgnoreCase("A") || a.value.equalsIgnoreCase("T"))
+      gt.calls.iterator.filter(_ != gt.alleles.ref).exists(a => a.value.equalsIgnoreCase("A") || a.value.equalsIgnoreCase("T"))
   }
 
   /** Calculates the p-value and returns it in the map of annotations. */

--- a/src/main/scala/com/fulcrumgenomics/vcf/filtration/EndRepairArtifactLikelihoodFilter.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/filtration/EndRepairArtifactLikelihoodFilter.scala
@@ -26,13 +26,12 @@ package com.fulcrumgenomics.vcf.filtration
 
 import java.lang.Math.{min, pow}
 
-import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.bam.{Bams, BaseEntry, Pileup, PileupEntry}
 import com.fulcrumgenomics.commons.util.LazyLogging
 import com.fulcrumgenomics.util.NumericTypes.{LogProbability => LnProb}
-import htsjdk.samtools.util.SequenceUtil
-import htsjdk.variant.variantcontext.Genotype
-import htsjdk.variant.vcf.{VCFFilterHeaderLine, VCFInfoHeaderLine}
+import com.fulcrumgenomics.util.Sequences
+import com.fulcrumgenomics.vcf.api._
+
 /**
   * Filter that examines SNVs with the alt allele being A or T to see if they are likely the result
   * of aberrant end-repair and A-base addition.
@@ -50,20 +49,20 @@ import htsjdk.variant.vcf.{VCFFilterHeaderLine, VCFInfoHeaderLine}
   */
 class EndRepairArtifactLikelihoodFilter(val distance: Int = 2,
                                         pValueThreshold: Option[Double] = None) extends SomaticVariantFilter with LazyLogging {
-  val InfoKey           = "ERAP"
-  val InfoDescription   = "P-Value for the End-Repair Artifact test."
-  val FilterKey         = "EndRepairArtifact"
-  val FilterDescription = "Variant is likely an artifact caused by end-repair and A-base addition."
 
-  override val VcfInfoLines: Iterable[VCFInfoHeaderLine]     = Seq(vcfInfoLine(InfoKey, InfoDescription))
-  override val VcfFilterLines: Iterable[VCFFilterHeaderLine] = Seq(vcfFilterLine(FilterKey, FilterDescription))
+  /** The INFO header line needed by this filter. */
+  val Info = VcfInfoHeader("ERAP", VcfCount.Fixed(1), VcfFieldType.Float, "P-Value for the End-Repair Artifact test.")
+
+  /** The FILTER header line needed by this filter. */
+  val Filter = VcfFilterHeader("EndRepairArtifact", "Variant is likely an artifact caused by end-repair and A-base addition.")
+
+  override val VcfInfoLines: Iterable[VcfInfoHeader]     = Seq(Info)
+  override val VcfFilterLines: Iterable[VcfFilterHeader] = Seq(Filter)
 
   /** Only applies to het SNVs where the alt allele is A or T. */
   override def appliesTo(gt: Genotype): Boolean = {
-    gt.isHet &&
-      !gt.isHetNonRef &&
-      gt.getAlleles.forall(_.length() == 1) &&
-      gt.getAlleles.filter(_.isNonReference).exists(a => a.getBaseString.equalsIgnoreCase("A") || a.getBaseString.equalsIgnoreCase("T"))
+    gt.isHet && !gt.isHetNonRef && gt.calls.forall(_.value.length == 1) &&
+      gt.calls.exists(a => a != gt.alleles.ref && a.value.equalsIgnoreCase("A") || a.value.equalsIgnoreCase("T"))
   }
 
   /** Calculates the p-value and returns it in the map of annotations. */
@@ -72,9 +71,9 @@ class EndRepairArtifactLikelihoodFilter(val distance: Int = 2,
       Map.empty
     }
     else {
-      val refAllele = SequenceUtil.upperCase(gt.getAlleles.filter(_.isReference).map(_.getBases()(0)).next())
-      val altAllele = SequenceUtil.upperCase(gt.getAlleles.filter(_.isNonReference).map(_.getBases()(0)).next())
-      annotations(pileup, refAllele, altAllele)
+      val refAllele = gt.alleles.ref.value.charAt(0).toUpper
+      val altAllele = gt.calls.filter(_ != gt.alleles.ref).head.value.charAt(0).toUpper
+      annotations(pileup, refAllele.toByte, altAllele.toByte)
     }
   }
 
@@ -122,7 +121,7 @@ class EndRepairArtifactLikelihoodFilter(val distance: Int = 2,
     val pMutation = LnProb.expProb(LnProb.normalizeByLogProbability(llMutation, total))
     val pArtifact = LnProb.expProb(LnProb.normalizeByLogProbability(llArtifact, total))
 
-    Map(InfoKey -> pMutation)
+    Map(Info.id -> pMutation)
   }
 
   /** Calculates a pair of priors:
@@ -202,7 +201,7 @@ class EndRepairArtifactLikelihoodFilter(val distance: Int = 2,
       false
     }
     else {
-      val congruentRef = if (congruentAlt == altAllele) refAllele else SequenceUtil.complement(refAllele)
+      val congruentRef = if (congruentAlt == altAllele) refAllele else Sequences.complement(refAllele)
       entry.baseInReadOrientation == (if (isRef) congruentRef else congruentAlt)
     }
   }
@@ -211,8 +210,8 @@ class EndRepairArtifactLikelihoodFilter(val distance: Int = 2,
     * pvalue is present in the annotations, and c) the pvalue <= threshold.
     */
   override def filters(annotations: Map[String, Any]): Iterable[String] = {
-    (this.pValueThreshold, annotations.get(InfoKey).map(_.asInstanceOf[Double])) match {
-      case (Some(threshold), Some(pvalue)) if pvalue <= threshold => List(FilterKey)
+    (this.pValueThreshold, annotations.get(Info.id).map(_.asInstanceOf[Double])) match {
+      case (Some(threshold), Some(pvalue)) if pvalue <= threshold => List(Filter.id)
       case _ => Nil
     }
   }

--- a/src/main/scala/com/fulcrumgenomics/vcf/filtration/FilterSomaticVcf.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/filtration/FilterSomaticVcf.scala
@@ -153,7 +153,7 @@ class FilterSomaticVcf
             s"""
               |Ignoring read ${e.rec.name} mapped over variant site ${pileup.refName}:${pileup.pos} that has
               |incompatible insert size yielding insert coordinates of ${pileup.refName}:$start-$end which do not overlap the variant.
-            """.stripMargin.trim.lines.mkString(" "))
+            """.stripMargin.trim.linesIterator.mkString(" "))
           false
         }
         else {

--- a/src/main/scala/com/fulcrumgenomics/vcf/filtration/FilterSomaticVcf.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/filtration/FilterSomaticVcf.scala
@@ -126,7 +126,7 @@ class FilterSomaticVcf
           allFilters     ++= f.filters(annotations)
         }
 
-        variant.copy(attrs = ListMap(allAnnotations:_*), filters = allFilters.toSet)
+        variant.copy(attrs = ListMap(allAnnotations.toSeq:_*), filters = allFilters.toSet)
       }
 
       out += variantOut

--- a/src/main/scala/com/fulcrumgenomics/vcf/filtration/FilterSomaticVcf.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/filtration/FilterSomaticVcf.scala
@@ -24,8 +24,6 @@
 
 package com.fulcrumgenomics.vcf.filtration
 
-import java.util.Collections
-
 import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.bam._
 import com.fulcrumgenomics.bam.api.{QueryType, SamSource}
@@ -33,9 +31,9 @@ import com.fulcrumgenomics.cmdline.{ClpGroups, FgBioTool}
 import com.fulcrumgenomics.commons.util.LazyLogging
 import com.fulcrumgenomics.sopt.{arg, clp}
 import com.fulcrumgenomics.util.Io
-import htsjdk.variant.variantcontext.VariantContextBuilder
-import htsjdk.variant.variantcontext.writer.{Options, VariantContextWriter, VariantContextWriterBuilder}
-import htsjdk.variant.vcf._
+import com.fulcrumgenomics.vcf.api.{VcfHeader, VcfSource, VcfWriter}
+
+import scala.collection.immutable.ListMap
 
 @clp(group=ClpGroups.VcfOrBcf, description=
   """
@@ -93,46 +91,45 @@ class FilterSomaticVcf
   Io.assertCanWriteFile(output)
 
   override def execute(): Unit = {
-    val vcfIn = new VCFFileReader(input.toFile, false)
+    val vcfIn = VcfSource(input)
     val bamIn = SamSource(bam)
     val dict  = bamIn.dict
     val vcfSample = sample match {
       case Some(s) =>
-        validate(vcfIn.getFileHeader.getSampleNamesInOrder.contains(s), s"Sample $s not present in VCF.")
+        validate(vcfIn.header.samples.contains(s), s"Sample $s not present in VCF.")
         s
       case None =>
-        if (vcfIn.getFileHeader.getNGenotypeSamples == 1) vcfIn.getFileHeader.getGenotypeSamples.get(0)
+        if (vcfIn.header.samples.size == 1) vcfIn.header.samples.head
         else invalid("Must supply --sample when VCF contains more than one sample.")
     }
 
     val filters = Seq(new EndRepairArtifactLikelihoodFilter(endRepairDistance, endRepairPValue))
     val builder = new PileupBuilder(bamIn.dict, mappedPairsOnly=pairedReadsOnly, minBaseQ=minBaseQuality, minMapQ=minMappingQuality)
-    val out = makeWriter(output, vcfIn.getFileHeader, filters)
+    val out = makeWriter(output, vcfIn.header, filters)
 
-    vcfIn.foreach { ctx =>
-      val gt    = ctx.getGenotype(vcfSample)
-      val chrom = ctx.getContig
-      val pos   = ctx.getStart
+    vcfIn.foreach { variant =>
+      val gt    = variant.genotypes(vcfSample)
       val applicableFilters = filters.filter(_.appliesTo(gt))
 
-      if (applicableFilters.nonEmpty) {
-        val ctxBuilder = new VariantContextBuilder(ctx)
-        val iterator   = bamIn.query(chrom, pos, pos, QueryType.Overlapping)
-        val pileup     = filterPileup(builder.build(iterator, chrom, pos).withoutOverlaps)
+      val variantOut = if (applicableFilters.isEmpty) variant else {
+        val iterator = bamIn.query(variant.chrom, variant.pos, variant.pos, QueryType.Overlapping)
+        val pileup   = filterPileup(builder.build(iterator, variant.chrom, variant.pos).withoutOverlaps)
         iterator.close()
+
+        val allAnnotations = variant.attrs.toBuffer
+        val allFilters     = variant.filters.toBuffer
 
         applicableFilters.foreach { f =>
           // Generate the set of annotations, push them into the ctxBuilder, then also add any filters to the ctxBuilder
           val annotations = f.annotations(pileup, gt)
-          annotations.foreach { case (key, value) => ctxBuilder.attribute(key, value) }
-          f.filters(annotations).foreach(ctxBuilder.filter)
+          allAnnotations ++= annotations
+          allFilters     ++= f.filters(annotations)
         }
 
-        out.add(ctxBuilder.make())
+        variant.copy(attrs = ListMap(allAnnotations:_*), filters = allFilters.toSet)
       }
-      else {
-        out.add(ctx)
-      }
+
+      out += variantOut
     }
 
     out.close()
@@ -169,27 +166,12 @@ class FilterSomaticVcf
   }
 
   /** Builds a VCF writer that had all the necessary headers. */
-  private def makeWriter(output: PathToVcf, in: VCFHeader, filters: Seq[SomaticVariantFilter]): VariantContextWriter = {
-    val header = new VCFHeader(Collections.emptySet[VCFHeaderLine](), in.getSampleNamesInOrder)
+  private def makeWriter(output: PathToVcf, in: VcfHeader, filters: Seq[SomaticVariantFilter]): VcfWriter = {
+    val header = in.copy(
+      filters = (in.filters ++ filters.flatMap(_.VcfFilterLines)).distinct,
+      infos   = (in.infos   ++ filters.flatMap(_.VcfInfoLines)).distinct
+    )
 
-    in.getFilterLines.foreach(header.addMetaDataLine)
-    in.getFormatHeaderLines.foreach(header.addMetaDataLine)
-    in.getInfoHeaderLines.foreach(header.addMetaDataLine)
-    filters.foreach { f =>
-      f.VcfInfoLines.foreach(header.addMetaDataLine)
-      f.VcfFilterLines.foreach(header.addMetaDataLine)
-    }
-
-    Option(in.getSequenceDictionary).foreach(header.setSequenceDictionary)
-
-    val writer = new VariantContextWriterBuilder()
-      .setOutputFile(output.toFile)
-      .setOption(Options.INDEX_ON_THE_FLY)
-      .setOption(Options.ALLOW_MISSING_FIELDS_IN_HEADER)
-      .setReferenceDictionary(in.getSequenceDictionary)
-      .build()
-
-    writer.writeHeader(header)
-    writer
+    VcfWriter(output, header)
   }
 }

--- a/src/main/scala/com/fulcrumgenomics/vcf/filtration/SomaticVariantFilter.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/filtration/SomaticVariantFilter.scala
@@ -34,10 +34,10 @@ import htsjdk.variant.vcf.{VCFFilterHeaderLine, VCFHeaderLineType, VCFInfoHeader
   */
 trait SomaticVariantFilter {
   /** The collection of VCF INFO header lines that the filter may reference. */
-  val VcfInfoLines: Traversable[VCFInfoHeaderLine]
+  val VcfInfoLines: Iterable[VCFInfoHeaderLine]
 
   /** The collection of VCF Filter header lines that the filter may reference. */
-  val VcfFilterLines: Traversable[VCFFilterHeaderLine]
+  val VcfFilterLines: Iterable[VCFFilterHeaderLine]
 
   /** Helper method to construct an INFO header line. */
   protected def vcfInfoLine(name: String, description: String, count: Int = 1, vcfType: VCFHeaderLineType = VCFHeaderLineType.Float) = {
@@ -56,5 +56,5 @@ trait SomaticVariantFilter {
   /** Given the set of annotations calculated by [[annotations]] determine the set of filters
     * to be applied to the VCF record.
     */
-  def filters(annotations: Map[String, Any]): Traversable[String]
+  def filters(annotations: Map[String, Any]): Iterable[String]
 }

--- a/src/main/scala/com/fulcrumgenomics/vcf/filtration/SomaticVariantFilter.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/filtration/SomaticVariantFilter.scala
@@ -25,8 +25,7 @@
 package com.fulcrumgenomics.vcf.filtration
 
 import com.fulcrumgenomics.bam.{Pileup, PileupEntry}
-import htsjdk.variant.variantcontext.Genotype
-import htsjdk.variant.vcf.{VCFFilterHeaderLine, VCFHeaderLineType, VCFInfoHeaderLine}
+import com.fulcrumgenomics.vcf.api.{VcfFilterHeader, VcfInfoHeader, Genotype}
 
 /**
   * Trait for classes that can compute annotations on a somatic variant call and optionally
@@ -34,18 +33,10 @@ import htsjdk.variant.vcf.{VCFFilterHeaderLine, VCFHeaderLineType, VCFInfoHeader
   */
 trait SomaticVariantFilter {
   /** The collection of VCF INFO header lines that the filter may reference. */
-  val VcfInfoLines: Iterable[VCFInfoHeaderLine]
+  val VcfInfoLines: Iterable[VcfInfoHeader]
 
   /** The collection of VCF Filter header lines that the filter may reference. */
-  val VcfFilterLines: Iterable[VCFFilterHeaderLine]
-
-  /** Helper method to construct an INFO header line. */
-  protected def vcfInfoLine(name: String, description: String, count: Int = 1, vcfType: VCFHeaderLineType = VCFHeaderLineType.Float) = {
-    new VCFInfoHeaderLine(name, count, vcfType, description)
-  }
-
-  /** Helper method to construct a filter header line. */
-  protected def vcfFilterLine(name: String, description: String) = new VCFFilterHeaderLine(name, description)
+  val VcfFilterLines: Iterable[VcfFilterHeader]
 
   /** Returns true if the filter can be applied to a genotype, false otherwise. */
   def appliesTo(gt: Genotype): Boolean

--- a/src/test/scala/com/fulcrumgenomics/alignment/AlignmentTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/alignment/AlignmentTest.scala
@@ -130,7 +130,7 @@ class AlignmentTest extends UnitSpec {
       +AACCGGTT
       +||||||||
       +AACCGGTT
-       """.stripMargin('+').trim.lines.toSeq
+       """.stripMargin('+').trim.linesIterator.toSeq
 
     val alignment = Alignment(expected.head.replace("-", ""), expected.last.replace("-", ""), 1, 1, Cigar("8M"), 1)
     alignment.paddedString() shouldBe expected
@@ -142,7 +142,7 @@ class AlignmentTest extends UnitSpec {
       +AACCGGTT
       +||||||.|
       +AACCGGGT
-       """.stripMargin('+').trim.lines.toSeq
+       """.stripMargin('+').trim.linesIterator.toSeq
 
     Seq("8M", "6=1X2=").foreach { cigar =>
       val alignment = Alignment(expected.head.replace("-", ""), expected.last.replace("-", ""), 1, 1, Cigar("8M"), 1)
@@ -156,7 +156,7 @@ class AlignmentTest extends UnitSpec {
       +AA--GGGTAAACC-GGGTTT
       +||  ||||||||| || |||
       +AACCGGGTAAACCCGG-TTT
-       """.stripMargin('+').trim.lines.toSeq
+       """.stripMargin('+').trim.linesIterator.toSeq
 
     val alignment = Alignment(expected.head.replace("-", ""), expected.last.replace("-", ""), 1, 1, Cigar("2=2D9=1D2=1I3="), 1)
     alignment.paddedString() shouldBe expected
@@ -168,7 +168,7 @@ class AlignmentTest extends UnitSpec {
       +AA--GGGGGAACC-GGGTTT
       +||  |||..|||| || |||
       +AACCGGGTAAACCCGG-TTT
-       """.stripMargin('+').trim.lines.toSeq
+       """.stripMargin('+').trim.linesIterator.toSeq
 
     val alignment = Alignment(expected.head.replace("-", ""), expected.last.replace("-", ""), 1, 1, Cigar("2M2D9M1D2M1I3M"), 1)
     alignment.paddedString() shouldBe expected
@@ -188,7 +188,7 @@ class AlignmentTest extends UnitSpec {
       |AA..GGGGGAACC.GGGTTT
       |++--+++##++++-++-+++
       |AACCGGGTAAACCCGG.TTT
-       """.stripMargin.trim.lines.toSeq
+       """.stripMargin.trim.linesIterator.toSeq
 
     val alignment = Alignment(expected.head.replace(".", ""), expected.last.replace(".", ""), 1, 1, Cigar("2M2D9M1D2M1I3M"), 1)
     alignment.paddedString(matchChar='+', mismatchChar='#', gapChar='-', padChar='.') shouldBe expected

--- a/src/test/scala/com/fulcrumgenomics/bam/BamsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/BamsTest.scala
@@ -26,6 +26,7 @@ package com.fulcrumgenomics.bam
 
 import java.util
 
+import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.alignment.Cigar
 import com.fulcrumgenomics.bam.api.{SamOrder, SamRecord}
 import com.fulcrumgenomics.testing.SamBuilder.{Minus, Plus}
@@ -96,10 +97,10 @@ class BamsTest extends UnitSpec {
     templates.map(_.name) shouldBe Seq("f1", "p0", "p1", "p2")
 
     templates.foreach {t =>
-      (t.r1Supplementals ++ t.r1Secondaries ++ t.r2Supplementals ++ t.r2Secondaries) shouldBe 'empty
+      (t.r1Supplementals ++ t.r1Secondaries ++ t.r2Supplementals ++ t.r2Secondaries).isEmpty shouldBe true
       if (t.name startsWith "f") {
         t.r1.exists(r => !r.paired) shouldBe true
-        t.r2 shouldBe 'empty
+        t.r2.isEmpty shouldBe true
       }
       else {
         t.r1.exists(r => r.firstOfPair) shouldBe true

--- a/src/test/scala/com/fulcrumgenomics/bam/ClipBamTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/ClipBamTest.scala
@@ -454,7 +454,7 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
 
       val out     = makeTempFile("out.", ".bam")
       val metrics = makeTempFile("out.", ".txt")
-      new ClipBam(input=builder.toTempFile(), output=out, metrics=Some(metrics), ref=ref, clippingMode=Some(mode), upgradeClipping=true).execute()
+      new ClipBam(input=builder.toTempFile(), output=out, metrics=Some(metrics), ref=ref, clippingMode=mode, upgradeClipping=true).execute()
       val clipped = SamSource(out).toSeq
 
       clipped.length shouldBe 2
@@ -494,7 +494,7 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
 
       val out     = makeTempFile("out.", ".bam")
       val metrics = makeTempFile("out.", ".txt")
-      new ClipBam(input=builder.toTempFile(), output=out, metrics=Some(metrics), ref=ref, clippingMode=Some(mode), upgradeClipping=true).execute()
+      new ClipBam(input=builder.toTempFile(), output=out, metrics=Some(metrics), ref=ref, clippingMode=mode, upgradeClipping=true).execute()
       val clipped = SamSource(out).toSeq
 
       clipped.length shouldBe 2

--- a/src/test/scala/com/fulcrumgenomics/bam/ErrorRateByReadPositionTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/ErrorRateByReadPositionTest.scala
@@ -187,7 +187,7 @@ class ErrorRateByReadPositionTest extends UnitSpec {
     }
 
     if (Rscript.Available) {
-      val plot = PathUtil.pathTo(pre + ErrorRateByReadPositionMetric.PlotExtension)
+      val plot = PathUtil.pathTo(s"${pre}${ErrorRateByReadPositionMetric.PlotExtension}")
       Files.exists(plot) shouldBe true
     }
   }

--- a/src/test/scala/com/fulcrumgenomics/bam/EstimatePoolingFractionsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/EstimatePoolingFractionsTest.scala
@@ -51,7 +51,7 @@ class EstimatePoolingFractionsTest extends UnitSpec with ParallelTestExecution {
     readers.zipWithIndex.foreach { case (reader, index) =>
         reader.header.getReadGroups.foreach(rg => rg.setLibrary(rg.getLibrary + ":" + index))
     }
-    val headerMerger = new SamFileHeaderMerger(SortOrder.coordinate, readers.map(_.header).asJava, false)
+    val headerMerger = new SamFileHeaderMerger(SortOrder.coordinate, readers.iterator.map(_.header).toJavaList, false)
     val iterator     = new MergingSamRecordIterator(headerMerger, readers.iterator.map(_.toSamReader).toJavaList, true)
 
     val output = makeTempFile("merged.", ".bam")

--- a/src/test/scala/com/fulcrumgenomics/bam/FindSwitchbackReadsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/FindSwitchbackReadsTest.scala
@@ -84,7 +84,7 @@ class FindSwitchbackReadsTest extends UnitSpec with OptionValues {
       |TTCTCAGCTCAAGATTCGTCTGGTCTTTCCCTACAGCTTTGTGTGTGCCATGGCCACATCTCCTGGGTAC
       |AGTTCAAGGAGACATCTTTTCTAAAAGGGTCTGCGTGATCATTAAAATATAATCAAATGTAAAAAAAAAA
       |AAAAAAAA
-    """.stripMargin.lines.foreach(seq.add(_))
+    """.stripMargin.linesIterator.foreach(seq.add(_))
 
     builder.add("chr2").add("ACGTACGT", 100)
 
@@ -313,7 +313,7 @@ class FindSwitchbackReadsTest extends UnitSpec with OptionValues {
       }
     }
 
-    val ms = Metric.read[SwitchMetric](PathUtil.pathTo(metricBase + ".summary.txt")).head
+    val ms = Metric.read[SwitchMetric](PathUtil.pathTo(s"${metricBase}.summary.txt")).head
     ms.sample                   shouldBe "switchback_sample"
     ms.library                  shouldBe "switchback_library"
     ms.templates                shouldBe 20+1+6+5+2

--- a/src/test/scala/com/fulcrumgenomics/bam/UpdateReadGroupsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/UpdateReadGroupsTest.scala
@@ -44,7 +44,7 @@ class UpdateReadGroupsTest extends UnitSpec {
   private val builderOne   = new SamBuilder(sort=Some(SamOrder.Coordinate), readGroupId=Some("IDA"))
   private val builderTwo   = new SamBuilder(sort=Some(SamOrder.Coordinate), readGroupId=Some("IDB"))
 
-  Stream(builderOne, builderTwo).foreach { builder =>
+  Iterator(builderOne, builderTwo).foreach { builder =>
     builder.addPair("ok_1" + builder.readGroupId.get, contig=0, start1=100, start2=300)
     builder.addPair("ok_2" + builder.readGroupId.get, contig=0, start1=200, start2=400)
     builder.header.getReadGroups.foreach { rg => rg.setDescription("Description") }
@@ -86,7 +86,7 @@ class UpdateReadGroupsTest extends UnitSpec {
   def mergeToTempFile(builder: SamBuilder*): PathToBam = {
     val path = Files.createTempFile("SamRecordSet.", ".bam")
     path.toFile.deleteOnExit()
-    val merger = new SamFileHeaderMerger(SortOrder.coordinate, builder.map(_.header).asJava, false)
+    val merger = new SamFileHeaderMerger(SortOrder.coordinate, builder.iterator.map(_.header).toJavaList, false)
     val header = merger.getMergedHeader
     merger.hasReadGroupCollisions shouldBe false
     val writer = SamWriter(path, header, sort=Some(SamOrder.Coordinate))

--- a/src/test/scala/com/fulcrumgenomics/bam/api/SamOrderTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/api/SamOrderTest.scala
@@ -132,7 +132,7 @@ class SamOrderTest extends UnitSpec {
     val iter = recs.iterator.bufferBetter
     while (iter.hasNext) {
       val name = iter.head.name
-      val remaining = iter.takeWhile(_.name == name).foreach { r => Unit }
+      val remaining = iter.takeWhile(_.name == name).foreach { r => () }
       counts.count(name)
     }
 
@@ -151,7 +151,7 @@ class SamOrderTest extends UnitSpec {
       b => b.addPair(name="ba3", start1=100, start2=100, strand1=Minus, strand2=Plus, attrs=Map("MI" -> "2/B"), bases1="AAAAAAAAAA", bases2="AAAAAAAAAA")
     )
 
-    def seq(n: Int, str: String): Seq[String] = Array.fill[String](n)(str)
+    def seq(n: Int, str: String): Seq[String] = IndexedSeq.fill[String](n)(str)
 
     Range.inclusive(start=1, end=10).foreach { _ =>
       val builder = new SamBuilder(readLength=10)

--- a/src/test/scala/com/fulcrumgenomics/bam/api/SamRecordTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/api/SamRecordTest.scala
@@ -114,11 +114,11 @@ class SamRecordTest extends UnitSpec with OptionValues {
 
     // apply
     rec[Int]("ax") shouldBe 10
-    Option(rec[Int]("bx")) shouldBe 'empty
+    Option(rec[Int]("bx")).isEmpty shouldBe true
 
     // get
     rec.get[Int]("ax").value shouldBe 10
-    rec.get[Int]("bx") shouldBe 'empty
+    rec.get[Int]("bx").isEmpty shouldBe true
 
     // attributes
     rec.attributes.toList should contain theSameElementsAs Seq(("RG", "A"), ("ax", 10))

--- a/src/test/scala/com/fulcrumgenomics/basecalling/ExtractBasecallingParamsForPicardTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/basecalling/ExtractBasecallingParamsForPicardTest.scala
@@ -117,7 +117,7 @@ class ExtractBasecallingParamsForPicardTest extends UnitSpec with ErrorLogLevel 
 
 
   "BasecallingParams.from" should "extract params from a single-index sequencing run" in {
-    val sampleSheet = SampleSheet(singleIndexSampleSheet.toIterator, lane=None)
+    val sampleSheet = SampleSheet(singleIndexSampleSheet.iterator, lane=None)
     val params = BasecallingParams.from(sampleSheet=sampleSheet, lanes=Seq(1), output=outputDir)
     params should have size 1
     val param = params.head
@@ -140,7 +140,7 @@ class ExtractBasecallingParamsForPicardTest extends UnitSpec with ErrorLogLevel 
   }
 
   it should "extract params for multiple lanes from a sequencing run" in {
-    val sampleSheet = SampleSheet(singleIndexSampleSheet.toIterator, lane=None)
+    val sampleSheet = SampleSheet(singleIndexSampleSheet.iterator, lane=None)
     val params = BasecallingParams.from(sampleSheet=sampleSheet, lanes=Seq(1, 2, 4), output=outputDir)
     params should have size 3
     val param = params.last
@@ -163,7 +163,7 @@ class ExtractBasecallingParamsForPicardTest extends UnitSpec with ErrorLogLevel 
   }
 
   it should "extract params from a dual-indexed sequencing run" in {
-    val sampleSheet = SampleSheet(dualIndexedSampleSheet.toIterator, lane=None)
+    val sampleSheet = SampleSheet(dualIndexedSampleSheet.iterator, lane=None)
     val params = BasecallingParams.from(sampleSheet=sampleSheet, lanes=Seq(1), output=outputDir)
     params should have size 1
     val param = params.head
@@ -186,7 +186,7 @@ class ExtractBasecallingParamsForPicardTest extends UnitSpec with ErrorLogLevel 
   }
 
   it should "exclude the description if the project and description are not defined on all samples" in {
-    val sampleSheet = SampleSheet(dualIndexedSampleSheetNoProjectOrDescription.toIterator, lane=None)
+    val sampleSheet = SampleSheet(dualIndexedSampleSheetNoProjectOrDescription.iterator, lane=None)
     val params = BasecallingParams.from(sampleSheet=sampleSheet, lanes=Seq(1), output=outputDir)
     params should have size 1
     val param = params.head

--- a/src/test/scala/com/fulcrumgenomics/cmdline/IntelCompressionTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/cmdline/IntelCompressionTest.scala
@@ -110,7 +110,7 @@ class IntelCompressionTest extends UnitSpec {
           val is    = new BlockCompressedInputStream(output.toFile, factory)
           val codec = new BAMRecordCodec(header)
           codec.setInputStream(is, testBam.toFile.toString)
-          while (null != codec.decode()) { Unit }
+          while (null != codec.decode()) { () }
           is.close()
         }
         val endTime = System.currentTimeMillis()

--- a/src/test/scala/com/fulcrumgenomics/fastq/DemuxFastqsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/fastq/DemuxFastqsTest.scala
@@ -122,7 +122,7 @@ class DemuxFastqsTest extends UnitSpec with OptionValues with ErrorLogLevel {
     record.quals shouldBe "I"*100
     record.pairedEnd shouldBe false
     demuxRecord.sampleInfo.isUnmatched shouldBe true
-    record.molecularBarcode shouldBe 'empty
+    record.molecularBarcode.isEmpty shouldBe true
   }
 
   private def outputDir(): DirPath = {
@@ -143,7 +143,7 @@ class DemuxFastqsTest extends UnitSpec with OptionValues with ErrorLogLevel {
     record.bases shouldBe "A"*100
     record.quals shouldBe "I"*100
     record.pairedEnd shouldBe false
-    record.molecularBarcode shouldBe 'empty
+    record.molecularBarcode.isEmpty shouldBe true
   }
 
   it should "demux paired reads with in-line sample barcodes" in {
@@ -161,14 +161,14 @@ class DemuxFastqsTest extends UnitSpec with OptionValues with ErrorLogLevel {
     r1.quals shouldBe "I"*100
     r1.pairedEnd shouldBe true
     r1.readNumber shouldBe 1
-    r1.molecularBarcode shouldBe 'empty
+    r1.molecularBarcode.isEmpty shouldBe true
 
     r2.name shouldBe "pair"
     r2.bases shouldBe "T"*100
     r2.quals shouldBe "I"*100
     r2.pairedEnd shouldBe true
     r2.readNumber shouldBe 2
-    r2.molecularBarcode shouldBe 'empty
+    r2.molecularBarcode.isEmpty shouldBe true
   }
 
   it should "demux dual-indexed paired end reads" in {
@@ -189,14 +189,14 @@ class DemuxFastqsTest extends UnitSpec with OptionValues with ErrorLogLevel {
     r1.pairedEnd shouldBe true
     r1.pairedEnd shouldBe true
     r1.readNumber shouldBe 1
-    r1.molecularBarcode shouldBe 'empty
+    r1.molecularBarcode.isEmpty shouldBe true
 
     r2.name shouldBe "pair"
     r2.bases shouldBe "T"*100
     r2.quals shouldBe "I"*100
     r2.pairedEnd shouldBe true
     r2.readNumber shouldBe 2
-    r2.molecularBarcode shouldBe 'empty
+    r2.molecularBarcode.isEmpty shouldBe true
   }
 
   it should "demux a very weird set of reads" in {
@@ -240,7 +240,7 @@ class DemuxFastqsTest extends UnitSpec with OptionValues with ErrorLogLevel {
     record.bases shouldBe "A"*60
     record.quals shouldBe "I"*60
     record.pairedEnd shouldBe false
-    record.molecularBarcode shouldBe 'empty
+    record.molecularBarcode.isEmpty shouldBe true
   }
 
   it should "fail if zero or more than two read structures have template bases" in {
@@ -460,18 +460,18 @@ class DemuxFastqsTest extends UnitSpec with OptionValues with ErrorLogLevel {
                 sampleBarcodes should contain theSameElementsInOrderAs Seq("AAAAAAAAGATTACTTT", "GGGGGGTTGATTACAGA", "AAAAAAAAGANNNNNNN") // NB: raw not assigned
               }
               else {
-                names shouldBe 'empty
+                names.isEmpty shouldBe true
                 sampleBarcodes.isEmpty shouldBe true
               }
             }
 
             if (outputType.producesFastq) {
-              val fastq = PathUtil.pathTo(prefix + ".fastq.gz")
+              val fastq = PathUtil.pathTo(s"${prefix}.fastq.gz")
               val records = FastqSource(fastq).toSeq
               checkOutput(records.map(_.name.replaceAll(":.*", "")), records.map(_.name.replaceAll(".*:", "")))
             }
             if (outputType.producesBam) {
-              val bam = PathUtil.pathTo(prefix + ".bam")
+              val bam = PathUtil.pathTo(s"${prefix}.bam")
               val records = readBamRecs(bam)
               checkOutput(records.map(_.name), records.map(_[String]("BC")))
             }
@@ -555,11 +555,11 @@ class DemuxFastqsTest extends UnitSpec with OptionValues with ErrorLogLevel {
         }
 
         val headersR1 = {
-          val fastq = PathUtil.pathTo(prefix + extensions.head)
+          val fastq = PathUtil.pathTo(s"${prefix}${extensions.head}")
           FastqSource(fastq).toSeq.map(toHeader).toList
         }
         val headersR2 = {
-          val fastq = PathUtil.pathTo(prefix + extensions.last)
+          val fastq = PathUtil.pathTo(s"${prefix}${extensions.last}")
           FastqSource(fastq).toSeq.map(toHeader).toList
         }
 
@@ -576,7 +576,7 @@ class DemuxFastqsTest extends UnitSpec with OptionValues with ErrorLogLevel {
           else headersR1 should contain theSameElementsInOrderAs Seq("AAAAAAAAGATTACTTT", sampleBarcode4, "AAAAAAAAGANNNNNNN")
         }
         else {
-          headersR1 shouldBe 'empty
+          headersR1.isEmpty shouldBe true
         }
       }
     }
@@ -743,13 +743,13 @@ class DemuxFastqsTest extends UnitSpec with OptionValues with ErrorLogLevel {
 
     val extensions = FastqRecordWriter.extensions(pairedEnd=true, illuminaStandards=false)
     def fastqRecord(which: Int): FastqRecord = {
-      val path = PathUtil.pathTo(prefix + extensions(which-1))
+      val path = PathUtil.pathTo(s"${prefix}${extensions(which-1)}")
       FastqSource(path).toSeq.headOption.value
     }
 
     val fastqR1    = fastqRecord(1)
     val fastqR2    = fastqRecord(2)
-    val records    = readBamRecs(output.resolve(prefix + ".bam"))
+    val records    = readBamRecs(output.resolve(s"${prefix}.bam"))
     val recR1      = records.find(_.firstOfPair).value
     val recR2      = records.find(_.secondOfPair).value
 

--- a/src/test/scala/com/fulcrumgenomics/fastq/FastqIoTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/fastq/FastqIoTest.scala
@@ -41,7 +41,7 @@ object FastqIoTest {
       |CCCCCCCTCCTTGGGGGGGAGAGGG
       |+Foo:279:000000000-ABCDE:1:1101:9471:1291/1 1:N:0:18
       |AAA,,++78,66AAA,,++78,666
-    """.stripMargin.trim().lines.toSeq.dropWhile(_.isEmpty)
+    """.stripMargin.trim().linesIterator.toSeq.dropWhile(_.isEmpty)
 
   val someFastqRecords = Seq(
     FastqRecord("Foo:279:000000000-ABCDE:1:1101:15033:1749", "ATGACTGCGTATATATGACGTCGTGCTA", "-,86,,;:C,<;-,86,,;:C,<;-,86", Some("1:N:0:18"), None),

--- a/src/test/scala/com/fulcrumgenomics/fastq/QualityEncodingTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/fastq/QualityEncodingTest.scala
@@ -97,7 +97,7 @@ class QualityEncodingTest extends UnitSpec {
       |ACC9<D@;8@FEEF>FEG@,8E8,,,,,,;,CEFF88,,CF8,C,,+CF89,88E9,C9FF,,CE8,,CEEGG9C
       |-<BCCGGGFCAC<<<,CE<FF8@E<<,,,B88E@F<9;9E<FFFDEC8E8FFFGG8E,,,@@@88CE8E,,,C9<
       |-A<9@F@EGGFGF<FF9EC,++F7:+CFFFGGFFGCFFFCFGGGA8F<7F,6C++@F7F89C@@BFG9=C+=FE,
-    """.stripMargin.trim.lines
+    """.stripMargin.trim.linesIterator
 
     val detector = new QualityEncodingDetector
     detector.sample(qualStrings)

--- a/src/test/scala/com/fulcrumgenomics/illumina/SampleSheetTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/illumina/SampleSheetTest.scala
@@ -72,7 +72,7 @@ class SampleSheetTest extends FlatSpec with Matchers with OptionValues {
       sampleSheet.foreach { sample => sample.lane.value shouldBe lane }
       sampleSheet.size shouldBe 4
     }
-    SampleSheet(testDir.resolve("SampleSheet.lanes.csv"), lane=Some(4)) shouldBe 'empty
+    SampleSheet(testDir.resolve("SampleSheet.lanes.csv"), lane=Some(4)).isEmpty shouldBe true
     SampleSheet(testDir.resolve("SampleSheet.lanes.csv"), lane=None).size shouldBe 12
   }
 

--- a/src/test/scala/com/fulcrumgenomics/illumina/SampleTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/illumina/SampleTest.scala
@@ -34,7 +34,7 @@ import org.scalatest.OptionValues
 class SampleTest extends UnitSpec with OptionValues{
 
   "Sample.sampleBarcodeBases" should "return the sample barcodes if present" in {
-    new Sample(0, "ID", "NAME", "LIBRARY").sampleBarcodeBases.flatten shouldBe 'empty
+    new Sample(0, "ID", "NAME", "LIBRARY").sampleBarcodeBases.flatten.isEmpty shouldBe true
     new Sample(0, "ID", "NAME", "LIBRARY", i7IndexBases=Some("GATTACA")).sampleBarcodeBases.flatten should contain theSameElementsInOrderAs Seq("GATTACA")
     new Sample(0, "ID", "NAME", "LIBRARY", i5IndexBases=Some("GATTACA")).sampleBarcodeBases.flatten should contain theSameElementsInOrderAs Seq("GATTACA")
     new Sample(0, "ID", "NAME", "LIBRARY", i7IndexBases=Some("GATTACA"), i5IndexBases=Some("TGTAATC")).sampleBarcodeBases.flatten should contain theSameElementsInOrderAs Seq("GATTACA", "TGTAATC")
@@ -48,12 +48,12 @@ class SampleTest extends UnitSpec with OptionValues{
     sample.extendedAttribute("bar").value shouldBe "2"
     sample.extendedAttribute("Bar").value shouldBe "2"
     sample.extendedAttribute("BAR").value shouldBe "2"
-    sample.extendedAttribute("baz") shouldBe 'empty
-    sample.extendedAttribute("Baz") shouldBe 'empty
-    sample.extendedAttribute("BAZ") shouldBe 'empty
-    sample.extendedAttribute("car") shouldBe 'empty
-    sample.extendedAttribute("Car") shouldBe 'empty
-    sample.extendedAttribute("CAR") shouldBe 'empty
+    sample.extendedAttribute("baz").isEmpty shouldBe true
+    sample.extendedAttribute("Baz").isEmpty shouldBe true
+    sample.extendedAttribute("BAZ").isEmpty shouldBe true
+    sample.extendedAttribute("car").isEmpty shouldBe true
+    sample.extendedAttribute("Car").isEmpty shouldBe true
+    sample.extendedAttribute("CAR").isEmpty shouldBe true
   }
 
   it should "support throw an exception if extended attribute keys are not all uppercase" in {

--- a/src/test/scala/com/fulcrumgenomics/rnaseq/CollectErccMetricsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/rnaseq/CollectErccMetricsTest.scala
@@ -88,7 +88,7 @@ class CollectErccMetricsTest extends UnitSpec with OptionValues {
 
   object Outputs {
     def apply(prefix: PathPrefix): Outputs = {
-      def f(ext: String): FilePath = PathUtil.pathTo(prefix + ext)
+      def f(ext: String): FilePath = PathUtil.pathTo(s"${prefix}${ext}")
       Outputs(
         summaryPath  = f(".ercc_summary_metrics.txt"),
         detailedPath = f(".ercc_detailed_metrics.txt"),
@@ -191,8 +191,8 @@ class CollectErccMetricsTest extends UnitSpec with OptionValues {
       metrics.head.total_reads shouldBe 2
       metrics.head.ercc_reads shouldBe 2
       metrics.head.ercc_templates shouldBe 1
-      metrics.head.pearsons_correlation shouldBe 'empty
-      metrics.head.slope shouldBe 'empty
+      metrics.head.pearsons_correlation.isEmpty shouldBe true
+      metrics.head.slope.isEmpty shouldBe true
       Files.exists(outputs.plotPath) shouldBe false
     }
 

--- a/src/test/scala/com/fulcrumgenomics/rnaseq/EstimateRnaSeqInsertSizeTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/rnaseq/EstimateRnaSeqInsertSizeTest.scala
@@ -129,16 +129,16 @@ class EstimateRnaSeqInsertSizeTest extends UnitSpec with OptionValues {
     ///////////////////////////////////////////////////////
 
     // too far left
-    builder.addPair(start1=9, start2=16, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.0) shouldBe 'empty }
-    builder.addPair(start1=16, start2=9, strand1=Minus, strand2=Plus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.0) shouldBe 'empty }
-    builder.addPair(start1=9, start2=16, strand1=Plus, strand2=Plus)   foreach { rec => testInsertSizeFromGene(rec, gene, 0.0) shouldBe 'empty }
-    builder.addPair(start1=16, start2=9, strand1=Minus, strand2=Minus) foreach { rec => testInsertSizeFromGene(rec, gene, 0.0) shouldBe 'empty }
+    builder.addPair(start1=9, start2=16, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.0).isEmpty shouldBe true }
+    builder.addPair(start1=16, start2=9, strand1=Minus, strand2=Plus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.0).isEmpty shouldBe true }
+    builder.addPair(start1=9, start2=16, strand1=Plus, strand2=Plus)   foreach { rec => testInsertSizeFromGene(rec, gene, 0.0).isEmpty shouldBe true }
+    builder.addPair(start1=16, start2=9, strand1=Minus, strand2=Minus) foreach { rec => testInsertSizeFromGene(rec, gene, 0.0).isEmpty shouldBe true }
 
     // too far right
-    builder.addPair(start1=10, start2=17, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.0) shouldBe 'empty }
-    builder.addPair(start1=17, start2=10, strand1=Minus, strand2=Plus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.0) shouldBe 'empty }
-    builder.addPair(start1=10, start2=17, strand1=Plus, strand2=Plus)   foreach { rec => testInsertSizeFromGene(rec, gene, 0.0) shouldBe 'empty }
-    builder.addPair(start1=17, start2=10, strand1=Minus, strand2=Minus) foreach { rec => testInsertSizeFromGene(rec, gene, 0.0) shouldBe 'empty }
+    builder.addPair(start1=10, start2=17, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.0).isEmpty shouldBe true }
+    builder.addPair(start1=17, start2=10, strand1=Minus, strand2=Plus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.0).isEmpty shouldBe true }
+    builder.addPair(start1=10, start2=17, strand1=Plus, strand2=Plus)   foreach { rec => testInsertSizeFromGene(rec, gene, 0.0).isEmpty shouldBe true }
+    builder.addPair(start1=17, start2=10, strand1=Minus, strand2=Minus) foreach { rec => testInsertSizeFromGene(rec, gene, 0.0).isEmpty shouldBe true }
     
     ///////////////////////////////////////////////////////
     // enclosed
@@ -158,9 +158,9 @@ class EstimateRnaSeqInsertSizeTest extends UnitSpec with OptionValues {
 
     builder.addPair(start1=10, start2=16, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.0).value shouldBe 2 }
     builder.addPair(start1=10, start2=16, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.2).value shouldBe 2 }
-    builder.addPair(start1=10, start2=16, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.2001) shouldBe 'empty }
-    builder.addPair(start1=10, start2=16, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.3) shouldBe 'empty }
-    builder.addPair(start1=10, start2=16, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 1.0) shouldBe 'empty }
+    builder.addPair(start1=10, start2=16, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.2001).isEmpty shouldBe true }
+    builder.addPair(start1=10, start2=16, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.3).isEmpty shouldBe true }
+    builder.addPair(start1=10, start2=16, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 1.0).isEmpty shouldBe true }
   }
 
   it should "not return a value if the insert size disagrees across two transcripts" in {
@@ -169,7 +169,7 @@ class EstimateRnaSeqInsertSizeTest extends UnitSpec with OptionValues {
     val gene        = Gene(contig="chr1", start=10, end=20, negativeStrand=false, name="", transcripts=Seq(transcriptA, transcriptB))
     val builder     = new SamBuilder(readLength=5)
 
-    builder.addPair(start1=10, start2=16, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.0) shouldBe 'empty }
+    builder.addPair(start1=10, start2=16, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.0).isEmpty shouldBe true }
   }
 
   private val RefFlatFile = {
@@ -208,7 +208,7 @@ class EstimateRnaSeqInsertSizeTest extends UnitSpec with OptionValues {
     builder.addPair(contig=2, start1=133801672, start2=133804074, strand1=Plus, strand2=Plus) // overlaps ACKR4 by 100%
 
     val bam = builder.toTempFile()
-    val out = PathUtil.pathTo(PathUtil.removeExtension(bam) + EstimateRnaSeqInsertSize.RnaSeqInsertSizeMetricExtension)
+    val out = PathUtil.pathTo(PathUtil.removeExtension(bam).toString + EstimateRnaSeqInsertSize.RnaSeqInsertSizeMetricExtension)
     new EstimateRnaSeqInsertSize(input=bam, refFlat=RefFlatFile).execute()
     val metrics = Metric.read[InsertSizeMetric](path=out)
     metrics.length shouldBe PairOrientation.values().length
@@ -250,7 +250,7 @@ class EstimateRnaSeqInsertSizeTest extends UnitSpec with OptionValues {
       actual shouldBe expected
     }
 
-    val histogramPath = PathUtil.pathTo(PathUtil.removeExtension(bam) + EstimateRnaSeqInsertSize.RnaSeqInsertSizeMetricHistogramExtension)
+    val histogramPath = PathUtil.pathTo(PathUtil.removeExtension(bam).toString + EstimateRnaSeqInsertSize.RnaSeqInsertSizeMetricHistogramExtension)
     Io.readLines(path=histogramPath).mkString("\n") shouldBe
       """
         |insert_size	fr	rf	tandem
@@ -273,7 +273,7 @@ class EstimateRnaSeqInsertSizeTest extends UnitSpec with OptionValues {
     val builder = new SamBuilder()
     builder.addPair(contig=3, start1=133801671, start2=133801671) // overlaps ACKR4-4-1 and ACKR4-4-2
     val bam = builder.toTempFile()
-    val out = PathUtil.pathTo(PathUtil.removeExtension(bam) + EstimateRnaSeqInsertSize.RnaSeqInsertSizeMetricExtension)
+    val out = PathUtil.pathTo(PathUtil.removeExtension(bam).toString + EstimateRnaSeqInsertSize.RnaSeqInsertSizeMetricExtension)
     new EstimateRnaSeqInsertSize(input=bam, refFlat=RefFlatFile, minimumOverlap=0.0).execute()
     val metrics = Metric.read[InsertSizeMetric](path=out)
     metrics.length shouldBe PairOrientation.values().length
@@ -287,7 +287,7 @@ class EstimateRnaSeqInsertSizeTest extends UnitSpec with OptionValues {
     builder.addPair(contig=2, start1=1, start2=133801671) // before ACKR4-3
     builder.addPair(contig=2, start1=133801671, start2=133814175) // after ACKR4-3
     val bam = builder.toTempFile()
-    val out = PathUtil.pathTo(PathUtil.removeExtension(bam) + EstimateRnaSeqInsertSize.RnaSeqInsertSizeMetricExtension)
+    val out = PathUtil.pathTo(PathUtil.removeExtension(bam).toString + EstimateRnaSeqInsertSize.RnaSeqInsertSizeMetricExtension)
     new EstimateRnaSeqInsertSize(input=bam, refFlat=RefFlatFile, minimumOverlap=0.0).execute()
     val metrics = Metric.read[InsertSizeMetric](path=out)
     metrics.length shouldBe PairOrientation.values().length
@@ -300,7 +300,7 @@ class EstimateRnaSeqInsertSizeTest extends UnitSpec with OptionValues {
     val builder = new SamBuilder()
     builder.addPair(contig=4, start1=133801671, start2=133804077) // overlaps ACKR4-5 (multiple transcripts)
     val bam = builder.toTempFile()
-    val out = PathUtil.pathTo(PathUtil.removeExtension(bam) + EstimateRnaSeqInsertSize.RnaSeqInsertSizeMetricExtension)
+    val out = PathUtil.pathTo(PathUtil.removeExtension(bam).toString + EstimateRnaSeqInsertSize.RnaSeqInsertSizeMetricExtension)
     new EstimateRnaSeqInsertSize(input=bam, refFlat=RefFlatFile, minimumOverlap=0.0).execute()
     val metrics = Metric.read[InsertSizeMetric](path=out)
     metrics.length shouldBe PairOrientation.values().length
@@ -313,7 +313,7 @@ class EstimateRnaSeqInsertSizeTest extends UnitSpec with OptionValues {
     val builder = new SamBuilder()
     builder.addPair(contig=5, start1=133801671, start2=133804077, strand1=Plus, strand2=Plus) // overlaps ACKR4-6 by 2 bases!
     val bam = builder.toTempFile()
-    val out = PathUtil.pathTo(PathUtil.removeExtension(bam) + EstimateRnaSeqInsertSize.RnaSeqInsertSizeMetricExtension)
+    val out = PathUtil.pathTo(PathUtil.removeExtension(bam).toString + EstimateRnaSeqInsertSize.RnaSeqInsertSizeMetricExtension)
 
     // OK
     {

--- a/src/test/scala/com/fulcrumgenomics/testing/ReferenceSetBuilderTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/testing/ReferenceSetBuilderTest.scala
@@ -40,7 +40,7 @@ class ReferenceSetBuilderTest extends UnitSpec {
     // Check the .dict file
     val dictIn = ReferenceSequenceFileFactory.getDefaultDictionaryForReferenceSequence(fasta)
     Files.exists(dictIn) shouldBe true
-    val dict = SAMSequenceDictionaryExtractor.extractDictionary(dictIn.toFile)
+    val dict = SAMSequenceDictionaryExtractor.extractDictionary(dictIn)
 
     // Check the .fai file
     val fai =  ReferenceSequenceFileFactory.getFastaIndexFileName(fasta)
@@ -61,7 +61,7 @@ class ReferenceSetBuilderTest extends UnitSpec {
       val builder = new ReferenceSetBuilder(assembly=assembly)
       builder.add("chr1").add("A", 100)
       val path = builder.toTempFile()
-      val dict = SAMSequenceDictionaryExtractor.extractDictionary(path.toFile)
+      val dict = SAMSequenceDictionaryExtractor.extractDictionary(path)
       dict.size() shouldBe 1
       dict
     }

--- a/src/test/scala/com/fulcrumgenomics/testing/UnitSpec.scala
+++ b/src/test/scala/com/fulcrumgenomics/testing/UnitSpec.scala
@@ -34,6 +34,7 @@ import com.fulcrumgenomics.commons.util.{LazyLogging, LogLevel, Logger}
 import com.fulcrumgenomics.sopt.cmdline.CommandLineProgramParser
 import com.fulcrumgenomics.sopt.util.ParsingUtil
 import com.fulcrumgenomics.util.Io
+import com.fulcrumgenomics.vcf.api.{Variant, VcfSource}
 import htsjdk.variant.variantcontext.VariantContext
 import htsjdk.variant.vcf.VCFFileReader
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
@@ -57,8 +58,8 @@ trait UnitSpec extends FlatSpec with Matchers {
   protected def readBamRecs(bam: PathToBam): IndexedSeq[SamRecord] = SamSource(bam).toIndexedSeq
 
   /** Reads all the records from a VCF file into an indexed seq. */
-  protected def readVcfRecs(vcf: PathToVcf): IndexedSeq[VariantContext] = {
-    val in = new VCFFileReader(vcf.toFile, false)
+  protected def readVcfRecs(vcf: PathToVcf): IndexedSeq[Variant] = {
+    val in = VcfSource(vcf)
     yieldAndThen(in.toIndexedSeq) { in.safelyClose() }
   }
 

--- a/src/test/scala/com/fulcrumgenomics/testing/VariantContextSetBuilderTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/testing/VariantContextSetBuilderTest.scala
@@ -26,11 +26,20 @@
 package com.fulcrumgenomics.testing
 
 import com.fulcrumgenomics.FgBioDef._
+import htsjdk.variant.variantcontext.VariantContext
+import htsjdk.variant.vcf.VCFFileReader
 
 /**
   * Tests for VariantContextSetBuilder.
   */
 class VariantContextSetBuilderTest extends  UnitSpec {
+  private def readVcf(vcf: PathToVcf): IndexedSeq[VariantContext] = {
+    val in = new VCFFileReader(vcf, false)
+    val recs = in.toIndexedSeq
+    in.close()
+    recs
+  }
+
   "VariantContextSetBuilder" should "add genotypes for two samples" in {
     val sampleNames = Seq("Sample1", "Sample2")
     val builder     = new VariantContextSetBuilder(sampleNames=sampleNames)
@@ -45,7 +54,7 @@ class VariantContextSetBuilderTest extends  UnitSpec {
     val builder     = new VariantContextSetBuilder()
       .addVariant(refIdx=0, start=1, variantAlleles=List("A", "C"))
     val vcf = builder.toTempFile()
-    val variants = readVcfRecs(vcf).toIndexedSeq
+    val variants = readVcf(vcf).toIndexedSeq
     variants.length shouldBe 1
     variants.head.getGenotype(0).isNoCall shouldBe true
   }
@@ -65,7 +74,7 @@ class VariantContextSetBuilderTest extends  UnitSpec {
         )
       )
     val vcf = builder.toTempFile()
-    val variants = readVcfRecs(vcf).toIndexedSeq
+    val variants = readVcf(vcf).toIndexedSeq
     variants.length shouldBe 1
     val genotype = variants.head.getGenotype(0)
     genotype.isNoCall shouldBe true

--- a/src/test/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReadsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReadsTest.scala
@@ -46,7 +46,7 @@ class CallMolecularConsensusReadsTest extends UnitSpec {
     val rejects = newBam
 
     // Create 2000 paired end reads, where there are two pairs with the same coordinates and have the same group tag.
-    Stream.range(0, 1000).foreach { idx =>
+    Range(0, 1000).foreach { idx =>
       val attrs = Map(DefaultTag -> ("GATTACA:" + idx), ConsensusTags.UmiBases -> "ACGT-TGCA")
       builder.addPair(name=s"READ:" + 2*idx,   start1=1+idx, start2=1000000+idx, bases1="A"*rlen, bases2="T"*rlen, attrs=attrs)
       builder.addPair(name=s"READ:" + 2*idx+1, start1=1+idx, start2=1000000+idx, bases1="A"*rlen, bases2="T"*rlen, attrs=attrs)
@@ -56,7 +56,7 @@ class CallMolecularConsensusReadsTest extends UnitSpec {
     new CallMolecularConsensusReads(input=builder.toTempFile(), output=output, minReads=1, rejects=Some(rejects), readGroupId="ABC").execute()
 
     // check we have no rejected records
-    readBamRecs(rejects) shouldBe 'empty
+    readBamRecs(rejects).isEmpty shouldBe true
 
     // we should have 1000 consensus paired end reads
     val records = readBamRecs(output)

--- a/src/test/scala/com/fulcrumgenomics/umi/CollectDuplexSeqMetricsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/CollectDuplexSeqMetricsTest.scala
@@ -267,8 +267,8 @@ class CollectDuplexSeqMetricsTest extends UnitSpec {
       val start2 = start1 + isize.sample().toInt - 75
       val abs = sampleNatural(abDist)
       val bas = sampleNatural(baDist)
-      (1 to abs) foreach { _ => builder.addPair(start1=start1, start2=start2, attrs=Map(RX -> "AAA-TTT", MI -> (i + "/A"))) }
-      (1 to bas) foreach { _ => builder.addPair(start1=start1, start2=start2, attrs=Map(RX -> "TTT-AAA", MI -> (i + "/B"))) }
+      (1 to abs) foreach { _ => builder.addPair(start1=start1, start2=start2, attrs=Map(RX -> "AAA-TTT", MI -> (s"$i/A"))) }
+      (1 to bas) foreach { _ => builder.addPair(start1=start1, start2=start2, attrs=Map(RX -> "TTT-AAA", MI -> (s"$i/B"))) }
       counter.count((max(abs, bas), min(abs, bas)))
     }
 

--- a/src/test/scala/com/fulcrumgenomics/umi/ConsensusCallerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/ConsensusCallerTest.scala
@@ -24,6 +24,7 @@
 
 package com.fulcrumgenomics.umi
 
+import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.testing.UnitSpec
 import com.fulcrumgenomics.util.NumericTypes.PhredScore
 

--- a/src/test/scala/com/fulcrumgenomics/umi/DuplexConsensusCallerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/DuplexConsensusCallerTest.scala
@@ -118,9 +118,9 @@ class DuplexConsensusCallerTest extends UnitSpec {
           { // Check a few per-base tags
             import ConsensusTags.PerBase._
             r1[Array[Short]](AbRawReadCount)  shouldBe Array[Byte](3,3,3,3,3,3,3,3,3,3)
-            r1.get[Array[Short]](BaRawReadCount) shouldBe 'empty
+            r1.get[Array[Short]](BaRawReadCount).isEmpty shouldBe true
             r2[Array[Short]](AbRawReadCount)  shouldBe Array[Byte](3,3,3,3,3,3,3,3,3,3)
-            r2.get[Array[Short]](BaRawReadCount) shouldBe 'empty
+            r2.get[Array[Short]](BaRawReadCount).isEmpty shouldBe true
           }
         }
         else {
@@ -402,14 +402,14 @@ class DuplexConsensusCallerTest extends UnitSpec {
         r2[Array[Short]](AbRawReadErrors) shouldBe Array[Byte](0,0,0,0,1,0,0,0,0,0)
         r2[String](AbConsensusBases)      shouldBe r2.basesString
         r2[String](AbConsensusQuals)      shouldBe "MMMM9MMMMM"
-        r1.get[Array[Short]](BaRawReadCount)  shouldBe 'empty
-        r1.get[Array[Short]](BaRawReadErrors) shouldBe 'empty
-        r1.get[String](BaConsensusBases)      shouldBe 'empty
-        r1.get[String](BaConsensusQuals)      shouldBe 'empty
-        r2.get[Array[Short]](BaRawReadCount)  shouldBe 'empty
-        r2.get[Array[Short]](BaRawReadErrors) shouldBe 'empty
-        r2.get[String](BaConsensusBases)      shouldBe 'empty
-        r2.get[String](BaConsensusQuals)      shouldBe 'empty
+        r1.get[Array[Short]](BaRawReadCount).isEmpty shouldBe true
+        r1.get[Array[Short]](BaRawReadErrors).isEmpty shouldBe true
+        r1.get[String](BaConsensusBases).isEmpty shouldBe true
+        r1.get[String](BaConsensusQuals).isEmpty shouldBe true
+        r2.get[Array[Short]](BaRawReadCount).isEmpty shouldBe true
+        r2.get[Array[Short]](BaRawReadErrors).isEmpty shouldBe true
+        r2.get[String](BaConsensusBases).isEmpty shouldBe true
+        r2.get[String](BaConsensusQuals).isEmpty shouldBe true
       }
     }
 
@@ -462,14 +462,14 @@ class DuplexConsensusCallerTest extends UnitSpec {
         r2[Array[Short]](AbRawReadErrors) shouldBe Array[Byte](0,0,0,0,0,1,0,0,0,0)
         r2[String](AbConsensusBases)      shouldBe r2.basesString
         r2[String](AbConsensusQuals)      shouldBe "MMMMM9MMMM"
-        r1.get[Array[Short]](BaRawReadCount)  shouldBe 'empty
-        r1.get[Array[Short]](BaRawReadErrors) shouldBe 'empty
-        r1.get[String](BaConsensusBases)      shouldBe 'empty
-        r1.get[String](BaConsensusQuals)      shouldBe 'empty
-        r2.get[Array[Short]](BaRawReadCount)  shouldBe 'empty
-        r2.get[Array[Short]](BaRawReadErrors) shouldBe 'empty
-        r2.get[String](BaConsensusBases)      shouldBe 'empty
-        r2.get[String](BaConsensusQuals)      shouldBe 'empty
+        r1.get[Array[Short]](BaRawReadCount).isEmpty shouldBe true
+        r1.get[Array[Short]](BaRawReadErrors).isEmpty shouldBe true
+        r1.get[String](BaConsensusBases).isEmpty shouldBe true
+        r1.get[String](BaConsensusQuals).isEmpty shouldBe true
+        r2.get[Array[Short]](BaRawReadCount).isEmpty shouldBe true
+        r2.get[Array[Short]](BaRawReadErrors).isEmpty shouldBe true
+        r2.get[String](BaConsensusBases).isEmpty shouldBe true
+        r2.get[String](BaConsensusQuals).isEmpty shouldBe true
       }
     }
   }

--- a/src/test/scala/com/fulcrumgenomics/umi/ExtractUmisFromBamTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/ExtractUmisFromBamTest.scala
@@ -49,7 +49,7 @@ class ExtractUmisFromBamTest extends UnitSpec with OptionValues {
 
   "ExtractUmisFromBam.annotateRecord" should "should not annotate with no molecular indices" in {
     val frag = annotateRecordFragment
-    ExtractUmisFromBam.annotateRecord(record=frag, ReadStructure("100T"), Seq.empty) shouldBe 'empty
+    ExtractUmisFromBam.annotateRecord(record=frag, ReadStructure("100T"), Seq.empty).isEmpty shouldBe true
     frag.length shouldBe 100
   }
 

--- a/src/test/scala/com/fulcrumgenomics/umi/ReviewConsensusVariantsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/ReviewConsensusVariantsTest.scala
@@ -44,20 +44,20 @@ object ReviewConsensusVariantsTest {
       |>chr2
       |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
       |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-    """.stripMargin.lines.toSeq
+    """.stripMargin.linesIterator.toSeq
 
   val Fai : Seq[String] =
     """
       |chr1    100     6       50      51
       |chr2    100     114     50      51
-    """.stripMargin.lines.map(_.trim.replaceAll("\\s+", "\t")).filter(_.nonEmpty).toSeq
+    """.stripMargin.linesIterator.map(_.trim.replaceAll("\\s+", "\t")).filter(_.nonEmpty).toSeq
 
   val Dict : Seq[String] =
     """
       |@HD    	VN:1.5 	SO:unsorted
       |@SQ    	SN:chr1	LN:100 	M5:8adc5937e635f6c9af646f0b23560fae    	AS:n/a 	UR:n/a 	SP:n/a
       |@SQ    	SN:chr2	LN:100 	M5:48ecc9d349522f836cadf615e370bc51    	AS:n/a 	UR:n/a 	SP:n/a
-    """.stripMargin.lines.map(_.trim.replaceAll("\\s+", "\t")).filter(_.nonEmpty).toSeq
+    """.stripMargin.linesIterator.map(_.trim.replaceAll("\\s+", "\t")).filter(_.nonEmpty).toSeq
 }
 
 
@@ -67,7 +67,7 @@ class ReviewConsensusVariantsTest extends UnitSpec {
   /** Sets up a trivial reference for testing against. */
   lazy val refFasta: PathToFasta = {
     val ref  = makeTempFile("ref.", ".fa")
-    val fai  = ref.getParent.resolve(ref.getFileName + ".fai")
+    val fai  = ref.getParent.resolve(s"${ref.getFileName}.fai")
     val dict = PathUtil.replaceExtension(ref, ".dict")
     Seq(fai, dict).foreach(_.toFile.deleteOnExit())
 
@@ -176,9 +176,9 @@ class ReviewConsensusVariantsTest extends UnitSpec {
 
   "ReviewConsensusVariants" should "create empty BAMs when given an empty interval list as input" in {
     val outBase = makeTempFile("review_consensus.", ".out")
-    val conOut  = outBase.getParent.resolve(outBase.getFileName + ".consensus.bam")
-    val rawOut  = outBase.getParent.resolve(outBase.getFileName + ".grouped.bam")
-    val txtOut  = outBase.getParent.resolve(outBase.getFileName + ".txt")
+    val conOut  = outBase.getParent.resolve(s"${outBase.getFileName}.consensus.bam")
+    val rawOut  = outBase.getParent.resolve(s"${outBase.getFileName}.grouped.bam")
+    val txtOut  = outBase.getParent.resolve(s"${outBase.getFileName}.txt")
     val intervals = makeTempFile("empty.", ".interval_list")
     new IntervalList(header).write(intervals.toFile)
     new ReviewConsensusVariants(input=intervals, consensusBam=consensusBam, groupedBam=rawBam, ref=refFasta, output=outBase).execute()
@@ -194,9 +194,9 @@ class ReviewConsensusVariantsTest extends UnitSpec {
 
   it should "create empty BAMs when given an empty VCF as input" in {
     val outBase = makeTempFile("review_consensus.", ".out")
-    val conOut  = outBase.getParent.resolve(outBase.getFileName + ".consensus.bam")
-    val rawOut  = outBase.getParent.resolve(outBase.getFileName + ".grouped.bam")
-    val txtOut  = outBase.getParent.resolve(outBase.getFileName + ".txt")
+    val conOut  = outBase.getParent.resolve(s"${outBase.getFileName}.consensus.bam")
+    val rawOut  = outBase.getParent.resolve(s"${outBase.getFileName}.grouped.bam")
+    val txtOut  = outBase.getParent.resolve(s"${outBase.getFileName}.txt")
     val intervals = makeTempFile("empty.", ".vcf")
 
     val vcfBuilder = VariantContextSetBuilder("s1")
@@ -215,9 +215,9 @@ class ReviewConsensusVariantsTest extends UnitSpec {
 
   it should "extract the right reads given a set of loci" in {
     val outBase = makeTempFile("review_consensus.", ".out")
-    val conOut  = outBase.getParent.resolve(outBase.getFileName + ".consensus.bam")
-    val rawOut  = outBase.getParent.resolve(outBase.getFileName + ".grouped.bam")
-    val txtOut  = outBase.getParent.resolve(outBase.getFileName + ".txt")
+    val conOut  = outBase.getParent.resolve(s"${outBase.getFileName}.consensus.bam")
+    val rawOut  = outBase.getParent.resolve(s"${outBase.getFileName}.grouped.bam")
+    val txtOut  = outBase.getParent.resolve(s"${outBase.getFileName}.txt")
 
     val vcfBuilder = new VariantContextSetBuilder(sampleNames=List("tumor"))
     vcfBuilder.header.setSequenceDictionary(this.header.getSequenceDictionary)

--- a/src/test/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCallerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCallerTest.scala
@@ -33,8 +33,8 @@ import com.fulcrumgenomics.umi.VanillaUmiConsensusCallerOptions._
 import com.fulcrumgenomics.util.NumericTypes._
 import htsjdk.samtools.SAMUtils
 import htsjdk.samtools.util.CloserUtil
-import net.jafama.FastMath._
 import org.scalatest.OptionValues
+import org.apache.commons.math3.util.FastMath._
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -453,6 +453,11 @@ class VanillaUmiConsensusCallerTest extends UnitSpec with OptionValues {
     output.map(_.cigar.toString()).sorted shouldBe expected
   }
 
+  it should "return a single read if a single read was given" in {
+    val srcs = Seq(src(cigar="50M"))
+    val recs = cc().filterToMostCommonAlignment(srcs)
+    recs should have size 1
+  }
 
   "VanillaConsensusCaller.toSourceRead" should "mask bases that are below the quality threshold" in {
     val builder = new SamBuilder(readLength=10)

--- a/src/test/scala/com/fulcrumgenomics/util/MetricTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/util/MetricTest.scala
@@ -144,7 +144,7 @@ class MetricTest extends UnitSpec with OptionValues with TimeLimits {
   // Various write methods to test with a writer
   private val writeWithWriters = Seq(
     ((writer: StringWriter, metrics: Seq[TestMetric]) => Metric.write[TestMetric](writer, metrics:_*), "write[T <: Metric](writer: Writer, metric: T*)"),
-    ((writer: StringWriter, metrics: Seq[TestMetric]) => Metric.write[TestMetric](writer, metrics), "write[T <: Metric](writer: Writer, metrics: TraversableOnce[T])")
+    ((writer: StringWriter, metrics: Seq[TestMetric]) => Metric.write[TestMetric](writer, metrics), "write[T <: Metric](writer: Writer, metrics: IterableOnce[T])")
   )
 
   writeWithWriters.foreach { case (writeMethod, desc) =>
@@ -160,7 +160,7 @@ class MetricTest extends UnitSpec with OptionValues with TimeLimits {
   // Various write methods to test with a path
   private val writeWithPaths = Seq(
     ((path: Path, metrics: Seq[TestMetric]) => Metric.write[TestMetric](path, metrics:_*), "write[T <: Metric](path: Path, metric: T*)"),
-    ((path: Path, metrics: Seq[TestMetric]) => Metric.write[TestMetric](path, metrics), "write[T <: Metric](path: Path, metric: TraversableOnce[T])")
+    ((path: Path, metrics: Seq[TestMetric]) => Metric.write[TestMetric](path, metrics), "write[T <: Metric](path: Path, metric: IterableOnce[T])")
   )
 
   writeWithPaths.foreach { case (writeMethod, desc) =>
@@ -240,7 +240,7 @@ class MetricTest extends UnitSpec with OptionValues with TimeLimits {
     testMetric.get("foo").value shouldBe "fooValue"
     testMetric.get("bar").value shouldBe "1"
     testMetric.get("car").value shouldBe "default"
-    testMetric.get("dar") shouldBe 'empty
+    testMetric.get("dar").isEmpty shouldBe true
   }
 
   it should "be iterable over tuples of names and values" in {

--- a/src/test/scala/com/fulcrumgenomics/util/PickIlluminaIndicesTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/util/PickIlluminaIndicesTest.scala
@@ -56,7 +56,7 @@ class PickIlluminaIndicesTest extends UnitSpec {
   }
 
   "PickIlluminaIndices" should "pick indices with length four and edit distance one" in {
-    Stream.range(1, 5, 1).foreach { numIndices =>
+    Range(1, 5, 1).foreach { numIndices =>
       val output = newOutput
       new PickIlluminaIndices(
         length = 4,

--- a/src/test/scala/com/fulcrumgenomics/vcf/AssessPhasingTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/vcf/AssessPhasingTest.scala
@@ -163,8 +163,8 @@ class AssessPhasingTest extends ErrorLogLevel {
 
     // output files
     val output                 = makeTempFile("AssessPhasingTest.", "prefix")
-    val phasingMetricsPath     = PathUtil.pathTo(output + AssessPhasingMetric.MetricExtension)
-    val blockLengthMetricsPath = PathUtil.pathTo(output + PhaseBlockLengthMetric.MetricExtension)
+    val phasingMetricsPath     = PathUtil.pathTo(s"${output}${AssessPhasingMetric.MetricExtension}")
+    val blockLengthMetricsPath = PathUtil.pathTo(s"${output}${PhaseBlockLengthMetric.MetricExtension}")
     Seq(phasingMetricsPath, blockLengthMetricsPath).foreach(_.toFile.deleteOnExit)
 
     // run it
@@ -175,8 +175,8 @@ class AssessPhasingTest extends ErrorLogLevel {
     val blockLengthMetrics = Metric.read[PhaseBlockLengthMetric](path=blockLengthMetricsPath)
 
     // get the expected metrics paths
-    val expectedPhasingMetricsPath     = PathUtil.pathTo(expectedPrefix + AssessPhasingMetric.MetricExtension)
-    val expectedBlockLengthMetricsPath = PathUtil.pathTo(expectedPrefix + PhaseBlockLengthMetric.MetricExtension)
+    val expectedPhasingMetricsPath     = PathUtil.pathTo(s"${expectedPrefix}${AssessPhasingMetric.MetricExtension}")
+    val expectedBlockLengthMetricsPath = PathUtil.pathTo(s"${expectedPrefix}${PhaseBlockLengthMetric.MetricExtension}")
 
     // read the expected metrics
     val expectedPhasingMetrics     = Metric.read[AssessPhasingMetric](path=expectedPhasingMetricsPath)
@@ -188,9 +188,9 @@ class AssessPhasingTest extends ErrorLogLevel {
 
     if (debugVcf) {
       val annotatedVcf         = Paths.get(output.toString + AssessPhasing.AnnotatedVcfExtension)
-      val expectedAnnotatedVcf = PathUtil.pathTo(expectedPrefix + AssessPhasing.AnnotatedVcfExtension)
-      val actualContexts = new VCFFileReader(annotatedVcf.toFile, false).iterator().toIterator.toList
-      val expectedContexts = new VCFFileReader(expectedAnnotatedVcf.toFile, false).iterator().toIterator.toList
+      val expectedAnnotatedVcf = PathUtil.pathTo(s"${expectedPrefix}${AssessPhasing.AnnotatedVcfExtension}")
+      val actualContexts = new VCFFileReader(annotatedVcf.toFile, false).iterator().toList
+      val expectedContexts = new VCFFileReader(expectedAnnotatedVcf.toFile, false).iterator().toList
       actualContexts.length shouldBe expectedContexts.length
       actualContexts.zip(expectedContexts).foreach { case (actualCtx, expectedCtx) =>
           actualCtx.toStringDecodeGenotypes shouldBe expectedCtx.toStringDecodeGenotypes
@@ -298,12 +298,12 @@ class PhaseBlockTest extends ErrorLogLevel {
 
   "PhaseBlock.toOverlapDetector" should "create an empty detector if no variants are given" in {
     val builder = new VariantContextSetBuilder()
-    PhaseBlock.buildOverlapDetector(iterator=builder.iterator, dict=builder.header.getSequenceDictionary).getAll shouldBe 'empty
+    PhaseBlock.buildOverlapDetector(iterator=builder.iterator, dict=builder.header.getSequenceDictionary).getAll.isEmpty shouldBe true
   }
 
   it should "create an empty detector when variants do not have the phase set tag" in {
     val builder  = new VariantContextSetBuilder().addVariant(start=1, variantAlleles=List("A", "C"), genotypeAlleles=List("A", "C"), phased=true)
-    PhaseBlock.buildOverlapDetector(iterator=builder.iterator, dict=builder.header.getSequenceDictionary).getAll shouldBe 'empty
+    PhaseBlock.buildOverlapDetector(iterator=builder.iterator, dict=builder.header.getSequenceDictionary).getAll.isEmpty shouldBe true
   }
 
   it should "create a detector for a single variant" in {
@@ -767,7 +767,7 @@ class PhaseCigarTest extends ErrorLogLevel {
   }
 
   "Cigar.toShortSwitchErrorIndices" should "find no indices for an empty cigar" in {
-    PhaseCigar(cigar=Seq.empty).toShortSwitchErrorIndices()shouldBe 'empty
+    PhaseCigar(cigar=Seq.empty).toShortSwitchErrorIndices().isEmpty shouldBe true
   }
 
   it should "find an error at the first or last cigar element if the mismatch is isolated" in {
@@ -790,12 +790,12 @@ class PhaseCigarTest extends ErrorLogLevel {
   }
 
   it should "ignore variant sites only in the truth or call set" in {
-    PhaseCigar(cigar=Seq(CallOnly, Match)).toShortSwitchErrorIndices()shouldBe 'empty
-    PhaseCigar(cigar=Seq(TruthOnly, Match)).toShortSwitchErrorIndices()shouldBe 'empty
+    PhaseCigar(cigar=Seq(CallOnly, Match)).toShortSwitchErrorIndices().isEmpty shouldBe true
+    PhaseCigar(cigar=Seq(TruthOnly, Match)).toShortSwitchErrorIndices().isEmpty shouldBe true
   }
 
   it should "not count adjacent mismatches" in {
-    PhaseCigar(cigar=Seq(Mismatch, Mismatch)).toShortSwitchErrorIndices()shouldBe 'empty
+    PhaseCigar(cigar=Seq(Mismatch, Mismatch)).toShortSwitchErrorIndices().isEmpty shouldBe true
   }
 
   "Cigar.toLongSwitchErrorsAndSites" should "find no errors and no sites for an empty cigar" in {
@@ -946,7 +946,7 @@ class PhaseCigarTest extends ErrorLogLevel {
     PhaseCigar.contextsToMatchingOperator(truth=None, call=Some(ctxStart)) shouldBe Some(CallOnly)
 
     // No truth, call is not the start of a phase block
-    PhaseCigar.contextsToBlockEndOperator(truth=None, call=Some(ctxNoStart)) shouldBe 'empty
+    PhaseCigar.contextsToBlockEndOperator(truth=None, call=Some(ctxNoStart)).isEmpty shouldBe true
     PhaseCigar.contextsToMatchingOperator(truth=None, call=Some(ctxNoStart)) shouldBe Some(CallOnly)
 
     // Truth is the start of a phase block, no call
@@ -954,7 +954,7 @@ class PhaseCigarTest extends ErrorLogLevel {
     PhaseCigar.contextsToMatchingOperator(truth=Some(ctxStart), call=None) shouldBe Some(TruthOnly)
 
     // Truth is the start of a phase block, no call
-    PhaseCigar.contextsToBlockEndOperator(truth=Some(ctxNoStart), call=None) shouldBe 'empty
+    PhaseCigar.contextsToBlockEndOperator(truth=Some(ctxNoStart), call=None).isEmpty shouldBe true
     PhaseCigar.contextsToMatchingOperator(truth=Some(ctxNoStart), call=None) shouldBe Some(TruthOnly)
 
     // Truth and call, both start of a phase block
@@ -970,7 +970,7 @@ class PhaseCigarTest extends ErrorLogLevel {
     PhaseCigar.contextsToMatchingOperator(truth=Some(ctxStart), call=Some(ctxNoStart)) shouldBe Some(Match)
 
     // Truth and call, neither are the start of a phase block
-    PhaseCigar.contextsToBlockEndOperator(truth=Some(ctxNoStart), call=Some(ctxNoStart)) shouldBe 'empty
+    PhaseCigar.contextsToBlockEndOperator(truth=Some(ctxNoStart), call=Some(ctxNoStart)).isEmpty shouldBe true
     PhaseCigar.contextsToMatchingOperator(truth=Some(ctxNoStart), call=Some(ctxNoStart)) shouldBe Some(Match)
   }
 

--- a/src/test/scala/com/fulcrumgenomics/vcf/ByIntervalListVariantContextIteratorTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/vcf/ByIntervalListVariantContextIteratorTest.scala
@@ -56,61 +56,61 @@ class ByIntervalListVariantContextIteratorTest extends UnitSpec {
   }
 
   "ByIntervalListVariantContextIterator" should "return no variants if the interval list is empty" in {
-    Stream(true, false).foreach { useIndex =>
+    Iterator(true, false).foreach { useIndex =>
       val builder = new VariantContextSetBuilder().addVariant(refIdx=0, start=1, variantAlleles=List("A"), genotypeAlleles=List("A"))
       val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=emtpyIntervalList(), useIndex=useIndex)
-      iterator shouldBe 'empty
+      iterator.isEmpty shouldBe true
     }
   }
 
   it should "return no variants if the variants are empty" in {
-    Stream(true, false).foreach { useIndex =>
+    Iterator(true, false).foreach { useIndex =>
       val builder = new VariantContextSetBuilder()
       val intervalList = emtpyIntervalList()
       intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 1, 1000, false, "foo"))
       val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=emtpyIntervalList(), useIndex=useIndex)
-      iterator shouldBe 'empty
+      iterator.isEmpty shouldBe true
     }
   }
 
   it should "return a variant context if it overlaps an interval" in {
-    Stream(true, false).foreach { useIndex =>
+    Iterator(true, false).foreach { useIndex =>
       val builder = new VariantContextSetBuilder().addVariant(refIdx=0, start=500, variantAlleles=List("A"), genotypeAlleles=List("A"))
       val intervalList = emtpyIntervalList()
       intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 1, 1000, false, "foo"))
       val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=intervalList, useIndex=useIndex)
-      iterator shouldBe 'nonEmpty
+      iterator.isEmpty shouldBe false
       val actual = iterator.next()
       val expected = builder.head
       actual.getContig shouldBe expected.getContig
       actual.getStart shouldBe expected.getStart
       actual.getEnd shouldBe expected.getEnd
-      iterator shouldBe 'empty
+      iterator.isEmpty shouldBe true
     }
   }
 
   it should "not return a variant context if it doesn't overlap an interval (same chromosome)" in {
-    Stream(true, false).foreach { useIndex =>
+    Iterator(true, false).foreach { useIndex =>
       val builder = new VariantContextSetBuilder().addVariant(refIdx=0, start=500, variantAlleles=List("A"), genotypeAlleles=List("A"))
       val intervalList = emtpyIntervalList()
       intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 750, 1000, false, "foo"))
       val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=intervalList, useIndex=useIndex)
-      iterator shouldBe 'empty
+      iterator.isEmpty shouldBe true
     }
   }
 
   it should "not return a variant context if it doesn't overlap an interval (different chromosome)" in {
-    Stream(true, false).foreach { useIndex =>
+    Iterator(true, false).foreach { useIndex =>
       val builder = new VariantContextSetBuilder().addVariant(refIdx=0, start=500, variantAlleles=List("A"), genotypeAlleles=List("A"))
       val intervalList = emtpyIntervalList()
       intervalList.add(new Interval(dict.getSequence(1).getSequenceName, 1, 1000, false, "foo"))
       val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=intervalList, useIndex=useIndex)
-      iterator shouldBe 'empty
+      iterator.isEmpty shouldBe true
     }
   }
 
   it should "throw an exception when next() is call but hasNext() is false" in {
-    Stream(true, false).foreach { useIndex =>
+    Iterator(true, false).foreach { useIndex =>
       val builder = new VariantContextSetBuilder().addVariant(refIdx=0, start=1, variantAlleles=List("A"), genotypeAlleles=List("A"))
       val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=emtpyIntervalList(), useIndex=useIndex)
       iterator.hasNext shouldBe false
@@ -119,35 +119,35 @@ class ByIntervalListVariantContextIteratorTest extends UnitSpec {
   }
 
   it should "return a variant context if it encloses an interval" in {
-    Stream(true, false).foreach { useIndex =>
+    Iterator(true, false).foreach { useIndex =>
       val builder = new VariantContextSetBuilder().addVariant(refIdx=0, start=495, variantAlleles=List("AAAAA", "A"), genotypeAlleles=List("A"))
       val intervalList = emtpyIntervalList()
       intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 496, 496, false, "foo"))
       val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=intervalList, useIndex=useIndex)
-      iterator shouldBe 'nonEmpty
+      iterator.isEmpty shouldBe false
       val actual = iterator.next()
       val expected = builder.head
       actual.getContig shouldBe expected.getContig
       actual.getStart shouldBe expected.getStart
       actual.getEnd shouldBe expected.getEnd
-      iterator shouldBe 'empty
+      iterator.isEmpty shouldBe true
     }
   }
 
   it should "return a variant context only once if it overlaps multiple intervals" in {
-    Stream(true, false).foreach { useIndex =>
+    Iterator(true, false).foreach { useIndex =>
       val builder = new VariantContextSetBuilder().addVariant(refIdx=0, start=495, variantAlleles=List("AAAAA", "A"), genotypeAlleles=List("A"))
       val intervalList = emtpyIntervalList()
       intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 496, 496, false, "foo"))
       intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 500, 500, false, "foo"))
       val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=intervalList, useIndex=useIndex)
-      iterator shouldBe 'nonEmpty
+      iterator.isEmpty shouldBe false
       val actual = iterator.next()
       val expected = builder.head
       actual.getContig shouldBe expected.getContig
       actual.getStart shouldBe expected.getStart
       actual.getEnd shouldBe expected.getEnd
-      iterator shouldBe 'empty
+      iterator.isEmpty shouldBe true
     }
   }
 
@@ -160,18 +160,18 @@ class ByIntervalListVariantContextIteratorTest extends UnitSpec {
     intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 500, 500, false, "foo"))
     val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=intervalList, useIndex=true)
     // OK, since we are overlapping the first interval
-    iterator shouldBe 'nonEmpty
+    iterator.isEmpty shouldBe false
     // NOK, since the intervals were overlapping when we pre-fetch the second variant context
     an[Exception] should be thrownBy iterator.next()
   }
 
   it should "ignore a variant context if does not overlap an interval" in {
-    Stream(true, false).foreach { useIndex =>
+    Iterator(true, false).foreach { useIndex =>
       val builder = new VariantContextSetBuilder().addVariant(refIdx=0, start=495, variantAlleles=List("A", "C"), genotypeAlleles=List("C"))
       val intervalList = emtpyIntervalList()
       intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 500, 500, false, "foo"))
       val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=intervalList, useIndex=useIndex)
-      iterator shouldBe 'empty
+      iterator.isEmpty shouldBe true
     }
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/vcf/HapCutToVcfTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/vcf/HapCutToVcfTest.scala
@@ -157,7 +157,7 @@ class HapCutToVcfTest extends UnitSpec with ParallelTestExecution {
     reader.close()  }
 
   "HapCutToVcf" should "convert a HAPCUT1 file to VCF in both GATK and VCF-spec phasing format" in {
-    Stream(true, false).foreach { gatkPhasingFormat =>
+    Iterator(true, false).foreach { gatkPhasingFormat =>
       val expectedOutput = if (gatkPhasingFormat) hapCut1GatkVcf else hapCut1Vcf
       val out = makeTempFile("hap_cut_to_vcf.hapcut", ".vcf")
 
@@ -192,7 +192,7 @@ class HapCutToVcfTest extends UnitSpec with ParallelTestExecution {
   }
 
   it should "convert a HAPCUT2 file to VCF in both GATK and VCF-spec phasing format" in {
-    Stream(true, false).foreach { gatkPhasingFormat =>
+    Iterator(true, false).foreach { gatkPhasingFormat =>
       val expectedOutput = if (gatkPhasingFormat) hapCut2GatkVcf else hapCut2Vcf
       val out = makeTempFile("hap_cut_to_vcf.hapcut2", ".vcf")
 
@@ -259,7 +259,7 @@ class HapCutToVcfTest extends UnitSpec with ParallelTestExecution {
   }
 
   it should "convert an empty HAPCUT1/HAPCUT2 file to VCF in both GATK and VCF-spec phasing format" in {
-    Stream(true, false).foreach { gatkPhasingFormat =>
+    Iterator(true, false).foreach { gatkPhasingFormat =>
       val out       = makeTempFile("hap_cut_to_vcf.hapcut", ".vcf")
       val hapCutOut = makeTempFile("hap_cut_to_vcf.hapcut", ".hapcut")
 

--- a/src/test/scala/com/fulcrumgenomics/vcf/VariantMaskTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/vcf/VariantMaskTest.scala
@@ -41,7 +41,7 @@ class VariantMaskTest extends UnitSpec {
     builder.toTempFile()
   }
 
-  val dict = SAMSequenceDictionaryExtractor.extractDictionary(ref.toFile)
+  val dict = SAMSequenceDictionaryExtractor.extractDictionary(ref)
 
   "VariantMask" should "mask SNPs as individual bases" in {
     val builder = new VariantContextSetBuilder().setSequenceDictionary(dict)

--- a/src/test/scala/com/fulcrumgenomics/vcf/api/AlleleTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/vcf/api/AlleleTest.scala
@@ -1,0 +1,74 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.fulcrumgenomics.vcf.api
+
+import com.fulcrumgenomics.FgBioDef._
+import com.fulcrumgenomics.testing.UnitSpec
+import com.fulcrumgenomics.vcf.api.Allele.{NoCallAllele, SimpleAllele, SpannedAllele, SymbolicAllele}
+
+class AlleleTest extends UnitSpec {
+  "Allele.apply()" should "generate SimpleAlleles for base strings" in {
+    Allele("ACT").isInstanceOf[SimpleAllele] shouldBe true
+    Allele("ACT").value shouldBe "ACT"
+    Allele("G").value shouldBe "G"
+    Allele("g").value shouldBe "g"
+  }
+
+  it should "return cached instances for single-base alleles" in {
+    Allele("A") eq Allele("a") shouldBe false
+    "ACGTNacgtn".sliding(1).foreach(b => Allele(b) eq Allele(b) shouldBe true)
+  }
+
+  it should "return the constant no-call allele for no-calls" in {
+    Allele(".") shouldBe NoCallAllele
+    Allele(".") eq NoCallAllele shouldBe true
+  }
+
+  it should "return the constant spanned allele for *" in {
+    Allele("*") eq SpannedAllele shouldBe true
+  }
+
+  it should "construct symbolic alleles for string wrapped in <>" in {
+    Allele("<NON_REF>").isInstanceOf[SymbolicAllele] shouldBe true
+    Allele("<NON_REF>").value shouldBe "<NON_REF>"
+  }
+
+  it should "reject alleles with non-ACGTN bases in them" in {
+    an[IllegalArgumentException] shouldBe thrownBy { Allele("ARR") }
+    an[IllegalArgumentException] shouldBe thrownBy { Allele("ABC") }
+    an[IllegalArgumentException] shouldBe thrownBy { Allele("Y") }
+  }
+
+  "Allele equality" should "be case insensitive" in {
+    Allele("T") == Allele("A") shouldBe false
+
+    "ACGTN".sliding(1).foreach { s =>
+      val upper = Allele(s)
+      val lower = Allele(s.toLowerCase)
+      upper.hashCode() shouldBe lower.hashCode()
+      upper == lower shouldBe true
+    }
+  }
+}

--- a/src/test/scala/com/fulcrumgenomics/vcf/api/GenotypeTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/vcf/api/GenotypeTest.scala
@@ -1,0 +1,134 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.fulcrumgenomics.vcf.api
+
+import com.fulcrumgenomics.FgBioDef._
+import com.fulcrumgenomics.testing.UnitSpec
+import com.fulcrumgenomics.vcf.api.Allele.NoCallAllele
+import org.scalatest.OptionValues
+
+class GenotypeTest extends UnitSpec with OptionValues {
+
+  private def gt(ref: String, gt: String, sample: String = "s1", attrs: Map[String,Any] = Map.empty): Genotype = {
+    val phased    = gt.contains('|')
+    val parts     = if (phased) gt.split('|') else gt.split('/')
+    val gtAlleles = parts.map(s => Allele(s)).toIndexedSeq
+    val refAllele = Allele(ref)
+    val alleles   = AlleleSet(ref=refAllele, alts=gtAlleles.filterNot(a => a == refAllele || a == NoCallAllele))
+    Genotype(alleles, sample, gtAlleles, phased=phased)
+  }
+
+  "Genotype.ploidy" should "return the right number for various genotypes" in {
+    gt(ref="A", gt="A").ploidy shouldBe 1
+    gt(ref="A", gt="A/A").ploidy shouldBe 2
+    gt(ref="A", gt="A/C").ploidy shouldBe 2
+    gt(ref="A", gt="C/T").ploidy shouldBe 2
+    gt(ref="A", gt="A|C|G").ploidy shouldBe 3
+  }
+
+  "Genotype.isNoCall" should "be true if all calls are no-calls and false otherwise" in {
+    gt(ref="C", gt="C/A").isNoCall shouldBe false
+    gt(ref="C", gt="C/.").isNoCall shouldBe false
+    gt(ref="C", gt="C/*").isNoCall shouldBe false
+    gt(ref="C", gt=".").isNoCall   shouldBe true
+    gt(ref="C", gt="./.").isNoCall shouldBe true
+  }
+
+  "Genotype.isFullyCalled" should "return true only if no called allele is a no-call" in {
+    gt(ref="C", gt="C/A").isFullyCalled shouldBe true
+    gt(ref="C", gt="C/.").isFullyCalled shouldBe false
+    gt(ref="C", gt="C/*").isFullyCalled shouldBe true
+    gt(ref="C", gt=".").isFullyCalled   shouldBe false
+    gt(ref="C", gt="./.").isFullyCalled shouldBe false
+  }
+
+  "Genotype.isHomRef" should "return true only if the call is homozygous reference" in {
+    gt(ref="C", gt="C/A").isHomRef shouldBe false
+    gt(ref="C", gt="A").isHomRef   shouldBe false
+    gt(ref="C", gt="C/*").isHomRef shouldBe false
+    gt(ref="C", gt="C/.").isHomRef shouldBe false
+    gt(ref="C", gt="./.").isHomRef shouldBe false
+    gt(ref="C", gt="A/A").isHomRef shouldBe false
+    gt(ref="C", gt="C").isHomRef   shouldBe true
+    gt(ref="C", gt="C/C").isHomRef shouldBe true
+    gt(ref="C", gt="C/C/C/C").isHomRef shouldBe true
+  }
+  
+  "Genotype.isHomVar" should "return true only if the call is homozygous alt" in {
+    gt(ref="C", gt="C/A").isHomVar   shouldBe false
+    gt(ref="C", gt="A"  ).isHomVar   shouldBe true
+    gt(ref="C", gt="A/*").isHomVar   shouldBe false
+    gt(ref="C", gt="A/.").isHomVar   shouldBe false
+    gt(ref="C", gt="./.").isHomVar   shouldBe false
+    gt(ref="C", gt="A/A").isHomVar   shouldBe true
+    gt(ref="C", gt="."  ).isHomVar   shouldBe false
+    gt(ref="C", gt="C/C").isHomVar   shouldBe false
+    gt(ref="C", gt="A/A/A").isHomVar shouldBe true
+  }
+
+  "Genotype.isHet" should "return true if the genotype contains any heterozygosity" in {
+    gt(ref="C", gt="C/C").isHet   shouldBe false
+    gt(ref="C", gt="A/A").isHet   shouldBe false
+    gt(ref="C", gt="A/*").isHet   shouldBe false
+    gt(ref="C", gt="A/.").isHet   shouldBe false
+    gt(ref="C", gt="C/A").isHet   shouldBe true
+    gt(ref="C", gt="G/T").isHet   shouldBe true
+    gt(ref="C", gt="A/C").isHet   shouldBe true
+    gt(ref="C", gt="A/C/*").isHet shouldBe true
+    gt(ref="C", gt="A/C/.").isHet shouldBe true
+  }
+
+  "Genotype.isHetNonRef" should "return true if the genotype contains any heterozygosity and doesn't contain the reference allele" in {
+    gt(ref="C", gt="C/C").isHetNonRef   shouldBe false
+    gt(ref="C", gt="A/A").isHetNonRef   shouldBe false
+    gt(ref="C", gt="A/*").isHetNonRef   shouldBe false
+    gt(ref="C", gt="A/.").isHetNonRef   shouldBe false
+    gt(ref="C", gt="C/A").isHetNonRef   shouldBe false
+    gt(ref="C", gt="G/T").isHetNonRef   shouldBe true
+    gt(ref="C", gt="A/C").isHetNonRef   shouldBe false
+    gt(ref="C", gt="A/G/*").isHetNonRef shouldBe true
+    gt(ref="C", gt="A/T/.").isHetNonRef shouldBe true
+  }
+
+  "Genotype.gtWithBases" should "return a VCF-like genotype string using the actual allele strings" in {
+    gt(ref="C", gt="C/C").gtWithBases       shouldBe "C/C"
+    gt(ref="C", gt="A/T").gtWithBases       shouldBe "A/T"
+    gt(ref="C", gt="A/*").gtWithBases       shouldBe "A/*"
+    gt(ref="C", gt="T|*").gtWithBases       shouldBe "T|*"
+    gt(ref="C", gt="A/C/G").gtWithBases     shouldBe "A/C/G"
+    gt(ref="C", gt="A|.|G").gtWithBases     shouldBe "A|.|G"
+    gt(ref="C", gt="A|<FOO>|G").gtWithBases shouldBe "A|<FOO>|G"
+  }
+
+  "Genotype.gtWithIndices" should "return a VCF-like genotype string using the indices of the alleles" in {
+    gt(ref="C", gt="C/C").gtVcfStyle       shouldBe "0/0"
+    gt(ref="C", gt="A/T").gtVcfStyle       shouldBe "1/2"
+    gt(ref="C", gt="A/*").gtVcfStyle       shouldBe "1/2"
+    gt(ref="C", gt="T|*").gtVcfStyle       shouldBe "1|2"
+    gt(ref="C", gt="A/C/G").gtVcfStyle     shouldBe "1/0/2"
+    gt(ref="C", gt="A|.|G").gtVcfStyle     shouldBe "1|.|2"
+    gt(ref="C", gt="A|<FOO>|G").gtVcfStyle shouldBe "1|2|3"
+  }
+}

--- a/src/test/scala/com/fulcrumgenomics/vcf/api/VariantTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/vcf/api/VariantTest.scala
@@ -1,0 +1,42 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.fulcrumgenomics.vcf.api
+
+import com.fulcrumgenomics.FgBioDef._
+import com.fulcrumgenomics.testing.UnitSpec
+import org.scalatest.OptionValues
+
+class VariantTest extends UnitSpec with OptionValues {
+  "Variant.isMissingValue" should "correctly handle missing and non-missing values" in {
+    Variant.isMissingValue(".") shouldBe true
+    Variant.isMissingValue('.') shouldBe true
+    Variant.isMissingValue(Variant.MissingInt) shouldBe true
+    Variant.isMissingValue(Variant.MissingFloat) shouldBe true
+
+    Variant.isMissingValue(".1")      shouldBe false
+    Variant.isMissingValue(Float.NaN) shouldBe false
+    Range(-500, 500).foreach { i => Variant.isMissingValue(i) shouldBe false}
+  }
+}

--- a/src/test/scala/com/fulcrumgenomics/vcf/api/VcfIoTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/vcf/api/VcfIoTest.scala
@@ -28,6 +28,7 @@ import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.testing.UnitSpec
 import org.scalatest.OptionValues
 
+import scala.collection.compat._
 import scala.collection.immutable.ListMap
 
 object VcfIoTest {
@@ -144,7 +145,7 @@ class VcfIoTest extends UnitSpec with OptionValues {
     result.vs.head.apply[ArrayAttr[Int]]("AC")      should contain theSameElementsInOrderAs Seq(1, 3)
 
     result.vs.head.genotypes.size shouldBe 2
-    val Seq(s1, s2) = Seq("s1", "s2").map(result.vs.head.genotypes.apply)
+    val Seq(s1, s2): Seq[Genotype] = Seq("s1", "s2").map(result.vs.head.genotypes.apply)
 
     s1.gtWithBases                shouldBe "C/G"
     s1.gtVcfStyle                 shouldBe "0/1"

--- a/src/test/scala/com/fulcrumgenomics/vcf/api/VcfIoTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/vcf/api/VcfIoTest.scala
@@ -1,0 +1,179 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.fulcrumgenomics.vcf.api
+
+import com.fulcrumgenomics.FgBioDef._
+import com.fulcrumgenomics.testing.UnitSpec
+import com.fulcrumgenomics.vcf.api.Variant.ArrayAttribute
+import org.scalatest.OptionValues
+
+import scala.collection.immutable.ListMap
+
+object VcfIoTest {
+  val Header = VcfHeader(
+    contigs = IndexedSeq(VcfContigHeader(index=0, name="chr1", length=Some(5000))),
+    infos   = Seq(
+      VcfInfoHeader(id="AC",  count=VcfCount.OnePerAltAllele, kind=VcfFieldType.Integer, description="Alternate allele counts in genotypes."),
+      VcfInfoHeader(id="DP",  count=VcfCount.Fixed(1),        kind=VcfFieldType.Integer, description="Depth across all samples."),
+      VcfInfoHeader(id="QD",  count=VcfCount.Fixed(1),        kind=VcfFieldType.Float,   description="Quality/depth."),
+      VcfInfoHeader(id="STR", count=VcfCount.Fixed(0),        kind=VcfFieldType.Flag,    description="Quality/depth.")
+    ),
+    formats = Seq(
+      VcfFormatHeader(id="GT", count=VcfCount.Fixed(1),       kind=VcfFieldType.String, description="Genotype string."),
+      VcfFormatHeader(id="AD", count=VcfCount.OnePerAllele,   kind=VcfFieldType.Integer, description="Depth per allele."),
+      VcfFormatHeader(id="GQ", count=VcfCount.Fixed(1),       kind=VcfFieldType.Integer, description="Genotype quality."),
+      VcfFormatHeader(id="PL", count=VcfCount.OnePerGenotype, kind=VcfFieldType.Integer, description="Phred scaled genotype likelihoods.")
+    ),
+    filters = Seq(
+      VcfFilterHeader(id="LowQD", description="Low Quality/Depth value"),
+      VcfFilterHeader(id="LowAB", description="Low/poor allele balance.")
+    ),
+    others  = Seq(
+      VcfGeneralHeader(headerType="simple",   id="is as simple does"),
+      VcfGeneralHeader(headerType="compound", id="time-of-day", data=Map("hour" -> "13", "minute" -> "53")),
+      VcfGeneralHeader(headerType="ALT",      id="NON_REF", data=Map("Description" -> "Represents any non-reference allele."))
+    ),
+    samples = IndexedSeq("s1")
+  )
+}
+
+/** Tests for reading and writing VCFs using the scala API. */
+class VcfIoTest extends UnitSpec with OptionValues {
+  case class Result(header: VcfHeader, vs: IndexedSeq[Variant])
+
+  /** Writes out the variants to a file and reads them back, returning the header and the variants. */
+  @inline private def roundtrip(variants: TraversableOnce[Variant], header: VcfHeader = VcfIoTest.Header): Result = {
+    val vcf = makeTempFile("test.", ".vcf")
+    val out = VcfWriter(vcf, header)
+    out ++= variants
+    out.close()
+    val in = VcfSource(vcf)
+    val results = Result(in.header, in.toIndexedSeq)
+    in.close()
+
+    // Check that the header didn't get mangled other than perhaps having lines resorted
+    results.header.samples should contain theSameElementsInOrderAs header.samples
+    results.header.contigs should contain theSameElementsInOrderAs header.contigs
+    results.header.infos   should contain theSameElementsAs        header.infos
+    results.header.formats should contain theSameElementsAs        header.formats
+    results.header.filters should contain theSameElementsAs        header.filters
+    results.header.others  should contain theSameElementsAs        header.others
+
+    results
+  }
+
+  "VcfReader and VcfWriter" should "write a VCF and read back a VCF" in {
+    val alleles = AlleleSet(ref=Allele("C"), alts=IndexedSeq(Allele("G"), Allele("T")))
+    val variant = Variant(
+      chrom = "chr1",
+      pos   = 1000,
+      id    = Some("testvar"),
+      alleles = alleles,
+      qual    = Some(1234.5),
+      attrs = ListMap("DP" -> 120, "AC" -> Seq(1, 1), "STR" -> "."),
+      genotypes = Map("s1" -> Genotype(alleles, "s1", alleles.alts, phased=false, attrs=Map("AD" -> Seq(0, 50, 54))))
+    )
+
+    val Result(header, variants) = roundtrip(Seq(variant))
+    header.samples should contain theSameElementsInOrderAs Seq("s1")
+    header.dict.getSequence(0).getSequenceName shouldBe "chr1"
+
+    variants should have size 1
+
+    variants.head.chrom                            shouldBe "chr1"
+    variants.head.pos                              shouldBe 1000
+    variants.head.end                              shouldBe 1000
+    variants.head.alleles.ref.toString             shouldBe "C"
+    variants.head.alleles.alts.map(_.toString)     should contain theSameElementsInOrderAs Seq("G", "T")
+    variants.head.qual.value                       shouldBe 1234.5
+    variants.head.apply[Int]("DP")                 shouldBe 120
+    variants.head.apply[ArrayAttribute[Int]]("AC") should contain theSameElementsInOrderAs Seq(1, 1)
+    variants.head.attrs.contains("STR")       shouldBe true
+    variants.head.attrs.contains("QD")        shouldBe false
+
+    variants.head.genotypes.size           shouldBe 1
+    val gt = variants.head.genotypes("s1")
+    gt.gtWithBases                         shouldBe "G/T"
+    gt.gtVcfStyle                          shouldBe "1/2"
+    gt[ArrayAttribute[Int]]("AD")          should contain theSameElementsInOrderAs Seq(0, 50, 54)
+    gt.attrs.contains("PL")                shouldBe false
+  }
+
+
+  it should "write and read back a multi-sample VCF with some missing fields for the second sample" in {
+    val alleles = AlleleSet(ref=Allele("C"), alts=IndexedSeq(Allele("G")))
+    val gts = Map(
+      "s1" -> Genotype(alleles, "s1", calls=alleles.toIndexedSeq, phased=false, attrs=Map("AD" -> Seq(50, 54), "GQ" -> 99, "PL" -> Seq(999, 41, 998))),
+      "s2" -> Genotype(alleles, "s2", calls=alleles.alts ++ alleles.alts, phased=false, attrs=Map("AD" -> Seq(0, 101)))
+    )
+    val inVariants = Seq(Variant(chrom="chr1", pos=1200, alleles=alleles, attrs=ListMap("DP" -> 205, "AC" -> Seq(1, 3)), genotypes=gts))
+    val inHeader   = VcfIoTest.Header.copy(samples=IndexedSeq("s1", "s2"))
+
+    val result = roundtrip(variants=inVariants, header=inHeader)
+    result.header.samples should contain theSameElementsInOrderAs Seq("s1", "s2")
+
+    result.vs should have size 1
+    result.vs.head.chrom                            shouldBe "chr1"
+    result.vs.head.pos                              shouldBe 1200
+    result.vs.head.end                              shouldBe 1200
+    result.vs.head.alleles.ref.toString             shouldBe "C"
+    result.vs.head.alleles.alts.map(_.toString)     should contain theSameElementsInOrderAs Seq("G")
+    result.vs.head.qual                             shouldBe None
+    result.vs.head.apply[Int]("DP")                 shouldBe 205
+    result.vs.head.apply[ArrayAttribute[Int]]("AC") should contain theSameElementsInOrderAs Seq(1, 3)
+
+    result.vs.head.genotypes.size shouldBe 2
+    val Seq(s1, s2) = Seq("s1", "s2").map(result.vs.head.genotypes.apply)
+
+    s1.gtWithBases                shouldBe "C/G"
+    s1.gtVcfStyle                 shouldBe "0/1"
+    s1[ArrayAttribute[Int]]("AD") should contain theSameElementsInOrderAs Seq(50, 54)
+    s1[ArrayAttribute[Int]]("PL") should contain theSameElementsInOrderAs Seq(999, 41, 998)
+    s1[Int]("GQ")                 shouldBe 99
+
+    s2.gtWithBases                shouldBe "G/G"
+    s2.gtVcfStyle                 shouldBe "1/1"
+    s2[ArrayAttribute[Int]]("AD") should contain theSameElementsInOrderAs Seq(0, 101)
+    s2.attrs.contains("PL")       shouldBe false
+    s2.attrs.contains("GQ")       shouldBe false
+  }
+
+  it should "write a VCF with an index and perform queries properly" in {
+    val alleles = AlleleSet(ref=Allele("C"), alts=IndexedSeq(Allele("G"), Allele("T")))
+    val variants = Range.inclusive(1000, 2000, step=10).map { s =>
+      Variant(chrom="chr1", pos=s, alleles=alleles, genotypes=Map("s1" -> Genotype(alleles, "s1", alleles.alts)))
+    }
+    val vcf = makeTempFile("queryable.", ".vcf.gz")
+    val out = VcfWriter(vcf, VcfIoTest.Header)
+    out ++= variants
+    out.close()
+
+    val in = VcfSource(vcf)
+    in.query("chr1", 1000, 1020) should have size 3
+    in.query("chr1", 1500, 1599) should have size 10
+    in.query("chr1", 999,  2001) should have size 101
+    in.iterator should have size 101
+  }
+}

--- a/src/test/scala/com/fulcrumgenomics/vcf/api/VcfIoTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/vcf/api/VcfIoTest.scala
@@ -63,7 +63,7 @@ class VcfIoTest extends UnitSpec with OptionValues {
   case class Result(header: VcfHeader, vs: IndexedSeq[Variant])
 
   /** Writes out the variants to a file and reads them back, returning the header and the variants. */
-  @inline private def roundtrip(variants: TraversableOnce[Variant], header: VcfHeader = VcfIoTest.Header): Result = {
+  @inline private def roundtrip(variants: IterableOnce[Variant], header: VcfHeader = VcfIoTest.Header): Result = {
     val vcf = makeTempFile("test.", ".vcf")
     val out = VcfWriter(vcf, header)
     out ++= variants
@@ -86,12 +86,12 @@ class VcfIoTest extends UnitSpec with OptionValues {
   "VcfReader and VcfWriter" should "write a VCF and read back a VCF" in {
     val alleles = AlleleSet(ref=Allele("C"), alts=IndexedSeq(Allele("G"), Allele("T")))
     val variant = Variant(
-      chrom = "chr1",
-      pos   = 1000,
-      id    = Some("testvar"),
-      alleles = alleles,
-      qual    = Some(1234.5),
-      attrs = ListMap("DP" -> 120, "AC" -> Seq(1, 1), "STR" -> "."),
+      chrom     = "chr1",
+      pos       = 1000,
+      id        = Some("testvar"),
+      alleles   = alleles,
+      qual      = Some(1234.5),
+      attrs     = ListMap("DP" -> 120, "AC" -> Seq(1, 1), "STR" -> "."),
       genotypes = Map("s1" -> Genotype(alleles, "s1", alleles.alts, phased=false, attrs=Map("AD" -> Seq(0, 50, 54))))
     )
 

--- a/src/test/scala/com/fulcrumgenomics/vcf/api/VcfIoTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/vcf/api/VcfIoTest.scala
@@ -26,7 +26,6 @@ package com.fulcrumgenomics.vcf.api
 
 import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.testing.UnitSpec
-import com.fulcrumgenomics.vcf.api.Variant.ArrayAttribute
 import org.scalatest.OptionValues
 
 import scala.collection.immutable.ListMap
@@ -109,15 +108,15 @@ class VcfIoTest extends UnitSpec with OptionValues {
     variants.head.alleles.alts.map(_.toString)     should contain theSameElementsInOrderAs Seq("G", "T")
     variants.head.qual.value                       shouldBe 1234.5
     variants.head.apply[Int]("DP")                 shouldBe 120
-    variants.head.apply[ArrayAttribute[Int]]("AC") should contain theSameElementsInOrderAs Seq(1, 1)
-    variants.head.attrs.contains("STR")       shouldBe true
-    variants.head.attrs.contains("QD")        shouldBe false
+    variants.head.apply[ArrayAttr[Int]]("AC")      should contain theSameElementsInOrderAs Seq(1, 1)
+    variants.head.attrs.contains("STR")            shouldBe true
+    variants.head.attrs.contains("QD")             shouldBe false
 
     variants.head.genotypes.size           shouldBe 1
     val gt = variants.head.genotypes("s1")
     gt.gtWithBases                         shouldBe "G/T"
     gt.gtVcfStyle                          shouldBe "1/2"
-    gt[ArrayAttribute[Int]]("AD")          should contain theSameElementsInOrderAs Seq(0, 50, 54)
+    gt[ArrayAttr[Int]]("AD")               should contain theSameElementsInOrderAs Seq(0, 50, 54)
     gt.attrs.contains("PL")                shouldBe false
   }
 
@@ -142,20 +141,20 @@ class VcfIoTest extends UnitSpec with OptionValues {
     result.vs.head.alleles.alts.map(_.toString)     should contain theSameElementsInOrderAs Seq("G")
     result.vs.head.qual                             shouldBe None
     result.vs.head.apply[Int]("DP")                 shouldBe 205
-    result.vs.head.apply[ArrayAttribute[Int]]("AC") should contain theSameElementsInOrderAs Seq(1, 3)
+    result.vs.head.apply[ArrayAttr[Int]]("AC")      should contain theSameElementsInOrderAs Seq(1, 3)
 
     result.vs.head.genotypes.size shouldBe 2
     val Seq(s1, s2) = Seq("s1", "s2").map(result.vs.head.genotypes.apply)
 
     s1.gtWithBases                shouldBe "C/G"
     s1.gtVcfStyle                 shouldBe "0/1"
-    s1[ArrayAttribute[Int]]("AD") should contain theSameElementsInOrderAs Seq(50, 54)
-    s1[ArrayAttribute[Int]]("PL") should contain theSameElementsInOrderAs Seq(999, 41, 998)
+    s1[ArrayAttr[Int]]("AD")      should contain theSameElementsInOrderAs Seq(50, 54)
+    s1[ArrayAttr[Int]]("PL")      should contain theSameElementsInOrderAs Seq(999, 41, 998)
     s1[Int]("GQ")                 shouldBe 99
 
     s2.gtWithBases                shouldBe "G/G"
     s2.gtVcfStyle                 shouldBe "1/1"
-    s2[ArrayAttribute[Int]]("AD") should contain theSameElementsInOrderAs Seq(0, 101)
+    s2[ArrayAttr[Int]]("AD")      should contain theSameElementsInOrderAs Seq(0, 101)
     s2.attrs.contains("PL")       shouldBe false
     s2.attrs.contains("GQ")       shouldBe false
   }

--- a/src/test/scala/com/fulcrumgenomics/vcf/filtration/EndRepairArtifactLikelihoodFilterTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/vcf/filtration/EndRepairArtifactLikelihoodFilterTest.scala
@@ -24,6 +24,7 @@
 
 package com.fulcrumgenomics.vcf.filtration
 
+import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.bam.{BaseEntry, Pileup, PileupBuilder, PileupEntry}
 import com.fulcrumgenomics.testing.SamBuilder.{Minus, Plus}
 import com.fulcrumgenomics.testing.{SamBuilder, UnitSpec, VariantContextSetBuilder}


### PR DESCRIPTION
A complete wrapper around the HTSJDK VCF classes.  The goal here is to completely hide the HTSJDK implementations - the scala versions are standalone classes and there is a single `VcfConversions` class that translates back and forth between the HTSJDK objects and the scala versions when reading/writing VCFs and BCFs.

I'm slightly worried about the performance of this approach, but I think it's likely we won't notice for smaller VCFs, and if we end up dealing with multi-TB VCFs using this API we can revisit and either do some performance tuning _or_ do some of our own parsing at least of rows in the VCF.

For anyone else looking, @nh13 and I had a lot of discussion about how to facilitate easy access to common INFO and sample fields, given that all INFO and sample fields are strictly optional, but most of the time you're working with VCFs that have a raft of common values.  We've decided for now to leave this up to the user, using the provided `apply[A](key)` and `get[A](key)` methods, and that once we have some road time with the API we will loop back on this front.

A few thoughts on where things are at:

1. Do we like the naming on all the classes, types, etc?
2. Do we like that in `Genotype` the numeric alleles (i.e. `0/1`) are second class citizens to the `Allele` objects which include the bases/IDs.
3. Is there any functionality obviously missing?
4. Do any of us understand the ALT, PEDIGREE and SAMPLE header lines well enough to make classes for those and handle translation from HTSJDK headers?
