### PR TITLE
Moving cross-building to 2.12 and 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,8 +83,8 @@ lazy val commonSettings = Seq(
   organizationName     := "Fulcrum Genomics LLC",
   homepage             := Some(url("http://github.com/fulcrumgenomics/fgbio")),
   startYear            := Some(2015),
-  scalaVersion         := "2.12.8",
-  crossScalaVersions   :=  Seq("2.11.12", "2.12.8"),
+  scalaVersion         := "2.13.0",
+  crossScalaVersions   :=  Seq("2.12.8", "2.13.0"),
   scalacOptions        ++= Seq("-target:jvm-1.8", "-deprecation", "-unchecked"),
   scalacOptions in (Compile, doc) ++= docScalacOptions,
   scalacOptions in (Test, doc) ++= docScalacOptions,
@@ -122,17 +122,19 @@ lazy val root = Project(id="fgbio", base=file("."))
     libraryDependencies ++= Seq(
       "org.scala-lang"            %  "scala-reflect"  % scalaVersion.value,
       "org.scala-lang"            %  "scala-compiler" % scalaVersion.value,
-      "org.scala-lang.modules"    %% "scala-xml"      % "1.0.6",
-      "com.fulcrumgenomics"       %% "commons"        % "0.7.0",
-      "com.fulcrumgenomics"       %% "sopt"           % "0.7.0",
+      "org.scala-lang.modules"    %% "scala-xml"      % "1.2.0",
+      "org.scala-lang.modules"    %% "scala-collection-compat" % "2.1.1",
+      "com.fulcrumgenomics"       %% "commons"        % "0.8.0-87f4b88-SNAPSHOT",
+      "com.fulcrumgenomics"       %% "sopt"           % "0.8.0-6330673-SNAPSHOT",
       "com.github.samtools"       %  "htsjdk"         % "2.16.1" excludeAll(htsjdkExcludes: _*),
       "org.apache.commons"        %  "commons-math3"  % "3.6.1",
-      "com.beachape"              %% "enumeratum"     % "1.5.12",
+      "com.beachape"              %% "enumeratum"     % "1.5.13",
       "com.intel.gkl"             %  "gkl"            % "0.8.6",
 
       //---------- Test libraries -------------------//
-      "org.scalatest"             %% "scalatest"     % "3.0.4"  % "test->*" excludeAll ExclusionRule(organization="org.junit", name="junit")
+      "org.scalatest"             %% "scalatest"     % "3.0.8"  % "test->*" excludeAll ExclusionRule(organization="org.junit", name="junit")
     ))
+
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
 // Merge strategy for assembly

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.1
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("fix-sbt-plugin-releases", url("http://dl.bintray.com/
 addSbtPlugin("com.typesafe.sbt"  % "sbt-git"       % "0.9.3")
 addSbtPlugin("com.github.gseitz" % "sbt-release"   % "1.0.6")
 addSbtPlugin("com.eed3si9n"      % "sbt-assembly"  % "0.14.6")
-addSbtPlugin("org.scoverage"     % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("org.scoverage"     % "sbt-scoverage" % "1.6.0")
 addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"  % "2.2")
 addSbtPlugin("com.jsuereth"      % "sbt-pgp"       % "1.1.0")
 addSbtPlugin("net.virtual-void"  % "sbt-dependency-graph" % "0.9.0")

--- a/src/main/java/com/fulcrumgenomics/util/PickLongIndices.scala
+++ b/src/main/java/com/fulcrumgenomics/util/PickLongIndices.scala
@@ -179,7 +179,7 @@ class PickLongIndices
   private val dnaFoldPredictor = viennaRnaDir.map(dir => new DnaFoldPredictor(dir.toFile, temperature))
   private[util] val adapterRegex = Pattern.compile("^[ACGT]*N+[ACGT]*$")
   adapters.map(_.toUpperCase).filterNot(adapterRegex.matcher(_).matches()) match {
-    case Seq() => Unit
+    case Seq() => ()
     case xs    => invalid(s"Adapters must be all [ACGT] with a single contiguous block of Ns where the index goes: ${xs}")
   }
 
@@ -332,7 +332,7 @@ class PickLongIndices
         x.distances.count(n)
         y.distances.count(n)
       }
-      case _ => Unit
+      case _ => ()
     }
 
     val metrics = annotated.map { ann =>

--- a/src/main/scala/com/fulcrumgenomics/alignment/Aligner.scala
+++ b/src/main/scala/com/fulcrumgenomics/alignment/Aligner.scala
@@ -415,7 +415,7 @@ class Aligner(val scorer: AlignmentScorer,
                                   location: MatrixLocation): Alignment = {
     var currOperator: CigarOperator = null
     var currLength: Direction = 0
-    val elems = new mutable.ArrayBuffer[CigarElem]()
+    val elems = IndexedSeq.newBuilder[CigarElem]
     var MatrixLocation(curI, curJ, curD) = location
 
     // The score is always the score from the starting cell
@@ -453,7 +453,7 @@ class Aligner(val scorer: AlignmentScorer,
       if (nextD == Done) elems += CigarElem(currOperator, currLength)
     }
 
-    Alignment(query=query, target=target, queryStart=curI+1, targetStart=curJ+1, cigar=Cigar(elems.reverse), score=score)
+    Alignment(query=query, target=target, queryStart=curI+1, targetStart=curJ+1, cigar=Cigar(elems.result.reverse), score=score)
   }
 
   /**
@@ -512,7 +512,7 @@ class Aligner(val scorer: AlignmentScorer,
   private def findByScore(matrices: Array[AlignmentMatrix], minScore: Int): Seq[MatrixLocation] = {
     val qLen = matrices(0).queryLength
     val tLen = matrices(0).targetLength
-    val hits = new ArrayBuffer[MatrixLocation]()
+    val hits = IndexedSeq.newBuilder[MatrixLocation]
 
     this.mode match {
       case Global =>
@@ -532,7 +532,7 @@ class Aligner(val scorer: AlignmentScorer,
         }
     }
 
-    hits
+    hits.result
   }
 
   /** Returns true if the two bases should be considered a match when generating the alignment from the matrix

--- a/src/main/scala/com/fulcrumgenomics/bam/Bams.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/Bams.scala
@@ -92,7 +92,7 @@ case class Template(r1: Option[SamRecord],
 
     (x1, x2) match {
       case (Some(a), Some(b)) => SamPairUtil.setMateInfo(a.asSam, b.asSam)
-      case _ => Unit
+      case _ => ()
     }
 
     Template(x1, x2)

--- a/src/main/scala/com/fulcrumgenomics/bam/BaseCounts.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/BaseCounts.scala
@@ -39,7 +39,7 @@ object BaseCounts {
     * Generates a BaseCounts object from a collection of RecordAndOffest objects
     * representing a pileup.  Ensures that each template is only counted once.
     */
-  def apply(recs: Traversable[SamLocusIterator.RecordAndOffset]): BaseCounts = {
+  def apply(recs: Iterable[SamLocusIterator.RecordAndOffset]): BaseCounts = {
     val countsByBase = recs.groupBy(r => Character.toUpperCase(r.getReadBase.toChar))
       .map { case (ch, rs) => (ch, rs.map(_.getRecord.getReadName).toSeq.distinct.size) }
 

--- a/src/main/scala/com/fulcrumgenomics/bam/ClipBam.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ClipBam.scala
@@ -114,7 +114,7 @@ class ClipBam
           template.r2Supplementals.foreach(s => SamPairUtil.setMateInformationOnSupplementalAlignment(s.asSam, r1.asSam, true))
         case (Some(frag), None) =>
           clipFragment(frag=frag, metric=metricsMap.get(ReadType.Fragment))
-        case _ => Unit
+        case _ => ()
       }
 
       template.allReads.foreach { r =>
@@ -143,7 +143,7 @@ class ClipBam
       metricsMap.foreach {
         case (Fragment, metric)          => metricsMap(All).add(metric)
         case (ReadOne | ReadTwo, metric) => Seq(Pair, All).foreach { r => metricsMap(r).add(metric) }
-        case _                           => Unit
+        case _                           => ()
       }
       // Write it!
       Metric.write(path, ReadType.values.map { readType => metricsMap(readType)})

--- a/src/main/scala/com/fulcrumgenomics/bam/ClipBam.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ClipBam.scala
@@ -71,9 +71,7 @@ class ClipBam
   @arg(flag='o', doc="Output SAM or BAM file.") val output: PathToBam,
   @arg(flag='m', doc="Optional output of clipping metrics.") val metrics: Option[FilePath] = None,
   @arg(flag='r', doc="Reference sequence fasta file.") val ref: PathToFasta,
-  @deprecated("Use clipping-mode instead.", since="0.4.0")
-  @arg(flag='s', doc="Soft clip reads instead of hard clipping.", mutex=Array("clippingMode")) val softClip: Boolean = false,
-  @arg(flag='c', doc="The type of clipping to perform.", mutex=Array("softClip")) val clippingMode: Option[ClippingMode] = None,
+  @arg(flag='c', doc="The type of clipping to perform.") val clippingMode: ClippingMode = ClippingMode.Hard,
   @arg(flag='a', doc="Automatically clip extended attributes that are the same length as bases.") val autoClipAttributes: Boolean = false,
   @arg(flag='H', doc="Upgrade all existing clipping in the input to the given clipping mode prior to applying any other clipping criteria.") val upgradeClipping: Boolean = false,
   @arg(          doc="Require at least this number of bases to be clipped on the 5' end of R1") val readOneFivePrime: Int  = 0,
@@ -86,12 +84,10 @@ class ClipBam
   Io.assertReadable(ref)
   Io.assertCanWriteFile(output)
 
-  private val mode = this.clippingMode.getOrElse { if (this.softClip) ClippingMode.Soft else ClippingMode.Hard }
-
   validate(upgradeClipping || clipOverlappingReads || Seq(readOneFivePrime, readOneThreePrime, readTwoFivePrime, readTwoThreePrime).exists(_ != 0),
     "At least one clipping option is required")
 
-  private val clipper = new SamRecordClipper(mode=this.mode, autoClipAttributes=autoClipAttributes)
+  private val clipper = new SamRecordClipper(mode=clippingMode, autoClipAttributes=autoClipAttributes)
 
   override def execute(): Unit = {
     val in         = SamSource(input)

--- a/src/main/scala/com/fulcrumgenomics/bam/ErrorRateByReadPosition.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ErrorRateByReadPosition.scala
@@ -102,8 +102,8 @@ class ErrorRateByReadPosition
     val in          = SamSource(input, ref=Some(ref))
     val metrics     = computeMetrics(in)
     val prefix      = output.getOrElse(PathUtil.removeExtension(input))
-    val metricsPath = PathUtil.pathTo(prefix + ErrorRateByReadPositionMetric.FileExtension)
-    val plotPath    = PathUtil.pathTo(prefix + ErrorRateByReadPositionMetric.PlotExtension)
+    val metricsPath = PathUtil.pathTo(s"${prefix}${ErrorRateByReadPositionMetric.FileExtension}")
+    val plotPath    = PathUtil.pathTo(s"${prefix}${ErrorRateByReadPositionMetric.PlotExtension}")
     Metric.write(metricsPath, metrics=metrics)
 
     // And try plotting
@@ -114,7 +114,7 @@ class ErrorRateByReadPosition
       val description = plotDescription(in, input)
       Rscript.execIfAvailable(ScriptPath, metricsPath.toString, plotPath.toString, description) match {
         case Failure(e) => logger.warning(s"Generation of PDF plots failed: ${e.getMessage}")
-        case _ => Unit
+        case _ => ()
       }
     }
   }

--- a/src/main/scala/com/fulcrumgenomics/bam/FindSwitchbackReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/FindSwitchbackReads.scala
@@ -401,7 +401,7 @@ class FindSwitchbackReads
         mean_gap                 = switchbackGaps.mean()
       )
 
-      Metric.write(PathUtil.pathTo(prefix + ".summary.txt"), m)
+      Metric.write(PathUtil.pathTo(s"${prefix}.summary.txt"), m)
 
       Seq(
         ("lengths", switchbackLengths, "length"),

--- a/src/main/scala/com/fulcrumgenomics/bam/FindTechnicalReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/FindTechnicalReads.scala
@@ -93,7 +93,7 @@ class FindTechnicalReads
       val recs = Seq(Some(r1), r2).flatten
 
       val isTechnical = if (isUnmappedTemplate(r1)) {
-        recs.toStream.flatMap(r => matcher.findMatch(r.bases)).headOption match {
+        recs.view.flatMap(r => matcher.findMatch(r.bases)).headOption match {
           case None =>
             false
           case Some(hit) =>

--- a/src/main/scala/com/fulcrumgenomics/bam/SamRecordClipper.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/SamRecordClipper.scala
@@ -360,7 +360,7 @@ class SamRecordClipper(val mode: ClippingMode, val autoClipAttributes: Boolean) 
       val addedHardClip = existingSoftClip + readBasesClipped
       val totalHardClip = existingHardClip + addedHardClip
       newElems.prepend(CigarElem(Op.HARD_CLIP, totalHardClip))
-      (newElems, readBasesClipped, refBasesClipped, bases.drop(addedHardClip), quals.drop(addedHardClip))
+      (newElems.toIndexedSeq, readBasesClipped, refBasesClipped, bases.drop(addedHardClip), quals.drop(addedHardClip))
     }
     else {
       val addedSoftClip = readBasesClipped
@@ -368,7 +368,7 @@ class SamRecordClipper(val mode: ClippingMode, val autoClipAttributes: Boolean) 
       newElems.prepend(CigarElem(Op.SOFT_CLIP, totalSoftClip))
       if (existingHardClip > 0) newElems.prepend(CigarElem(Op.HARD_CLIP, existingHardClip))
       if (mode == ClippingMode.SoftWithMask) hardMaskStartOfRead(bases, quals, totalSoftClip)
-      (newElems, readBasesClipped, refBasesClipped, bases, quals)
+      (newElems.toIndexedSeq, readBasesClipped, refBasesClipped, bases, quals)
     }
   }
 
@@ -388,7 +388,7 @@ class SamRecordClipper(val mode: ClippingMode, val autoClipAttributes: Boolean) 
       rec.attributes.foreach {
         case (tag, s: String)   if s.length == oldLength => rec(tag) = if (fromStart) s.drop(remove) else s.take(newLength)
         case (tag, a: Array[_]) if a.length == oldLength => rec(tag) = if (fromStart) a.drop(remove) else a.take(newLength)
-        case _  => Unit
+        case _  => ()
       }
     }
   }
@@ -425,7 +425,7 @@ class SamRecordClipper(val mode: ClippingMode, val autoClipAttributes: Boolean) 
         case ClippingMode.Hard =>
           bases = bases.drop(lengthToUpgrade)
           quals = quals.drop(lengthToUpgrade)
-          val newElems = ArrayBuffer[CigarElem]()
+          val newElems = IndexedSeq.newBuilder[CigarElem]
 
           elems match {
             case CigarElem(Op.H, h) +: CigarElem(Op.S, s) +: remaining =>
@@ -440,7 +440,7 @@ class SamRecordClipper(val mode: ClippingMode, val autoClipAttributes: Boolean) 
               unreachable(s"Cigar $es doesn't contain soft clipping at the start")
           }
 
-          elems = newElems
+          elems = newElems.result
       }
 
       if (fromStart) {

--- a/src/main/scala/com/fulcrumgenomics/bam/TrimPrimers.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/TrimPrimers.scala
@@ -38,6 +38,8 @@ import htsjdk.samtools._
 import htsjdk.samtools.reference.ReferenceSequenceFileWalker
 import htsjdk.samtools.util._
 
+import scala.collection.BufferedIterator
+
 object TrimPrimers {
   val Headers: Seq[String] = Seq("chrom", "left_start", "left_end", "right_start", "right_end")
   val Seq(hdChrom, hdleftStart, hdLeftEnd, hdRightStart, hdRightEnd) = Headers
@@ -145,7 +147,7 @@ class TrimPrimers
         }
 
         sorter.safelyClose()
-      case _ => Unit
+      case _ => ()
     }
 
     out.close()

--- a/src/main/scala/com/fulcrumgenomics/bam/api/SamWriter.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/api/SamWriter.scala
@@ -27,7 +27,7 @@ package com.fulcrumgenomics.bam.api
 import java.io.Closeable
 
 import com.fulcrumgenomics.FgBioDef._
-import com.fulcrumgenomics.Writer
+import com.fulcrumgenomics.commons.io.Writer
 import com.fulcrumgenomics.commons.util.LazyLogging
 import com.fulcrumgenomics.util.{ProgressLogger, Sorter}
 import htsjdk.samtools.SAMFileHeader.SortOrder

--- a/src/main/scala/com/fulcrumgenomics/basecalling/ExtractBasecallingParamsForPicard.scala
+++ b/src/main/scala/com/fulcrumgenomics/basecalling/ExtractBasecallingParamsForPicard.scala
@@ -159,7 +159,7 @@ object BasecallingParams {
     Io.writeLines(path=barcodeFile, lines=barcodeLines)
     Io.writeLines(path=libraryParamsFile, lines=libraryParamLines)
 
-    BasecallingParams(lane=lane, barcodeFile=barcodeFile, libraryParamsFile=libraryParamsFile, bams=bams)
+    BasecallingParams(lane=lane, barcodeFile=barcodeFile, libraryParamsFile=libraryParamsFile, bams=bams.toSeq)
   }
 
   /** The lane-specific file containing information necessary to run Picard's ExtractIlluminaBarcodes and

--- a/src/main/scala/com/fulcrumgenomics/cmdline/FgBioMain.scala
+++ b/src/main/scala/com/fulcrumgenomics/cmdline/FgBioMain.scala
@@ -128,7 +128,7 @@ class FgBioMain extends LazyLogging {
     }
 
     val startTime = System.currentTimeMillis()
-    val exit      = Sopt.parseCommandAndSubCommand[FgBioCommonArgs,FgBioTool](name, args, Sopt.find[FgBioTool](packageList)) match {
+    val exit      = Sopt.parseCommandAndSubCommand[FgBioCommonArgs,FgBioTool](name, args.toIndexedSeq, Sopt.find[FgBioTool](packageList)) match {
       case Sopt.Failure(usage) =>
         System.err.print(usage())
         1
@@ -147,7 +147,7 @@ class FgBioMain extends LazyLogging {
             val banner = "#" * ex.message.map(_.length).getOrElse(80)
             logger.fatal(banner)
             logger.fatal("Execution failed!")
-            ex.message.foreach(msg => msg.lines.foreach(logger.fatal))
+            ex.message.foreach(msg => msg.linesIterator.foreach(logger.fatal))
             logger.fatal(banner)
             printEndingLines(startTime, name, false)
             ex.exit

--- a/src/main/scala/com/fulcrumgenomics/fastq/DemuxFastqs.scala
+++ b/src/main/scala/com/fulcrumgenomics/fastq/DemuxFastqs.scala
@@ -297,9 +297,7 @@ class DemuxFastqs
  @arg(doc="Platform model to insert into the group header (ex. miseq, hiseq2500, hiseqX)") val platformModel: Option[String] = None,
  @arg(doc="Comment(s) to include in the merged output file's header.", minElements = 0) val comments: List[String] = Nil,
  @arg(doc="Date the run was produced, to insert into the read group header") val runDate: Option[Iso8601Date] = None,
- @arg(doc="The type of outputs to produce.", mutex=Array("outputFastqs")) var outputType: Option[OutputType] = None,
- @deprecated("Use outputType instead.", since="0.5.0")
- @arg(doc="*** Deprecated: use --output-type instead ***. Output gzipped FASTQs (`.fastq.gz`) instead of BAM files", mutex=Array("outputType")) val outputFastqs: Option[Boolean] = None,
+ @arg(doc="The type of outputs to produce.") val outputType: Option[OutputType] = None,
  @arg(doc="Output FASTQs according to Illumina naming standards, for example, for upload to the BaseSpace Sequence Hub") val illuminaStandards: Boolean = false,
  @arg(
    doc=
@@ -315,11 +313,9 @@ class DemuxFastqs
   private[fastq] val metricsPath = metrics.getOrElse(output.resolve(DefaultDemuxMetricsFileName))
 
   // NB: remove me when outputFastqs gets removed and use outputType directly
-  private val _outputType = (this.outputType, this.outputFastqs) match {
-    case (None, None) => OutputType.Bam
-    case (None, Some(fastqs)) => if (fastqs) OutputType.Fastq else OutputType.Bam
-    case (Some(tpe), None) => tpe
-    case _ => unreachable("Bug: outputType and outputFastqs should never be both defined")
+  private val _outputType = this.outputType match {
+    case Some(tpe) => tpe
+    case None      => OutputType.Bam
   }
 
   validate(inputs.length == readStructures.length, "The same number of read structures should be given as FASTQs.")

--- a/src/main/scala/com/fulcrumgenomics/fastq/FastqWriter.scala
+++ b/src/main/scala/com/fulcrumgenomics/fastq/FastqWriter.scala
@@ -26,7 +26,7 @@ package com.fulcrumgenomics.fastq
 import java.io.{BufferedWriter, Closeable}
 import java.nio.file.Path
 
-import com.fulcrumgenomics.Writer
+import com.fulcrumgenomics.commons.io.Writer
 import com.fulcrumgenomics.util.Io
 
 /**
@@ -37,9 +37,9 @@ object FastqWriter {
   def apply(path: Path): FastqWriter = apply(Io.toWriter(path))
 
   /** Constructs a FastqWriter from a Writer. */
-  def apply(writer: java.io.Writer): FastqWriter = {
-    if (writer.isInstanceOf[BufferedWriter]) new FastqWriter(writer.asInstanceOf[BufferedWriter])
-    else new FastqWriter(new BufferedWriter(writer))
+  def apply(writer: java.io.Writer): FastqWriter = writer match {
+    case bw: BufferedWriter => new FastqWriter(bw)
+    case w                  => new FastqWriter(new BufferedWriter(w))
   }
 }
 

--- a/src/main/scala/com/fulcrumgenomics/fastq/SortFastq.scala
+++ b/src/main/scala/com/fulcrumgenomics/fastq/SortFastq.scala
@@ -37,7 +37,7 @@ object SortFastq {
 
     /** Decodes the record from the fastq string. */
     override def decode(bs: Array[Byte], start: Int, length: Int): FastqRecord = {
-      val lines = new String(bs, start, length).lines
+      val lines = new String(bs, start, length).linesIterator
       val name       = lines.next().substring(1)
       val bases      = lines.next()
       val qualHeader = lines.next()

--- a/src/main/scala/com/fulcrumgenomics/internal/BuildToolDocs.scala
+++ b/src/main/scala/com/fulcrumgenomics/internal/BuildToolDocs.scala
@@ -113,7 +113,7 @@ class BuildToolDocs
         a.name,
         a.flag.getOrElse(""),
         a.kind,
-        a.description.lines.mkString(" "),
+        a.description.linesIterator.mkString(" "),
         if (a.minValues == 0) "Optional" else "Required",
         if (a.maxValues == Int.MaxValue) "Unlimited" else a.maxValues,
         a.defaultValues.mkString(", ")

--- a/src/main/scala/com/fulcrumgenomics/internal/FgMetricsDoclet.scala
+++ b/src/main/scala/com/fulcrumgenomics/internal/FgMetricsDoclet.scala
@@ -29,9 +29,11 @@ import java.nio.file.Paths
 
 import com.fulcrumgenomics.util.Metric
 
+import scala.tools.nsc.Settings
 import scala.tools.nsc.doc.base.comment._
 import scala.tools.nsc.doc.html.Doclet
 import scala.tools.nsc.doc.model.DocTemplateEntity
+import scala.tools.nsc.reporters.ConsoleReporter
 
 /** Case class to capture information about a field/column in a metrics class/file. */
 case class ColumnDescription(name: String, typ: String, description: String)
@@ -45,7 +47,7 @@ case class MetricDescription(name: String, description: String, columns: Seq[Col
   * Custom scaladoc Doclet for rendering the documentation for [[com.fulcrumgenomics.util.Metric]] classes into
   * MarkDown for display on the fgbio website.
   */
-class FgMetricsDoclet extends Doclet {
+class FgMetricsDoclet extends Doclet(reporter = new ConsoleReporter(new Settings())) {
   /**
     * Main entry point for the doclet.  Scans for documentation for the metrics classes and
     * renders it into MarkDown.
@@ -131,11 +133,11 @@ class FgMetricsDoclet extends Doclet {
     def renderBlock(block: Block, indent: String): Unit = {
       block match {
         case para:  Paragraph      => render(para.text)
-        case dlist: DefinitionList => Unit // TODO
-        case hr:    HorizontalRule => Unit // TODO
-        case olist: OrderedList    => Unit // TODO
+        case dlist: DefinitionList => () // TODO
+        case hr:    HorizontalRule => () // TODO
+        case olist: OrderedList    => () // TODO
         case title: Title          => buffer.append("#" * title.level).append(" "); render(title.text); buffer.append("\n\n")
-        case ulist: UnorderedList  => Unit // TODO
+        case ulist: UnorderedList  => () // TODO
       }
     }
 

--- a/src/main/scala/com/fulcrumgenomics/internal/InternalTools.scala
+++ b/src/main/scala/com/fulcrumgenomics/internal/InternalTools.scala
@@ -38,7 +38,7 @@ trait InternalTool extends LazyLogging {
 object InternalTools {
   def main(args: Array[String]): Unit = {
     val tools = Sopt.find[InternalTool](packages=Seq("com.fulcrumgenomics.internal"))
-    Sopt.parseCommand[InternalTool]("fgbio-internal", args, tools) match {
+    Sopt.parseCommand[InternalTool]("fgbio-internal", args.toIndexedSeq, tools) match {
       case Failure(usage) => {
         System.err.println(usage())
         System.exit(1)

--- a/src/main/scala/com/fulcrumgenomics/personal/nhomer/SplitTag.scala
+++ b/src/main/scala/com/fulcrumgenomics/personal/nhomer/SplitTag.scala
@@ -31,6 +31,8 @@ import com.fulcrumgenomics.commons.io.Io
 import com.fulcrumgenomics.sopt._
 import htsjdk.samtools.util.CloserUtil
 
+import scala.collection.compat._
+
 @clp(
   description = "Splits an optional tag in a SAM or BAM into multiple optional tags.",
   group = ClpGroups.Personal

--- a/src/main/scala/com/fulcrumgenomics/rnaseq/CollectErccMetrics.scala
+++ b/src/main/scala/com/fulcrumgenomics/rnaseq/CollectErccMetrics.scala
@@ -189,7 +189,7 @@ class CollectErccMetrics
 
     // Write the output
     {
-      def f(ext: String): FilePath = PathUtil.pathTo(output + ext)
+      def f(ext: String): FilePath = PathUtil.pathTo(s"${output}${ext}")
 
       val summaryPath  = f(".ercc_summary_metrics.txt")
       val detailedPath = f(".ercc_detailed_metrics.txt")
@@ -218,7 +218,7 @@ class CollectErccMetrics
       else {
         Rscript.execIfAvailable(ScriptPath, detailedPath.toString, plotPath.toString, plotDescription(in, input), minTranscriptCount.toString) match {
           case Failure(e) => logger.warning(s"Generation of PDF plots failed: ${e.getMessage}")
-          case _ => Unit
+          case _ => ()
         }
       }
     }

--- a/src/main/scala/com/fulcrumgenomics/rnaseq/EstimateRnaSeqInsertSize.scala
+++ b/src/main/scala/com/fulcrumgenomics/rnaseq/EstimateRnaSeqInsertSize.scala
@@ -102,7 +102,7 @@ class EstimateRnaSeqInsertSize
 
     recordIterator.foreach { rec =>
       calculateInsertSize(rec=rec) match {
-        case None             => Unit // ignore
+        case None             => () // ignore
         case Some(insertSize) => counters(rec.pairOrientation).count(insertSize)
       }
     }
@@ -138,11 +138,12 @@ class EstimateRnaSeqInsertSize
     }
 
     // Write the metrics
-    val metricPath = PathUtil.pathTo(prefix.getOrElse(PathUtil.removeExtension(input)) + RnaSeqInsertSizeMetricExtension)
+    val actualPrefix = prefix.getOrElse(PathUtil.removeExtension(input))
+    val metricPath = PathUtil.pathTo(s"${actualPrefix}${RnaSeqInsertSizeMetricExtension}")
     Metric.write(metricPath, metrics)
 
     // Write the histogram
-    val histogramPath   = PathUtil.pathTo(prefix.getOrElse(PathUtil.removeExtension(input)) + RnaSeqInsertSizeMetricHistogramExtension)
+    val histogramPath   = PathUtil.pathTo(s"${actualPrefix}${RnaSeqInsertSizeMetricHistogramExtension}")
     val histogramKeys   = pairOrientations.flatMap(counters(_).iterator.map(_._1)).distinct.sorted.toList
     val histogramHeader = ("insert_size" +: pairOrientations.map(_.name().toLowerCase)).mkString("\t")
     val histogramLines  = histogramHeader +: histogramKeys.map { insertSize =>

--- a/src/main/scala/com/fulcrumgenomics/testing/SamBuilder.scala
+++ b/src/main/scala/com/fulcrumgenomics/testing/SamBuilder.scala
@@ -63,7 +63,7 @@ class SamBuilder(val readLength: Int=100,
   { // Build the default dictionary
     val dict: SAMSequenceDictionary = sd.getOrElse {
       val seqs = (Range.inclusive(1, 22) ++ Seq("X", "Y", "M")).map { chr => new SAMSequenceRecord("chr" + chr, 200e6.toInt) }
-      new SAMSequenceDictionary(seqs.toIterator.toJavaList)
+      new SAMSequenceDictionary(seqs.iterator.toJavaList)
     }
     header.setSequenceDictionary(dict)
   }
@@ -111,8 +111,8 @@ class SamBuilder(val readLength: Int=100,
               start2: Int = SAMRecord.NO_ALIGNMENT_START,
               unmapped1: Boolean = false,
               unmapped2: Boolean = false,
-              cigar1: String = readLength + "M",
-              cigar2: String = readLength + "M",
+              cigar1: String = s"${readLength}M",
+              cigar2: String = s"${readLength}M",
               mapq1: Int = 60,
               mapq2: Int = 60,
               strand1: Strand = Plus,
@@ -180,7 +180,7 @@ class SamBuilder(val readLength: Int=100,
               contig: Int = 0,
               start: Int  = SAMRecord.NO_ALIGNMENT_START,
               unmapped: Boolean = false,
-              cigar: String = readLength + "M",
+              cigar: String = s"${readLength}M",
               mapq: Int = 60,
               strand: Strand = Plus,
               attrs: Map[String,Any] = Map.empty) : Option[SamRecord] = {

--- a/src/main/scala/com/fulcrumgenomics/testing/VariantContextSetBuilder.scala
+++ b/src/main/scala/com/fulcrumgenomics/testing/VariantContextSetBuilder.scala
@@ -35,6 +35,7 @@ import htsjdk.variant.variantcontext.writer.{Options, VariantContextWriterBuilde
 import htsjdk.variant.vcf.{VCFFileReader, VCFHeader, VCFHeaderLine}
 
 import scala.collection.mutable.ListBuffer
+import scala.collection.compat._
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 
@@ -87,7 +88,7 @@ class VariantContextSetBuilder(sampleNames: Seq[String] = List("Sample")) extend
     *
     * Genotype attributes may be given with the `genotypeAttributes` parameter.  The value for the `GQ` and `DP`
     * attributes must have type [[Int]].  The value for the `AD` and `PL` attributes must have either type
-    * [[TraversableOnce]] or [[Array]], with each item having type [[Int]].  For example:
+    * [[IterableOnce]] or [[Array]], with each item having type [[Int]].  For example:
     * {{{
     *   val builder = new VariantContextSetBuilder()
     *   builder.addVariant(
@@ -177,10 +178,10 @@ class VariantContextSetBuilder(sampleNames: Seq[String] = List("Sample")) extend
     * or if any element in `v` is not of type `T` .*/
   private def anyToArray[T : ClassTag](k: String, v: Any, typeName: String): Array[T] = {
     val values = v match {
-      case _v: TraversableOnce[_] => _v.toArray[Any]
+      case _v: IterableOnce[_] => _v.iterator.toArray[Any]
       case _v: Array[_]           => _v
       case _                      =>
-        throw new IllegalArgumentException(s"$k attribute value must be an TraversableOnce[$typeName], found ${v.getClass.getSimpleName}")
+        throw new IllegalArgumentException(s"$k attribute value must be an IterableOnce[$typeName], found ${v.getClass.getSimpleName}")
     }
     values.map(anyToType[T](k, _, typeName))
   }

--- a/src/main/scala/com/fulcrumgenomics/umi/CallDuplexConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CallDuplexConsensusReads.scala
@@ -132,7 +132,7 @@ class CallDuplexConsensusReads
       maxReadsPerStrand   = maxReadsPerStrand.getOrElse(VanillaUmiConsensusCallerOptions.DefaultMaxReads)
     )
     val progress = ProgressLogger(logger, unit=1000000)
-    val iterator = new ConsensusCallingIterator(in.toIterator, caller, Some(progress), threads)
+    val iterator = new ConsensusCallingIterator(in.iterator, caller, Some(progress), threads)
     out ++= iterator
     progress.logLast()
 

--- a/src/main/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReads.scala
@@ -163,7 +163,7 @@ class CallMolecularConsensusReads
       rejects        = rej
     )
 
-    val iterator = new ConsensusCallingIterator(in.toIterator, caller, Some(ProgressLogger(logger, unit=5e5.toInt)))
+    val iterator = new ConsensusCallingIterator(in.iterator, caller, Some(ProgressLogger(logger, unit=5e5.toInt)))
     out ++= iterator
 
     in.safelyClose()

--- a/src/main/scala/com/fulcrumgenomics/umi/ConsensusCallingIterator.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/ConsensusCallingIterator.scala
@@ -24,6 +24,8 @@
 
 package com.fulcrumgenomics.umi
 
+import java.util.concurrent.ForkJoinPool
+
 import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.bam.api.SamRecord
 import com.fulcrumgenomics.commons.async.AsyncIterator
@@ -31,7 +33,7 @@ import com.fulcrumgenomics.commons.util.LazyLogging
 import com.fulcrumgenomics.umi.UmiConsensusCaller.SimpleRead
 import com.fulcrumgenomics.util.ProgressLogger
 
-import scala.concurrent.forkjoin.ForkJoinPool
+import java.util.concurrent.ForkJoinPool
 
 /**
   * An iterator that consumes from an incoming iterator of [[SamRecord]]s and generates consensus
@@ -55,7 +57,7 @@ class ConsensusCallingIterator[ConsensusRead <: SimpleRead](sourceIterator: Iter
     case None    => sourceIterator
   }
 
-  protected val iterator: Iterator[SamRecord] = {
+  protected val iter: Iterator[SamRecord] = {
     if (threads <= 1) {
       val groupingIterator = new SamRecordGroupedIterator(progressIterator, caller.sourceMoleculeId)
       groupingIterator.flatMap(caller.consensusReadsFromSamRecords)
@@ -99,8 +101,8 @@ class ConsensusCallingIterator[ConsensusRead <: SimpleRead](sourceIterator: Iter
 
     }
   }
-  override def hasNext: Boolean = this.iterator.hasNext
-  override def next(): SamRecord = this.iterator.next
+  override def hasNext: Boolean = this.iter.hasNext
+  override def next(): SamRecord = this.iter.next
 }
 
 // TODO: migrate to the commons version of this class after the next commons release
@@ -115,7 +117,7 @@ private class IterableThreadLocal[A](factory: () => A) extends ThreadLocal[A] wi
   }
 
   /** Care should be taken accessing the iterator since objects may be in use by other threads. */
-  def iterator: Iterator[A] = all.toIterator
+  def iterator: Iterator[A] = all.iterator
 }
 
 

--- a/src/main/scala/com/fulcrumgenomics/umi/CorrectUmis.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CorrectUmis.scala
@@ -150,7 +150,7 @@ class CorrectUmis
     }
 
     // Warn if any of the UMIs are too close together
-    CorrectUmis.findUmiPairsWithinDistance(umiSequences, minDistance-1).foreach { case (umi1, umi2, distance) =>
+    CorrectUmis.findUmiPairsWithinDistance(umiSequences.toSeq, minDistance-1).foreach { case (umi1, umi2, distance) =>
         logger.warning(s"Umis $umi1 and $umi2 are $distance edits apart which is less than the min distance: $minDistance")
     }
 
@@ -173,7 +173,7 @@ class CorrectUmis
           if (missingUmisRecords == 0) logger.warning(s"Read (${rec.name}) detected without UMI in tag $umiTag")
           missingUmisRecords += 1
           rejectOut.foreach(w => w += rec)
-        case Some(umi) =>
+        case Some(umi: String) =>
           val sequences = umi.split('-')
           if (sequences.exists(_.length != umiLength)) {
             if (wrongLengthRecords == 0) logger.warning(s"Read (${rec.name}) detected with unexpected length UMI(s): ${sequences.mkString(" ")}")

--- a/src/main/scala/com/fulcrumgenomics/umi/ExtractUmisFromBam.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/ExtractUmisFromBam.scala
@@ -263,8 +263,8 @@ object ExtractUmisFromBam {
                                              clippingAttribute: Option[String],
                                              readStructure: ReadStructure): Unit = {
     clippingAttribute.map(tag => (tag, record.get[Int](tag))) match {
-      case None => Unit
-      case Some((tag, None)) => Unit
+      case None => ()
+      case Some((tag, None)) => ()
       case Some((tag, Some(clippingPosition))) =>
         val newClippingPosition = readStructure.takeWhile(_.offset < clippingPosition).filter(_.kind == SegmentType.Template).map { t =>
           if (t.length.exists(l => t.offset + l < clippingPosition)) t.length.get

--- a/src/main/scala/com/fulcrumgenomics/umi/ReviewConsensusVariants.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/ReviewConsensusVariants.scala
@@ -171,7 +171,7 @@ class ReviewConsensusVariants
   }
 
   override def execute(): Unit = {
-    def f(ext: String): Path = output.getParent.resolve(output.getFileName + ext)
+    def f(ext: String): Path = output.getParent.resolve(s"${output.getFileName}${ext}")
 
     val consensusIn  = SamSource(consensusBam)
     val groupedIn    = SamSource(groupedBam)

--- a/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
@@ -193,7 +193,7 @@ trait UmiConsensusCaller[ConsensusRead <: SimpleRead] {
   def consensusReadsConstructed: Long = _consensusReadsConstructed
 
   /** Records that the supplied records were rejected, and not used to build a consensus read. */
-  protected def rejectRecords(recs: Traversable[SamRecord], reason: String) : Unit = this._filteredReads.count(reason, recs.size)
+  protected def rejectRecords(recs: Iterable[SamRecord], reason: String) : Unit = this._filteredReads.count(reason, recs.size)
 
   /** Records that the supplied records were rejected, and not used to build a consensus read. */
   protected def rejectRecords(reason: String, rec: SamRecord*) : Unit = rejectRecords(rec, reason)
@@ -257,7 +257,7 @@ trait UmiConsensusCaller[ConsensusRead <: SimpleRead] {
 
     len match {
       case 0 =>
-        rejectRecords(Traversable(rec), FilterLowQuality)
+        rejectRecords(Iterable(rec), FilterLowQuality)
         None
       case n if n == bases.length =>
         Some(SourceRead(sourceMoleculeId(rec), bases, quals, cigar, Some(rec)))
@@ -354,7 +354,8 @@ trait UmiConsensusCaller[ConsensusRead <: SimpleRead] {
         if (bestGroup.contains(i)) keepers += sorted(i)
         else sorted(i).sam.foreach(rejectRecords(FilterMinorityAlignment, _))
       }
-      keepers
+
+      keepers.toIndexedSeq
     }
   }
 

--- a/src/main/scala/com/fulcrumgenomics/util/GeneAnnotations.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/GeneAnnotations.scala
@@ -33,7 +33,7 @@ object GeneAnnotations {
   /** A gene with zero or more transcripts, that all are on the same transcription strand. */
   case class Gene(contig: String, start: Int, end: Int, negativeStrand: Boolean, name: String, transcripts: Seq[Transcript])
     extends Interval(contig, start, end, negativeStrand, name) with Iterable[Transcript] {
-    def iterator: Iterator[Transcript] = transcripts.toIterator
+    def iterator: Iterator[Transcript] = transcripts.iterator
   }
 
   /** A transcript associated with a given gene (which stores the transcription strand).  Contains zero or more exons.
@@ -44,9 +44,9 @@ object GeneAnnotations {
       require(!exonsOverlap, s"exons overlap for transcript: $name")
     }
     /** The order in which exons appear in the transcripts */
-    def transcriptOrder: Iterator[Exon] = exons.toIterator
+    def transcriptOrder: Iterator[Exon] = exons.iterator
     /** The order in which exons appear in the genome */
-    def genomicOrder: Iterator[Exon] = exons.sortBy { exon => (exon.start, exon.end) }.toIterator
+    def genomicOrder: Iterator[Exon] = exons.sortBy { exon => (exon.start, exon.end) }.iterator
   }
 
   /** Defines an exonic sequence within a transcript. */

--- a/src/main/scala/com/fulcrumgenomics/util/Metric.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/Metric.scala
@@ -36,6 +36,7 @@ import com.fulcrumgenomics.commons.util.DelimitedDataParser
 import htsjdk.samtools.util.{FormatUtil, Iso8601Date}
 import com.fulcrumgenomics.commons.io.{Writer => CommonsWriter}
 
+import scala.collection.compat._
 import scala.reflect.runtime.{universe => ru}
 import scala.util.{Failure, Success}
 
@@ -150,16 +151,16 @@ object Metric {
   /** Writes a metric to the given writer.  The first line will be a header with the field names.  Each subsequent
     * line is a single metric.
     */
-  def write[T <: Metric](writer: Writer, metrics: TraversableOnce[T])(implicit tt: ru.TypeTag[T]): Unit = {
+  def write[T <: Metric](writer: Writer, metrics: IterableOnce[T])(implicit tt: ru.TypeTag[T]): Unit = {
     val out = new MetricWriter[T](writer)
-    metrics.foreach(out.write(_))
+    out ++= metrics
     out.close()
   }
 
   /** Writes metrics to the given path.  The first line will be a header with the field names.  Each subsequent
     * line is a single metric.
     */
-  def write[T <: Metric](path: Path, metrics: TraversableOnce[T])(implicit tt: ru.TypeTag[T]): Unit = {
+  def write[T <: Metric](path: Path, metrics: IterableOnce[T])(implicit tt: ru.TypeTag[T]): Unit = {
     val writer = Io.toWriter(path)
     write(writer, metrics)
     writer.close()
@@ -203,7 +204,7 @@ trait Metric extends Product with Iterable[(String,String)] {
   }
 
   /** Gets an iterator over the fields of this metric in the order they were defined.  Returns tuples of names and values */
-  override def iterator: Iterator[(String,String)] = this.names.zip(this.values).toIterator
+  override def iterator: Iterator[(String,String)] = this.names.zip(this.values).iterator
 
   /** @deprecated use [[formatValue]] instead. */
   @deprecated("Use formatValue instead.", since="0.5.0")

--- a/src/main/scala/com/fulcrumgenomics/util/ReadStructure.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/ReadStructure.scala
@@ -74,7 +74,7 @@ object ReadStructure {
   /** Creates a sequence of read segments from a string. */
   private def segments(rs: String): Seq[ReadSegment] = {
     var i = 0
-    val segs = ArrayBuffer[ReadSegment]()
+    val segs = IndexedSeq.newBuilder[ReadSegment]
     while (i < rs.length) {
       // Stash the beginning position of our parsing so we can highlight what we're having trouble with
       val parsePosition = i
@@ -104,7 +104,7 @@ object ReadStructure {
       }
     }
 
-    segs
+    segs.result
   }
 
   /**

--- a/src/main/scala/com/fulcrumgenomics/util/RefFlatSource.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/RefFlatSource.scala
@@ -144,7 +144,7 @@ class RefFlatSource private(lines: Iterator[String],
           end      = row[Int]("txEnd"),
           cdsStart = row[Int]("cdsStart") + 1,
           cdsEnd   = row[Int]("cdsEnd"),
-          exons    = exonStarts.zip(exonEnds).map { case (s, e) => Exon(start=s + 1, end=e) }
+          exons    = exonStarts.iterator.zip(exonEnds.iterator).map { case (s, e) => Exon(start=s + 1, end=e) }.toIndexedSeq
         )
 
         val gene = Gene(
@@ -203,7 +203,7 @@ class RefFlatSource private(lines: Iterator[String],
     _genes
   }
 
-  def iterator: Iterator[Gene] = this.genes.toIterator
+  def iterator: Iterator[Gene] = this.genes.iterator
 
   /** Closes the underlying reader; only necessary if EOF hasn't been reached. */
   override def close(): Unit = this.source.foreach(_.close())

--- a/src/main/scala/com/fulcrumgenomics/util/Rscript.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/Rscript.scala
@@ -53,11 +53,11 @@ object Rscript extends LazyLogging {
 
   /** Executes an Rscript from the classpath if Rscript is available. */
   def execIfAvailable(scriptResource: String, args: String*): Try[Unit] =
-    if (Available) exec(scriptResource, args:_*) else Success(Unit)
+    if (Available) exec(scriptResource, args:_*) else Success(())
 
   /** Executes an Rscript from a script stored at a Path if Rscript is available. */
   def execIfAvailable(script: Path, args: String*): Try[Unit] =
-    if (Available) exec(script, args:_*) else Success(Unit)
+    if (Available) exec(script, args:_*) else Success(())
 
   /** Executes an Rscript from the classpath. */
   def exec(scriptResource: String, args: String*): Try[Unit] =

--- a/src/main/scala/com/fulcrumgenomics/util/Sorter.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/Sorter.scala
@@ -29,7 +29,7 @@ import java.nio.file.{Files, Path}
 import java.util
 
 import com.fulcrumgenomics.FgBioDef._
-import com.fulcrumgenomics.Writer
+import com.fulcrumgenomics.commons.io.Writer
 import com.fulcrumgenomics.commons.collection.SelfClosingIterator
 import com.fulcrumgenomics.util.Sorter.{Codec, SortEntry}
 import htsjdk.samtools.util.TempStreamFactory
@@ -216,7 +216,7 @@ class Sorter[A,B <: Ordered[B]](val maxObjectsInRam: Int,
      */
   def iterator: SelfClosingIterator[A] = {
     spill()
-    val streams = files.map(f => _tmpStreamFactory.wrapTempInputStream(Io.toInputStream(f), Io.bufferSize))
+    val streams = files.iterator.map(f => _tmpStreamFactory.wrapTempInputStream(Io.toInputStream(f), Io.bufferSize)).toSeq
     val mergingIterator = new MergingIterator(streams)
     new SelfClosingIterator(mergingIterator, () => mergingIterator.close())
   }

--- a/src/main/scala/com/fulcrumgenomics/vcf/HapCutToVcf.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/HapCutToVcf.scala
@@ -302,7 +302,7 @@ private class HapCutAndVcfMergingIterator(hapCutPath: FilePath,
   extends Iterator[VariantContext] with Closeable {
   import HapCutType.HapCutType
 
-  private val sourceIterator = vcfReader.toStream.zipWithIndex.iterator.buffered
+  private val sourceIterator = vcfReader.iterator.zipWithIndex.buffered
   private val hapCutReader   = HapCutReader(path=hapCutPath)
   private val sampleName     = vcfReader.getFileHeader.getSampleNamesInOrder.iterator().next()
 

--- a/src/main/scala/com/fulcrumgenomics/vcf/MakeTwoSampleMixtureVcf.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/MakeTwoSampleMixtureVcf.scala
@@ -154,7 +154,7 @@ class MakeTwoSampleMixtureVcf
         if (isMultiAllelic) filters += MultiAllelicFilter
         if (!tumorOnly && !oldNormalGt.isHomRef) filters += GermlineFilter
         if (newTumorGt.isNoCall) filters += UnknownGtFilter
-        if (filters.nonEmpty) builder.filters(filters: _*) else builder.passFilters()
+        if (filters.nonEmpty) builder.filters(filters.iterator.toJavaSet) else builder.passFilters()
         out.add(builder.make())
       }
     }

--- a/src/main/scala/com/fulcrumgenomics/vcf/filtration/EndRepairArtifactLikelihoodFilter.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/filtration/EndRepairArtifactLikelihoodFilter.scala
@@ -55,8 +55,8 @@ class EndRepairArtifactLikelihoodFilter(val distance: Int = 2,
   val FilterKey         = "EndRepairArtifact"
   val FilterDescription = "Variant is likely an artifact caused by end-repair and A-base addition."
 
-  override val VcfInfoLines: Traversable[VCFInfoHeaderLine]     = Seq(vcfInfoLine(InfoKey, InfoDescription))
-  override val VcfFilterLines: Traversable[VCFFilterHeaderLine] = Seq(vcfFilterLine(FilterKey, FilterDescription))
+  override val VcfInfoLines: Iterable[VCFInfoHeaderLine]     = Seq(vcfInfoLine(InfoKey, InfoDescription))
+  override val VcfFilterLines: Iterable[VCFFilterHeaderLine] = Seq(vcfFilterLine(FilterKey, FilterDescription))
 
   /** Only applies to het SNVs where the alt allele is A or T. */
   override def appliesTo(gt: Genotype): Boolean = {
@@ -210,7 +210,7 @@ class EndRepairArtifactLikelihoodFilter(val distance: Int = 2,
   /** Applies a single filter if a) a threshold was provided at construction, b) the computed
     * pvalue is present in the annotations, and c) the pvalue <= threshold.
     */
-  override def filters(annotations: Map[String, Any]): Traversable[String] = {
+  override def filters(annotations: Map[String, Any]): Iterable[String] = {
     (this.pValueThreshold, annotations.get(InfoKey).map(_.asInstanceOf[Double])) match {
       case (Some(threshold), Some(pvalue)) if pvalue <= threshold => List(FilterKey)
       case _ => Nil

--- a/src/main/scala/com/fulcrumgenomics/vcf/filtration/FilterSomaticVcf.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/filtration/FilterSomaticVcf.scala
@@ -153,7 +153,7 @@ class FilterSomaticVcf
             s"""
               |Ignoring read ${e.rec.name} mapped over variant site ${pileup.refName}:${pileup.pos} that has
               |incompatible insert size yielding insert coordinates of ${pileup.refName}:$start-$end which do not overlap the variant.
-            """.stripMargin.trim.lines.mkString(" "))
+            """.stripMargin.trim.linesIterator.mkString(" "))
           false
         }
         else {

--- a/src/main/scala/com/fulcrumgenomics/vcf/filtration/SomaticVariantFilter.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/filtration/SomaticVariantFilter.scala
@@ -34,10 +34,10 @@ import htsjdk.variant.vcf.{VCFFilterHeaderLine, VCFHeaderLineType, VCFInfoHeader
   */
 trait SomaticVariantFilter {
   /** The collection of VCF INFO header lines that the filter may reference. */
-  val VcfInfoLines: Traversable[VCFInfoHeaderLine]
+  val VcfInfoLines: Iterable[VCFInfoHeaderLine]
 
   /** The collection of VCF Filter header lines that the filter may reference. */
-  val VcfFilterLines: Traversable[VCFFilterHeaderLine]
+  val VcfFilterLines: Iterable[VCFFilterHeaderLine]
 
   /** Helper method to construct an INFO header line. */
   protected def vcfInfoLine(name: String, description: String, count: Int = 1, vcfType: VCFHeaderLineType = VCFHeaderLineType.Float) = {
@@ -56,5 +56,5 @@ trait SomaticVariantFilter {
   /** Given the set of annotations calculated by [[annotations]] determine the set of filters
     * to be applied to the VCF record.
     */
-  def filters(annotations: Map[String, Any]): Traversable[String]
+  def filters(annotations: Map[String, Any]): Iterable[String]
 }

--- a/src/test/scala/com/fulcrumgenomics/alignment/AlignmentTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/alignment/AlignmentTest.scala
@@ -130,7 +130,7 @@ class AlignmentTest extends UnitSpec {
       +AACCGGTT
       +||||||||
       +AACCGGTT
-       """.stripMargin('+').trim.lines.toSeq
+       """.stripMargin('+').trim.linesIterator.toSeq
 
     val alignment = Alignment(expected.head.replace("-", ""), expected.last.replace("-", ""), 1, 1, Cigar("8M"), 1)
     alignment.paddedString() shouldBe expected
@@ -142,7 +142,7 @@ class AlignmentTest extends UnitSpec {
       +AACCGGTT
       +||||||.|
       +AACCGGGT
-       """.stripMargin('+').trim.lines.toSeq
+       """.stripMargin('+').trim.linesIterator.toSeq
 
     Seq("8M", "6=1X2=").foreach { cigar =>
       val alignment = Alignment(expected.head.replace("-", ""), expected.last.replace("-", ""), 1, 1, Cigar("8M"), 1)
@@ -156,7 +156,7 @@ class AlignmentTest extends UnitSpec {
       +AA--GGGTAAACC-GGGTTT
       +||  ||||||||| || |||
       +AACCGGGTAAACCCGG-TTT
-       """.stripMargin('+').trim.lines.toSeq
+       """.stripMargin('+').trim.linesIterator.toSeq
 
     val alignment = Alignment(expected.head.replace("-", ""), expected.last.replace("-", ""), 1, 1, Cigar("2=2D9=1D2=1I3="), 1)
     alignment.paddedString() shouldBe expected
@@ -168,7 +168,7 @@ class AlignmentTest extends UnitSpec {
       +AA--GGGGGAACC-GGGTTT
       +||  |||..|||| || |||
       +AACCGGGTAAACCCGG-TTT
-       """.stripMargin('+').trim.lines.toSeq
+       """.stripMargin('+').trim.linesIterator.toSeq
 
     val alignment = Alignment(expected.head.replace("-", ""), expected.last.replace("-", ""), 1, 1, Cigar("2M2D9M1D2M1I3M"), 1)
     alignment.paddedString() shouldBe expected
@@ -188,7 +188,7 @@ class AlignmentTest extends UnitSpec {
       |AA..GGGGGAACC.GGGTTT
       |++--+++##++++-++-+++
       |AACCGGGTAAACCCGG.TTT
-       """.stripMargin.trim.lines.toSeq
+       """.stripMargin.trim.linesIterator.toSeq
 
     val alignment = Alignment(expected.head.replace(".", ""), expected.last.replace(".", ""), 1, 1, Cigar("2M2D9M1D2M1I3M"), 1)
     alignment.paddedString(matchChar='+', mismatchChar='#', gapChar='-', padChar='.') shouldBe expected

--- a/src/test/scala/com/fulcrumgenomics/bam/BamsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/BamsTest.scala
@@ -26,6 +26,7 @@ package com.fulcrumgenomics.bam
 
 import java.util
 
+import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.alignment.Cigar
 import com.fulcrumgenomics.bam.api.{SamOrder, SamRecord}
 import com.fulcrumgenomics.testing.SamBuilder.{Minus, Plus}
@@ -96,10 +97,10 @@ class BamsTest extends UnitSpec {
     templates.map(_.name) shouldBe Seq("f1", "p0", "p1", "p2")
 
     templates.foreach {t =>
-      (t.r1Supplementals ++ t.r1Secondaries ++ t.r2Supplementals ++ t.r2Secondaries) shouldBe 'empty
+      (t.r1Supplementals ++ t.r1Secondaries ++ t.r2Supplementals ++ t.r2Secondaries).isEmpty shouldBe true
       if (t.name startsWith "f") {
         t.r1.exists(r => !r.paired) shouldBe true
-        t.r2 shouldBe 'empty
+        t.r2.isEmpty shouldBe true
       }
       else {
         t.r1.exists(r => r.firstOfPair) shouldBe true

--- a/src/test/scala/com/fulcrumgenomics/bam/ClipBamTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/ClipBamTest.scala
@@ -454,7 +454,7 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
 
       val out     = makeTempFile("out.", ".bam")
       val metrics = makeTempFile("out.", ".txt")
-      new ClipBam(input=builder.toTempFile(), output=out, metrics=Some(metrics), ref=ref, clippingMode=Some(mode), upgradeClipping=true).execute()
+      new ClipBam(input=builder.toTempFile(), output=out, metrics=Some(metrics), ref=ref, clippingMode=mode, upgradeClipping=true).execute()
       val clipped = SamSource(out).toSeq
 
       clipped.length shouldBe 2
@@ -494,7 +494,7 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
 
       val out     = makeTempFile("out.", ".bam")
       val metrics = makeTempFile("out.", ".txt")
-      new ClipBam(input=builder.toTempFile(), output=out, metrics=Some(metrics), ref=ref, clippingMode=Some(mode), upgradeClipping=true).execute()
+      new ClipBam(input=builder.toTempFile(), output=out, metrics=Some(metrics), ref=ref, clippingMode=mode, upgradeClipping=true).execute()
       val clipped = SamSource(out).toSeq
 
       clipped.length shouldBe 2

--- a/src/test/scala/com/fulcrumgenomics/bam/ErrorRateByReadPositionTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/ErrorRateByReadPositionTest.scala
@@ -187,7 +187,7 @@ class ErrorRateByReadPositionTest extends UnitSpec {
     }
 
     if (Rscript.Available) {
-      val plot = PathUtil.pathTo(pre + ErrorRateByReadPositionMetric.PlotExtension)
+      val plot = PathUtil.pathTo(s"${pre}${ErrorRateByReadPositionMetric.PlotExtension}")
       Files.exists(plot) shouldBe true
     }
   }

--- a/src/test/scala/com/fulcrumgenomics/bam/EstimatePoolingFractionsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/EstimatePoolingFractionsTest.scala
@@ -51,7 +51,7 @@ class EstimatePoolingFractionsTest extends UnitSpec with ParallelTestExecution {
     readers.zipWithIndex.foreach { case (reader, index) =>
         reader.header.getReadGroups.foreach(rg => rg.setLibrary(rg.getLibrary + ":" + index))
     }
-    val headerMerger = new SamFileHeaderMerger(SortOrder.coordinate, readers.map(_.header).asJava, false)
+    val headerMerger = new SamFileHeaderMerger(SortOrder.coordinate, readers.iterator.map(_.header).toJavaList, false)
     val iterator     = new MergingSamRecordIterator(headerMerger, readers.iterator.map(_.toSamReader).toJavaList, true)
 
     val output = makeTempFile("merged.", ".bam")

--- a/src/test/scala/com/fulcrumgenomics/bam/FindSwitchbackReadsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/FindSwitchbackReadsTest.scala
@@ -84,7 +84,7 @@ class FindSwitchbackReadsTest extends UnitSpec with OptionValues {
       |TTCTCAGCTCAAGATTCGTCTGGTCTTTCCCTACAGCTTTGTGTGTGCCATGGCCACATCTCCTGGGTAC
       |AGTTCAAGGAGACATCTTTTCTAAAAGGGTCTGCGTGATCATTAAAATATAATCAAATGTAAAAAAAAAA
       |AAAAAAAA
-    """.stripMargin.lines.foreach(seq.add(_))
+    """.stripMargin.linesIterator.foreach(seq.add(_))
 
     builder.add("chr2").add("ACGTACGT", 100)
 
@@ -313,7 +313,7 @@ class FindSwitchbackReadsTest extends UnitSpec with OptionValues {
       }
     }
 
-    val ms = Metric.read[SwitchMetric](PathUtil.pathTo(metricBase + ".summary.txt")).head
+    val ms = Metric.read[SwitchMetric](PathUtil.pathTo(s"${metricBase}.summary.txt")).head
     ms.sample                   shouldBe "switchback_sample"
     ms.library                  shouldBe "switchback_library"
     ms.templates                shouldBe 20+1+6+5+2

--- a/src/test/scala/com/fulcrumgenomics/bam/UpdateReadGroupsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/UpdateReadGroupsTest.scala
@@ -44,7 +44,7 @@ class UpdateReadGroupsTest extends UnitSpec {
   private val builderOne   = new SamBuilder(sort=Some(SamOrder.Coordinate), readGroupId=Some("IDA"))
   private val builderTwo   = new SamBuilder(sort=Some(SamOrder.Coordinate), readGroupId=Some("IDB"))
 
-  Stream(builderOne, builderTwo).foreach { builder =>
+  Iterator(builderOne, builderTwo).foreach { builder =>
     builder.addPair("ok_1" + builder.readGroupId.get, contig=0, start1=100, start2=300)
     builder.addPair("ok_2" + builder.readGroupId.get, contig=0, start1=200, start2=400)
     builder.header.getReadGroups.foreach { rg => rg.setDescription("Description") }
@@ -86,7 +86,7 @@ class UpdateReadGroupsTest extends UnitSpec {
   def mergeToTempFile(builder: SamBuilder*): PathToBam = {
     val path = Files.createTempFile("SamRecordSet.", ".bam")
     path.toFile.deleteOnExit()
-    val merger = new SamFileHeaderMerger(SortOrder.coordinate, builder.map(_.header).asJava, false)
+    val merger = new SamFileHeaderMerger(SortOrder.coordinate, builder.iterator.map(_.header).toJavaList, false)
     val header = merger.getMergedHeader
     merger.hasReadGroupCollisions shouldBe false
     val writer = SamWriter(path, header, sort=Some(SamOrder.Coordinate))

--- a/src/test/scala/com/fulcrumgenomics/bam/api/SamOrderTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/api/SamOrderTest.scala
@@ -132,7 +132,7 @@ class SamOrderTest extends UnitSpec {
     val iter = recs.iterator.bufferBetter
     while (iter.hasNext) {
       val name = iter.head.name
-      val remaining = iter.takeWhile(_.name == name).foreach { r => Unit }
+      val remaining = iter.takeWhile(_.name == name).foreach { r => () }
       counts.count(name)
     }
 
@@ -151,7 +151,7 @@ class SamOrderTest extends UnitSpec {
       b => b.addPair(name="ba3", start1=100, start2=100, strand1=Minus, strand2=Plus, attrs=Map("MI" -> "2/B"), bases1="AAAAAAAAAA", bases2="AAAAAAAAAA")
     )
 
-    def seq(n: Int, str: String): Seq[String] = Array.fill[String](n)(str)
+    def seq(n: Int, str: String): Seq[String] = IndexedSeq.fill[String](n)(str)
 
     Range.inclusive(start=1, end=10).foreach { _ =>
       val builder = new SamBuilder(readLength=10)

--- a/src/test/scala/com/fulcrumgenomics/bam/api/SamRecordTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/api/SamRecordTest.scala
@@ -114,11 +114,11 @@ class SamRecordTest extends UnitSpec with OptionValues {
 
     // apply
     rec[Int]("ax") shouldBe 10
-    Option(rec[Int]("bx")) shouldBe 'empty
+    Option(rec[Int]("bx")).isEmpty shouldBe true
 
     // get
     rec.get[Int]("ax").value shouldBe 10
-    rec.get[Int]("bx") shouldBe 'empty
+    rec.get[Int]("bx").isEmpty shouldBe true
 
     // attributes
     rec.attributes.toList should contain theSameElementsAs Seq(("RG", "A"), ("ax", 10))

--- a/src/test/scala/com/fulcrumgenomics/basecalling/ExtractBasecallingParamsForPicardTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/basecalling/ExtractBasecallingParamsForPicardTest.scala
@@ -117,7 +117,7 @@ class ExtractBasecallingParamsForPicardTest extends UnitSpec with ErrorLogLevel 
 
 
   "BasecallingParams.from" should "extract params from a single-index sequencing run" in {
-    val sampleSheet = SampleSheet(singleIndexSampleSheet.toIterator, lane=None)
+    val sampleSheet = SampleSheet(singleIndexSampleSheet.iterator, lane=None)
     val params = BasecallingParams.from(sampleSheet=sampleSheet, lanes=Seq(1), output=outputDir)
     params should have size 1
     val param = params.head
@@ -140,7 +140,7 @@ class ExtractBasecallingParamsForPicardTest extends UnitSpec with ErrorLogLevel 
   }
 
   it should "extract params for multiple lanes from a sequencing run" in {
-    val sampleSheet = SampleSheet(singleIndexSampleSheet.toIterator, lane=None)
+    val sampleSheet = SampleSheet(singleIndexSampleSheet.iterator, lane=None)
     val params = BasecallingParams.from(sampleSheet=sampleSheet, lanes=Seq(1, 2, 4), output=outputDir)
     params should have size 3
     val param = params.last
@@ -163,7 +163,7 @@ class ExtractBasecallingParamsForPicardTest extends UnitSpec with ErrorLogLevel 
   }
 
   it should "extract params from a dual-indexed sequencing run" in {
-    val sampleSheet = SampleSheet(dualIndexedSampleSheet.toIterator, lane=None)
+    val sampleSheet = SampleSheet(dualIndexedSampleSheet.iterator, lane=None)
     val params = BasecallingParams.from(sampleSheet=sampleSheet, lanes=Seq(1), output=outputDir)
     params should have size 1
     val param = params.head
@@ -186,7 +186,7 @@ class ExtractBasecallingParamsForPicardTest extends UnitSpec with ErrorLogLevel 
   }
 
   it should "exclude the description if the project and description are not defined on all samples" in {
-    val sampleSheet = SampleSheet(dualIndexedSampleSheetNoProjectOrDescription.toIterator, lane=None)
+    val sampleSheet = SampleSheet(dualIndexedSampleSheetNoProjectOrDescription.iterator, lane=None)
     val params = BasecallingParams.from(sampleSheet=sampleSheet, lanes=Seq(1), output=outputDir)
     params should have size 1
     val param = params.head

--- a/src/test/scala/com/fulcrumgenomics/cmdline/IntelCompressionTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/cmdline/IntelCompressionTest.scala
@@ -110,7 +110,7 @@ class IntelCompressionTest extends UnitSpec {
           val is    = new BlockCompressedInputStream(output.toFile, factory)
           val codec = new BAMRecordCodec(header)
           codec.setInputStream(is, testBam.toFile.toString)
-          while (null != codec.decode()) { Unit }
+          while (null != codec.decode()) { () }
           is.close()
         }
         val endTime = System.currentTimeMillis()

--- a/src/test/scala/com/fulcrumgenomics/fastq/DemuxFastqsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/fastq/DemuxFastqsTest.scala
@@ -122,7 +122,7 @@ class DemuxFastqsTest extends UnitSpec with OptionValues with ErrorLogLevel {
     record.quals shouldBe "I"*100
     record.pairedEnd shouldBe false
     demuxRecord.sampleInfo.isUnmatched shouldBe true
-    record.molecularBarcode shouldBe 'empty
+    record.molecularBarcode.isEmpty shouldBe true
   }
 
   private def outputDir(): DirPath = {
@@ -143,7 +143,7 @@ class DemuxFastqsTest extends UnitSpec with OptionValues with ErrorLogLevel {
     record.bases shouldBe "A"*100
     record.quals shouldBe "I"*100
     record.pairedEnd shouldBe false
-    record.molecularBarcode shouldBe 'empty
+    record.molecularBarcode.isEmpty shouldBe true
   }
 
   it should "demux paired reads with in-line sample barcodes" in {
@@ -161,14 +161,14 @@ class DemuxFastqsTest extends UnitSpec with OptionValues with ErrorLogLevel {
     r1.quals shouldBe "I"*100
     r1.pairedEnd shouldBe true
     r1.readNumber shouldBe 1
-    r1.molecularBarcode shouldBe 'empty
+    r1.molecularBarcode.isEmpty shouldBe true
 
     r2.name shouldBe "pair"
     r2.bases shouldBe "T"*100
     r2.quals shouldBe "I"*100
     r2.pairedEnd shouldBe true
     r2.readNumber shouldBe 2
-    r2.molecularBarcode shouldBe 'empty
+    r2.molecularBarcode.isEmpty shouldBe true
   }
 
   it should "demux dual-indexed paired end reads" in {
@@ -189,14 +189,14 @@ class DemuxFastqsTest extends UnitSpec with OptionValues with ErrorLogLevel {
     r1.pairedEnd shouldBe true
     r1.pairedEnd shouldBe true
     r1.readNumber shouldBe 1
-    r1.molecularBarcode shouldBe 'empty
+    r1.molecularBarcode.isEmpty shouldBe true
 
     r2.name shouldBe "pair"
     r2.bases shouldBe "T"*100
     r2.quals shouldBe "I"*100
     r2.pairedEnd shouldBe true
     r2.readNumber shouldBe 2
-    r2.molecularBarcode shouldBe 'empty
+    r2.molecularBarcode.isEmpty shouldBe true
   }
 
   it should "demux a very weird set of reads" in {
@@ -240,7 +240,7 @@ class DemuxFastqsTest extends UnitSpec with OptionValues with ErrorLogLevel {
     record.bases shouldBe "A"*60
     record.quals shouldBe "I"*60
     record.pairedEnd shouldBe false
-    record.molecularBarcode shouldBe 'empty
+    record.molecularBarcode.isEmpty shouldBe true
   }
 
   it should "fail if zero or more than two read structures have template bases" in {
@@ -460,18 +460,18 @@ class DemuxFastqsTest extends UnitSpec with OptionValues with ErrorLogLevel {
                 sampleBarcodes should contain theSameElementsInOrderAs Seq("AAAAAAAAGATTACTTT", "GGGGGGTTGATTACAGA", "AAAAAAAAGANNNNNNN") // NB: raw not assigned
               }
               else {
-                names shouldBe 'empty
+                names.isEmpty shouldBe true
                 sampleBarcodes.isEmpty shouldBe true
               }
             }
 
             if (outputType.producesFastq) {
-              val fastq = PathUtil.pathTo(prefix + ".fastq.gz")
+              val fastq = PathUtil.pathTo(s"${prefix}.fastq.gz")
               val records = FastqSource(fastq).toSeq
               checkOutput(records.map(_.name.replaceAll(":.*", "")), records.map(_.name.replaceAll(".*:", "")))
             }
             if (outputType.producesBam) {
-              val bam = PathUtil.pathTo(prefix + ".bam")
+              val bam = PathUtil.pathTo(s"${prefix}.bam")
               val records = readBamRecs(bam)
               checkOutput(records.map(_.name), records.map(_[String]("BC")))
             }
@@ -555,11 +555,11 @@ class DemuxFastqsTest extends UnitSpec with OptionValues with ErrorLogLevel {
         }
 
         val headersR1 = {
-          val fastq = PathUtil.pathTo(prefix + extensions.head)
+          val fastq = PathUtil.pathTo(s"${prefix}${extensions.head}")
           FastqSource(fastq).toSeq.map(toHeader).toList
         }
         val headersR2 = {
-          val fastq = PathUtil.pathTo(prefix + extensions.last)
+          val fastq = PathUtil.pathTo(s"${prefix}${extensions.last}")
           FastqSource(fastq).toSeq.map(toHeader).toList
         }
 
@@ -576,7 +576,7 @@ class DemuxFastqsTest extends UnitSpec with OptionValues with ErrorLogLevel {
           else headersR1 should contain theSameElementsInOrderAs Seq("AAAAAAAAGATTACTTT", sampleBarcode4, "AAAAAAAAGANNNNNNN")
         }
         else {
-          headersR1 shouldBe 'empty
+          headersR1.isEmpty shouldBe true
         }
       }
     }
@@ -743,13 +743,13 @@ class DemuxFastqsTest extends UnitSpec with OptionValues with ErrorLogLevel {
 
     val extensions = FastqRecordWriter.extensions(pairedEnd=true, illuminaStandards=false)
     def fastqRecord(which: Int): FastqRecord = {
-      val path = PathUtil.pathTo(prefix + extensions(which-1))
+      val path = PathUtil.pathTo(s"${prefix}${extensions(which-1)}")
       FastqSource(path).toSeq.headOption.value
     }
 
     val fastqR1    = fastqRecord(1)
     val fastqR2    = fastqRecord(2)
-    val records    = readBamRecs(output.resolve(prefix + ".bam"))
+    val records    = readBamRecs(output.resolve(s"${prefix}.bam"))
     val recR1      = records.find(_.firstOfPair).value
     val recR2      = records.find(_.secondOfPair).value
 

--- a/src/test/scala/com/fulcrumgenomics/fastq/FastqIoTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/fastq/FastqIoTest.scala
@@ -41,7 +41,7 @@ object FastqIoTest {
       |CCCCCCCTCCTTGGGGGGGAGAGGG
       |+Foo:279:000000000-ABCDE:1:1101:9471:1291/1 1:N:0:18
       |AAA,,++78,66AAA,,++78,666
-    """.stripMargin.trim().lines.toSeq.dropWhile(_.isEmpty)
+    """.stripMargin.trim().linesIterator.toSeq.dropWhile(_.isEmpty)
 
   val someFastqRecords = Seq(
     FastqRecord("Foo:279:000000000-ABCDE:1:1101:15033:1749", "ATGACTGCGTATATATGACGTCGTGCTA", "-,86,,;:C,<;-,86,,;:C,<;-,86", Some("1:N:0:18"), None),

--- a/src/test/scala/com/fulcrumgenomics/fastq/QualityEncodingTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/fastq/QualityEncodingTest.scala
@@ -97,7 +97,7 @@ class QualityEncodingTest extends UnitSpec {
       |ACC9<D@;8@FEEF>FEG@,8E8,,,,,,;,CEFF88,,CF8,C,,+CF89,88E9,C9FF,,CE8,,CEEGG9C
       |-<BCCGGGFCAC<<<,CE<FF8@E<<,,,B88E@F<9;9E<FFFDEC8E8FFFGG8E,,,@@@88CE8E,,,C9<
       |-A<9@F@EGGFGF<FF9EC,++F7:+CFFFGGFFGCFFFCFGGGA8F<7F,6C++@F7F89C@@BFG9=C+=FE,
-    """.stripMargin.trim.lines
+    """.stripMargin.trim.linesIterator
 
     val detector = new QualityEncodingDetector
     detector.sample(qualStrings)

--- a/src/test/scala/com/fulcrumgenomics/illumina/SampleSheetTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/illumina/SampleSheetTest.scala
@@ -72,7 +72,7 @@ class SampleSheetTest extends FlatSpec with Matchers with OptionValues {
       sampleSheet.foreach { sample => sample.lane.value shouldBe lane }
       sampleSheet.size shouldBe 4
     }
-    SampleSheet(testDir.resolve("SampleSheet.lanes.csv"), lane=Some(4)) shouldBe 'empty
+    SampleSheet(testDir.resolve("SampleSheet.lanes.csv"), lane=Some(4)).isEmpty shouldBe true
     SampleSheet(testDir.resolve("SampleSheet.lanes.csv"), lane=None).size shouldBe 12
   }
 

--- a/src/test/scala/com/fulcrumgenomics/illumina/SampleTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/illumina/SampleTest.scala
@@ -34,7 +34,7 @@ import org.scalatest.OptionValues
 class SampleTest extends UnitSpec with OptionValues{
 
   "Sample.sampleBarcodeBases" should "return the sample barcodes if present" in {
-    new Sample(0, "ID", "NAME", "LIBRARY").sampleBarcodeBases.flatten shouldBe 'empty
+    new Sample(0, "ID", "NAME", "LIBRARY").sampleBarcodeBases.flatten.isEmpty shouldBe true
     new Sample(0, "ID", "NAME", "LIBRARY", i7IndexBases=Some("GATTACA")).sampleBarcodeBases.flatten should contain theSameElementsInOrderAs Seq("GATTACA")
     new Sample(0, "ID", "NAME", "LIBRARY", i5IndexBases=Some("GATTACA")).sampleBarcodeBases.flatten should contain theSameElementsInOrderAs Seq("GATTACA")
     new Sample(0, "ID", "NAME", "LIBRARY", i7IndexBases=Some("GATTACA"), i5IndexBases=Some("TGTAATC")).sampleBarcodeBases.flatten should contain theSameElementsInOrderAs Seq("GATTACA", "TGTAATC")
@@ -48,12 +48,12 @@ class SampleTest extends UnitSpec with OptionValues{
     sample.extendedAttribute("bar").value shouldBe "2"
     sample.extendedAttribute("Bar").value shouldBe "2"
     sample.extendedAttribute("BAR").value shouldBe "2"
-    sample.extendedAttribute("baz") shouldBe 'empty
-    sample.extendedAttribute("Baz") shouldBe 'empty
-    sample.extendedAttribute("BAZ") shouldBe 'empty
-    sample.extendedAttribute("car") shouldBe 'empty
-    sample.extendedAttribute("Car") shouldBe 'empty
-    sample.extendedAttribute("CAR") shouldBe 'empty
+    sample.extendedAttribute("baz").isEmpty shouldBe true
+    sample.extendedAttribute("Baz").isEmpty shouldBe true
+    sample.extendedAttribute("BAZ").isEmpty shouldBe true
+    sample.extendedAttribute("car").isEmpty shouldBe true
+    sample.extendedAttribute("Car").isEmpty shouldBe true
+    sample.extendedAttribute("CAR").isEmpty shouldBe true
   }
 
   it should "support throw an exception if extended attribute keys are not all uppercase" in {

--- a/src/test/scala/com/fulcrumgenomics/rnaseq/CollectErccMetricsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/rnaseq/CollectErccMetricsTest.scala
@@ -88,7 +88,7 @@ class CollectErccMetricsTest extends UnitSpec with OptionValues {
 
   object Outputs {
     def apply(prefix: PathPrefix): Outputs = {
-      def f(ext: String): FilePath = PathUtil.pathTo(prefix + ext)
+      def f(ext: String): FilePath = PathUtil.pathTo(s"${prefix}${ext}")
       Outputs(
         summaryPath  = f(".ercc_summary_metrics.txt"),
         detailedPath = f(".ercc_detailed_metrics.txt"),
@@ -191,8 +191,8 @@ class CollectErccMetricsTest extends UnitSpec with OptionValues {
       metrics.head.total_reads shouldBe 2
       metrics.head.ercc_reads shouldBe 2
       metrics.head.ercc_templates shouldBe 1
-      metrics.head.pearsons_correlation shouldBe 'empty
-      metrics.head.slope shouldBe 'empty
+      metrics.head.pearsons_correlation.isEmpty shouldBe true
+      metrics.head.slope.isEmpty shouldBe true
       Files.exists(outputs.plotPath) shouldBe false
     }
 

--- a/src/test/scala/com/fulcrumgenomics/rnaseq/EstimateRnaSeqInsertSizeTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/rnaseq/EstimateRnaSeqInsertSizeTest.scala
@@ -129,16 +129,16 @@ class EstimateRnaSeqInsertSizeTest extends UnitSpec with OptionValues {
     ///////////////////////////////////////////////////////
 
     // too far left
-    builder.addPair(start1=9, start2=16, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.0) shouldBe 'empty }
-    builder.addPair(start1=16, start2=9, strand1=Minus, strand2=Plus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.0) shouldBe 'empty }
-    builder.addPair(start1=9, start2=16, strand1=Plus, strand2=Plus)   foreach { rec => testInsertSizeFromGene(rec, gene, 0.0) shouldBe 'empty }
-    builder.addPair(start1=16, start2=9, strand1=Minus, strand2=Minus) foreach { rec => testInsertSizeFromGene(rec, gene, 0.0) shouldBe 'empty }
+    builder.addPair(start1=9, start2=16, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.0).isEmpty shouldBe true }
+    builder.addPair(start1=16, start2=9, strand1=Minus, strand2=Plus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.0).isEmpty shouldBe true }
+    builder.addPair(start1=9, start2=16, strand1=Plus, strand2=Plus)   foreach { rec => testInsertSizeFromGene(rec, gene, 0.0).isEmpty shouldBe true }
+    builder.addPair(start1=16, start2=9, strand1=Minus, strand2=Minus) foreach { rec => testInsertSizeFromGene(rec, gene, 0.0).isEmpty shouldBe true }
 
     // too far right
-    builder.addPair(start1=10, start2=17, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.0) shouldBe 'empty }
-    builder.addPair(start1=17, start2=10, strand1=Minus, strand2=Plus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.0) shouldBe 'empty }
-    builder.addPair(start1=10, start2=17, strand1=Plus, strand2=Plus)   foreach { rec => testInsertSizeFromGene(rec, gene, 0.0) shouldBe 'empty }
-    builder.addPair(start1=17, start2=10, strand1=Minus, strand2=Minus) foreach { rec => testInsertSizeFromGene(rec, gene, 0.0) shouldBe 'empty }
+    builder.addPair(start1=10, start2=17, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.0).isEmpty shouldBe true }
+    builder.addPair(start1=17, start2=10, strand1=Minus, strand2=Plus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.0).isEmpty shouldBe true }
+    builder.addPair(start1=10, start2=17, strand1=Plus, strand2=Plus)   foreach { rec => testInsertSizeFromGene(rec, gene, 0.0).isEmpty shouldBe true }
+    builder.addPair(start1=17, start2=10, strand1=Minus, strand2=Minus) foreach { rec => testInsertSizeFromGene(rec, gene, 0.0).isEmpty shouldBe true }
     
     ///////////////////////////////////////////////////////
     // enclosed
@@ -158,9 +158,9 @@ class EstimateRnaSeqInsertSizeTest extends UnitSpec with OptionValues {
 
     builder.addPair(start1=10, start2=16, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.0).value shouldBe 2 }
     builder.addPair(start1=10, start2=16, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.2).value shouldBe 2 }
-    builder.addPair(start1=10, start2=16, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.2001) shouldBe 'empty }
-    builder.addPair(start1=10, start2=16, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.3) shouldBe 'empty }
-    builder.addPair(start1=10, start2=16, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 1.0) shouldBe 'empty }
+    builder.addPair(start1=10, start2=16, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.2001).isEmpty shouldBe true }
+    builder.addPair(start1=10, start2=16, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.3).isEmpty shouldBe true }
+    builder.addPair(start1=10, start2=16, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 1.0).isEmpty shouldBe true }
   }
 
   it should "not return a value if the insert size disagrees across two transcripts" in {
@@ -169,7 +169,7 @@ class EstimateRnaSeqInsertSizeTest extends UnitSpec with OptionValues {
     val gene        = Gene(contig="chr1", start=10, end=20, negativeStrand=false, name="", transcripts=Seq(transcriptA, transcriptB))
     val builder     = new SamBuilder(readLength=5)
 
-    builder.addPair(start1=10, start2=16, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.0) shouldBe 'empty }
+    builder.addPair(start1=10, start2=16, strand1=Plus, strand2=Minus)  foreach { rec => testInsertSizeFromGene(rec, gene, 0.0).isEmpty shouldBe true }
   }
 
   private val RefFlatFile = {
@@ -208,7 +208,7 @@ class EstimateRnaSeqInsertSizeTest extends UnitSpec with OptionValues {
     builder.addPair(contig=2, start1=133801672, start2=133804074, strand1=Plus, strand2=Plus) // overlaps ACKR4 by 100%
 
     val bam = builder.toTempFile()
-    val out = PathUtil.pathTo(PathUtil.removeExtension(bam) + EstimateRnaSeqInsertSize.RnaSeqInsertSizeMetricExtension)
+    val out = PathUtil.pathTo(PathUtil.removeExtension(bam).toString + EstimateRnaSeqInsertSize.RnaSeqInsertSizeMetricExtension)
     new EstimateRnaSeqInsertSize(input=bam, refFlat=RefFlatFile).execute()
     val metrics = Metric.read[InsertSizeMetric](path=out)
     metrics.length shouldBe PairOrientation.values().length
@@ -250,7 +250,7 @@ class EstimateRnaSeqInsertSizeTest extends UnitSpec with OptionValues {
       actual shouldBe expected
     }
 
-    val histogramPath = PathUtil.pathTo(PathUtil.removeExtension(bam) + EstimateRnaSeqInsertSize.RnaSeqInsertSizeMetricHistogramExtension)
+    val histogramPath = PathUtil.pathTo(PathUtil.removeExtension(bam).toString + EstimateRnaSeqInsertSize.RnaSeqInsertSizeMetricHistogramExtension)
     Io.readLines(path=histogramPath).mkString("\n") shouldBe
       """
         |insert_size	fr	rf	tandem
@@ -273,7 +273,7 @@ class EstimateRnaSeqInsertSizeTest extends UnitSpec with OptionValues {
     val builder = new SamBuilder()
     builder.addPair(contig=3, start1=133801671, start2=133801671) // overlaps ACKR4-4-1 and ACKR4-4-2
     val bam = builder.toTempFile()
-    val out = PathUtil.pathTo(PathUtil.removeExtension(bam) + EstimateRnaSeqInsertSize.RnaSeqInsertSizeMetricExtension)
+    val out = PathUtil.pathTo(PathUtil.removeExtension(bam).toString + EstimateRnaSeqInsertSize.RnaSeqInsertSizeMetricExtension)
     new EstimateRnaSeqInsertSize(input=bam, refFlat=RefFlatFile, minimumOverlap=0.0).execute()
     val metrics = Metric.read[InsertSizeMetric](path=out)
     metrics.length shouldBe PairOrientation.values().length
@@ -287,7 +287,7 @@ class EstimateRnaSeqInsertSizeTest extends UnitSpec with OptionValues {
     builder.addPair(contig=2, start1=1, start2=133801671) // before ACKR4-3
     builder.addPair(contig=2, start1=133801671, start2=133814175) // after ACKR4-3
     val bam = builder.toTempFile()
-    val out = PathUtil.pathTo(PathUtil.removeExtension(bam) + EstimateRnaSeqInsertSize.RnaSeqInsertSizeMetricExtension)
+    val out = PathUtil.pathTo(PathUtil.removeExtension(bam).toString + EstimateRnaSeqInsertSize.RnaSeqInsertSizeMetricExtension)
     new EstimateRnaSeqInsertSize(input=bam, refFlat=RefFlatFile, minimumOverlap=0.0).execute()
     val metrics = Metric.read[InsertSizeMetric](path=out)
     metrics.length shouldBe PairOrientation.values().length
@@ -300,7 +300,7 @@ class EstimateRnaSeqInsertSizeTest extends UnitSpec with OptionValues {
     val builder = new SamBuilder()
     builder.addPair(contig=4, start1=133801671, start2=133804077) // overlaps ACKR4-5 (multiple transcripts)
     val bam = builder.toTempFile()
-    val out = PathUtil.pathTo(PathUtil.removeExtension(bam) + EstimateRnaSeqInsertSize.RnaSeqInsertSizeMetricExtension)
+    val out = PathUtil.pathTo(PathUtil.removeExtension(bam).toString + EstimateRnaSeqInsertSize.RnaSeqInsertSizeMetricExtension)
     new EstimateRnaSeqInsertSize(input=bam, refFlat=RefFlatFile, minimumOverlap=0.0).execute()
     val metrics = Metric.read[InsertSizeMetric](path=out)
     metrics.length shouldBe PairOrientation.values().length
@@ -313,7 +313,7 @@ class EstimateRnaSeqInsertSizeTest extends UnitSpec with OptionValues {
     val builder = new SamBuilder()
     builder.addPair(contig=5, start1=133801671, start2=133804077, strand1=Plus, strand2=Plus) // overlaps ACKR4-6 by 2 bases!
     val bam = builder.toTempFile()
-    val out = PathUtil.pathTo(PathUtil.removeExtension(bam) + EstimateRnaSeqInsertSize.RnaSeqInsertSizeMetricExtension)
+    val out = PathUtil.pathTo(PathUtil.removeExtension(bam).toString + EstimateRnaSeqInsertSize.RnaSeqInsertSizeMetricExtension)
 
     // OK
     {

--- a/src/test/scala/com/fulcrumgenomics/testing/ReferenceSetBuilderTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/testing/ReferenceSetBuilderTest.scala
@@ -40,7 +40,7 @@ class ReferenceSetBuilderTest extends UnitSpec {
     // Check the .dict file
     val dictIn = ReferenceSequenceFileFactory.getDefaultDictionaryForReferenceSequence(fasta)
     Files.exists(dictIn) shouldBe true
-    val dict = SAMSequenceDictionaryExtractor.extractDictionary(dictIn.toFile)
+    val dict = SAMSequenceDictionaryExtractor.extractDictionary(dictIn)
 
     // Check the .fai file
     val fai =  ReferenceSequenceFileFactory.getFastaIndexFileName(fasta)
@@ -61,7 +61,7 @@ class ReferenceSetBuilderTest extends UnitSpec {
       val builder = new ReferenceSetBuilder(assembly=assembly)
       builder.add("chr1").add("A", 100)
       val path = builder.toTempFile()
-      val dict = SAMSequenceDictionaryExtractor.extractDictionary(path.toFile)
+      val dict = SAMSequenceDictionaryExtractor.extractDictionary(path)
       dict.size() shouldBe 1
       dict
     }

--- a/src/test/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReadsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReadsTest.scala
@@ -46,7 +46,7 @@ class CallMolecularConsensusReadsTest extends UnitSpec {
     val rejects = newBam
 
     // Create 2000 paired end reads, where there are two pairs with the same coordinates and have the same group tag.
-    Stream.range(0, 1000).foreach { idx =>
+    Range(0, 1000).foreach { idx =>
       val attrs = Map(DefaultTag -> ("GATTACA:" + idx), ConsensusTags.UmiBases -> "ACGT-TGCA")
       builder.addPair(name=s"READ:" + 2*idx,   start1=1+idx, start2=1000000+idx, bases1="A"*rlen, bases2="T"*rlen, attrs=attrs)
       builder.addPair(name=s"READ:" + 2*idx+1, start1=1+idx, start2=1000000+idx, bases1="A"*rlen, bases2="T"*rlen, attrs=attrs)
@@ -56,7 +56,7 @@ class CallMolecularConsensusReadsTest extends UnitSpec {
     new CallMolecularConsensusReads(input=builder.toTempFile(), output=output, minReads=1, rejects=Some(rejects), readGroupId="ABC").execute()
 
     // check we have no rejected records
-    readBamRecs(rejects) shouldBe 'empty
+    readBamRecs(rejects).isEmpty shouldBe true
 
     // we should have 1000 consensus paired end reads
     val records = readBamRecs(output)

--- a/src/test/scala/com/fulcrumgenomics/umi/CollectDuplexSeqMetricsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/CollectDuplexSeqMetricsTest.scala
@@ -267,8 +267,8 @@ class CollectDuplexSeqMetricsTest extends UnitSpec {
       val start2 = start1 + isize.sample().toInt - 75
       val abs = sampleNatural(abDist)
       val bas = sampleNatural(baDist)
-      (1 to abs) foreach { _ => builder.addPair(start1=start1, start2=start2, attrs=Map(RX -> "AAA-TTT", MI -> (i + "/A"))) }
-      (1 to bas) foreach { _ => builder.addPair(start1=start1, start2=start2, attrs=Map(RX -> "TTT-AAA", MI -> (i + "/B"))) }
+      (1 to abs) foreach { _ => builder.addPair(start1=start1, start2=start2, attrs=Map(RX -> "AAA-TTT", MI -> (s"$i/A"))) }
+      (1 to bas) foreach { _ => builder.addPair(start1=start1, start2=start2, attrs=Map(RX -> "TTT-AAA", MI -> (s"$i/B"))) }
       counter.count((max(abs, bas), min(abs, bas)))
     }
 

--- a/src/test/scala/com/fulcrumgenomics/umi/ConsensusCallerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/ConsensusCallerTest.scala
@@ -24,6 +24,7 @@
 
 package com.fulcrumgenomics.umi
 
+import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.testing.UnitSpec
 import com.fulcrumgenomics.util.NumericTypes.PhredScore
 

--- a/src/test/scala/com/fulcrumgenomics/umi/DuplexConsensusCallerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/DuplexConsensusCallerTest.scala
@@ -118,9 +118,9 @@ class DuplexConsensusCallerTest extends UnitSpec {
           { // Check a few per-base tags
             import ConsensusTags.PerBase._
             r1[Array[Short]](AbRawReadCount)  shouldBe Array[Byte](3,3,3,3,3,3,3,3,3,3)
-            r1.get[Array[Short]](BaRawReadCount) shouldBe 'empty
+            r1.get[Array[Short]](BaRawReadCount).isEmpty shouldBe true
             r2[Array[Short]](AbRawReadCount)  shouldBe Array[Byte](3,3,3,3,3,3,3,3,3,3)
-            r2.get[Array[Short]](BaRawReadCount) shouldBe 'empty
+            r2.get[Array[Short]](BaRawReadCount).isEmpty shouldBe true
           }
         }
         else {
@@ -402,14 +402,14 @@ class DuplexConsensusCallerTest extends UnitSpec {
         r2[Array[Short]](AbRawReadErrors) shouldBe Array[Byte](0,0,0,0,1,0,0,0,0,0)
         r2[String](AbConsensusBases)      shouldBe r2.basesString
         r2[String](AbConsensusQuals)      shouldBe "MMMM9MMMMM"
-        r1.get[Array[Short]](BaRawReadCount)  shouldBe 'empty
-        r1.get[Array[Short]](BaRawReadErrors) shouldBe 'empty
-        r1.get[String](BaConsensusBases)      shouldBe 'empty
-        r1.get[String](BaConsensusQuals)      shouldBe 'empty
-        r2.get[Array[Short]](BaRawReadCount)  shouldBe 'empty
-        r2.get[Array[Short]](BaRawReadErrors) shouldBe 'empty
-        r2.get[String](BaConsensusBases)      shouldBe 'empty
-        r2.get[String](BaConsensusQuals)      shouldBe 'empty
+        r1.get[Array[Short]](BaRawReadCount).isEmpty shouldBe true
+        r1.get[Array[Short]](BaRawReadErrors).isEmpty shouldBe true
+        r1.get[String](BaConsensusBases).isEmpty shouldBe true
+        r1.get[String](BaConsensusQuals).isEmpty shouldBe true
+        r2.get[Array[Short]](BaRawReadCount).isEmpty shouldBe true
+        r2.get[Array[Short]](BaRawReadErrors).isEmpty shouldBe true
+        r2.get[String](BaConsensusBases).isEmpty shouldBe true
+        r2.get[String](BaConsensusQuals).isEmpty shouldBe true
       }
     }
 
@@ -462,14 +462,14 @@ class DuplexConsensusCallerTest extends UnitSpec {
         r2[Array[Short]](AbRawReadErrors) shouldBe Array[Byte](0,0,0,0,0,1,0,0,0,0)
         r2[String](AbConsensusBases)      shouldBe r2.basesString
         r2[String](AbConsensusQuals)      shouldBe "MMMMM9MMMM"
-        r1.get[Array[Short]](BaRawReadCount)  shouldBe 'empty
-        r1.get[Array[Short]](BaRawReadErrors) shouldBe 'empty
-        r1.get[String](BaConsensusBases)      shouldBe 'empty
-        r1.get[String](BaConsensusQuals)      shouldBe 'empty
-        r2.get[Array[Short]](BaRawReadCount)  shouldBe 'empty
-        r2.get[Array[Short]](BaRawReadErrors) shouldBe 'empty
-        r2.get[String](BaConsensusBases)      shouldBe 'empty
-        r2.get[String](BaConsensusQuals)      shouldBe 'empty
+        r1.get[Array[Short]](BaRawReadCount).isEmpty shouldBe true
+        r1.get[Array[Short]](BaRawReadErrors).isEmpty shouldBe true
+        r1.get[String](BaConsensusBases).isEmpty shouldBe true
+        r1.get[String](BaConsensusQuals).isEmpty shouldBe true
+        r2.get[Array[Short]](BaRawReadCount).isEmpty shouldBe true
+        r2.get[Array[Short]](BaRawReadErrors).isEmpty shouldBe true
+        r2.get[String](BaConsensusBases).isEmpty shouldBe true
+        r2.get[String](BaConsensusQuals).isEmpty shouldBe true
       }
     }
   }

--- a/src/test/scala/com/fulcrumgenomics/umi/ExtractUmisFromBamTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/ExtractUmisFromBamTest.scala
@@ -49,7 +49,7 @@ class ExtractUmisFromBamTest extends UnitSpec with OptionValues {
 
   "ExtractUmisFromBam.annotateRecord" should "should not annotate with no molecular indices" in {
     val frag = annotateRecordFragment
-    ExtractUmisFromBam.annotateRecord(record=frag, ReadStructure("100T"), Seq.empty) shouldBe 'empty
+    ExtractUmisFromBam.annotateRecord(record=frag, ReadStructure("100T"), Seq.empty).isEmpty shouldBe true
     frag.length shouldBe 100
   }
 

--- a/src/test/scala/com/fulcrumgenomics/umi/ReviewConsensusVariantsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/ReviewConsensusVariantsTest.scala
@@ -44,20 +44,20 @@ object ReviewConsensusVariantsTest {
       |>chr2
       |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
       |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-    """.stripMargin.lines.toSeq
+    """.stripMargin.linesIterator.toSeq
 
   val Fai : Seq[String] =
     """
       |chr1    100     6       50      51
       |chr2    100     114     50      51
-    """.stripMargin.lines.map(_.trim.replaceAll("\\s+", "\t")).filter(_.nonEmpty).toSeq
+    """.stripMargin.linesIterator.map(_.trim.replaceAll("\\s+", "\t")).filter(_.nonEmpty).toSeq
 
   val Dict : Seq[String] =
     """
       |@HD    	VN:1.5 	SO:unsorted
       |@SQ    	SN:chr1	LN:100 	M5:8adc5937e635f6c9af646f0b23560fae    	AS:n/a 	UR:n/a 	SP:n/a
       |@SQ    	SN:chr2	LN:100 	M5:48ecc9d349522f836cadf615e370bc51    	AS:n/a 	UR:n/a 	SP:n/a
-    """.stripMargin.lines.map(_.trim.replaceAll("\\s+", "\t")).filter(_.nonEmpty).toSeq
+    """.stripMargin.linesIterator.map(_.trim.replaceAll("\\s+", "\t")).filter(_.nonEmpty).toSeq
 }
 
 
@@ -67,7 +67,7 @@ class ReviewConsensusVariantsTest extends UnitSpec {
   /** Sets up a trivial reference for testing against. */
   lazy val refFasta: PathToFasta = {
     val ref  = makeTempFile("ref.", ".fa")
-    val fai  = ref.getParent.resolve(ref.getFileName + ".fai")
+    val fai  = ref.getParent.resolve(s"${ref.getFileName}.fai")
     val dict = PathUtil.replaceExtension(ref, ".dict")
     Seq(fai, dict).foreach(_.toFile.deleteOnExit())
 
@@ -176,9 +176,9 @@ class ReviewConsensusVariantsTest extends UnitSpec {
 
   "ReviewConsensusVariants" should "create empty BAMs when given an empty interval list as input" in {
     val outBase = makeTempFile("review_consensus.", ".out")
-    val conOut  = outBase.getParent.resolve(outBase.getFileName + ".consensus.bam")
-    val rawOut  = outBase.getParent.resolve(outBase.getFileName + ".grouped.bam")
-    val txtOut  = outBase.getParent.resolve(outBase.getFileName + ".txt")
+    val conOut  = outBase.getParent.resolve(s"${outBase.getFileName}.consensus.bam")
+    val rawOut  = outBase.getParent.resolve(s"${outBase.getFileName}.grouped.bam")
+    val txtOut  = outBase.getParent.resolve(s"${outBase.getFileName}.txt")
     val intervals = makeTempFile("empty.", ".interval_list")
     new IntervalList(header).write(intervals.toFile)
     new ReviewConsensusVariants(input=intervals, consensusBam=consensusBam, groupedBam=rawBam, ref=refFasta, output=outBase).execute()
@@ -194,9 +194,9 @@ class ReviewConsensusVariantsTest extends UnitSpec {
 
   it should "create empty BAMs when given an empty VCF as input" in {
     val outBase = makeTempFile("review_consensus.", ".out")
-    val conOut  = outBase.getParent.resolve(outBase.getFileName + ".consensus.bam")
-    val rawOut  = outBase.getParent.resolve(outBase.getFileName + ".grouped.bam")
-    val txtOut  = outBase.getParent.resolve(outBase.getFileName + ".txt")
+    val conOut  = outBase.getParent.resolve(s"${outBase.getFileName}.consensus.bam")
+    val rawOut  = outBase.getParent.resolve(s"${outBase.getFileName}.grouped.bam")
+    val txtOut  = outBase.getParent.resolve(s"${outBase.getFileName}.txt")
     val intervals = makeTempFile("empty.", ".vcf")
 
     val vcfBuilder = VariantContextSetBuilder("s1")
@@ -215,9 +215,9 @@ class ReviewConsensusVariantsTest extends UnitSpec {
 
   it should "extract the right reads given a set of loci" in {
     val outBase = makeTempFile("review_consensus.", ".out")
-    val conOut  = outBase.getParent.resolve(outBase.getFileName + ".consensus.bam")
-    val rawOut  = outBase.getParent.resolve(outBase.getFileName + ".grouped.bam")
-    val txtOut  = outBase.getParent.resolve(outBase.getFileName + ".txt")
+    val conOut  = outBase.getParent.resolve(s"${outBase.getFileName}.consensus.bam")
+    val rawOut  = outBase.getParent.resolve(s"${outBase.getFileName}.grouped.bam")
+    val txtOut  = outBase.getParent.resolve(s"${outBase.getFileName}.txt")
 
     val vcfBuilder = new VariantContextSetBuilder(sampleNames=List("tumor"))
     vcfBuilder.header.setSequenceDictionary(this.header.getSequenceDictionary)

--- a/src/test/scala/com/fulcrumgenomics/util/MetricTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/util/MetricTest.scala
@@ -144,7 +144,7 @@ class MetricTest extends UnitSpec with OptionValues with TimeLimits {
   // Various write methods to test with a writer
   private val writeWithWriters = Seq(
     ((writer: StringWriter, metrics: Seq[TestMetric]) => Metric.write[TestMetric](writer, metrics:_*), "write[T <: Metric](writer: Writer, metric: T*)"),
-    ((writer: StringWriter, metrics: Seq[TestMetric]) => Metric.write[TestMetric](writer, metrics), "write[T <: Metric](writer: Writer, metrics: TraversableOnce[T])")
+    ((writer: StringWriter, metrics: Seq[TestMetric]) => Metric.write[TestMetric](writer, metrics), "write[T <: Metric](writer: Writer, metrics: IterableOnce[T])")
   )
 
   writeWithWriters.foreach { case (writeMethod, desc) =>
@@ -160,7 +160,7 @@ class MetricTest extends UnitSpec with OptionValues with TimeLimits {
   // Various write methods to test with a path
   private val writeWithPaths = Seq(
     ((path: Path, metrics: Seq[TestMetric]) => Metric.write[TestMetric](path, metrics:_*), "write[T <: Metric](path: Path, metric: T*)"),
-    ((path: Path, metrics: Seq[TestMetric]) => Metric.write[TestMetric](path, metrics), "write[T <: Metric](path: Path, metric: TraversableOnce[T])")
+    ((path: Path, metrics: Seq[TestMetric]) => Metric.write[TestMetric](path, metrics), "write[T <: Metric](path: Path, metric: IterableOnce[T])")
   )
 
   writeWithPaths.foreach { case (writeMethod, desc) =>
@@ -240,7 +240,7 @@ class MetricTest extends UnitSpec with OptionValues with TimeLimits {
     testMetric.get("foo").value shouldBe "fooValue"
     testMetric.get("bar").value shouldBe "1"
     testMetric.get("car").value shouldBe "default"
-    testMetric.get("dar") shouldBe 'empty
+    testMetric.get("dar").isEmpty shouldBe true
   }
 
   it should "be iterable over tuples of names and values" in {

--- a/src/test/scala/com/fulcrumgenomics/util/PickIlluminaIndicesTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/util/PickIlluminaIndicesTest.scala
@@ -56,7 +56,7 @@ class PickIlluminaIndicesTest extends UnitSpec {
   }
 
   "PickIlluminaIndices" should "pick indices with length four and edit distance one" in {
-    Stream.range(1, 5, 1).foreach { numIndices =>
+    Range(1, 5, 1).foreach { numIndices =>
       val output = newOutput
       new PickIlluminaIndices(
         length = 4,

--- a/src/test/scala/com/fulcrumgenomics/vcf/AssessPhasingTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/vcf/AssessPhasingTest.scala
@@ -163,8 +163,8 @@ class AssessPhasingTest extends ErrorLogLevel {
 
     // output files
     val output                 = makeTempFile("AssessPhasingTest.", "prefix")
-    val phasingMetricsPath     = PathUtil.pathTo(output + AssessPhasingMetric.MetricExtension)
-    val blockLengthMetricsPath = PathUtil.pathTo(output + PhaseBlockLengthMetric.MetricExtension)
+    val phasingMetricsPath     = PathUtil.pathTo(s"${output}${AssessPhasingMetric.MetricExtension}")
+    val blockLengthMetricsPath = PathUtil.pathTo(s"${output}${PhaseBlockLengthMetric.MetricExtension}")
     Seq(phasingMetricsPath, blockLengthMetricsPath).foreach(_.toFile.deleteOnExit)
 
     // run it
@@ -175,8 +175,8 @@ class AssessPhasingTest extends ErrorLogLevel {
     val blockLengthMetrics = Metric.read[PhaseBlockLengthMetric](path=blockLengthMetricsPath)
 
     // get the expected metrics paths
-    val expectedPhasingMetricsPath     = PathUtil.pathTo(expectedPrefix + AssessPhasingMetric.MetricExtension)
-    val expectedBlockLengthMetricsPath = PathUtil.pathTo(expectedPrefix + PhaseBlockLengthMetric.MetricExtension)
+    val expectedPhasingMetricsPath     = PathUtil.pathTo(s"${expectedPrefix}${AssessPhasingMetric.MetricExtension}")
+    val expectedBlockLengthMetricsPath = PathUtil.pathTo(s"${expectedPrefix}${PhaseBlockLengthMetric.MetricExtension}")
 
     // read the expected metrics
     val expectedPhasingMetrics     = Metric.read[AssessPhasingMetric](path=expectedPhasingMetricsPath)
@@ -188,9 +188,9 @@ class AssessPhasingTest extends ErrorLogLevel {
 
     if (debugVcf) {
       val annotatedVcf         = Paths.get(output.toString + AssessPhasing.AnnotatedVcfExtension)
-      val expectedAnnotatedVcf = PathUtil.pathTo(expectedPrefix + AssessPhasing.AnnotatedVcfExtension)
-      val actualContexts = new VCFFileReader(annotatedVcf.toFile, false).iterator().toIterator.toList
-      val expectedContexts = new VCFFileReader(expectedAnnotatedVcf.toFile, false).iterator().toIterator.toList
+      val expectedAnnotatedVcf = PathUtil.pathTo(s"${expectedPrefix}${AssessPhasing.AnnotatedVcfExtension}")
+      val actualContexts = new VCFFileReader(annotatedVcf.toFile, false).iterator().toList
+      val expectedContexts = new VCFFileReader(expectedAnnotatedVcf.toFile, false).iterator().toList
       actualContexts.length shouldBe expectedContexts.length
       actualContexts.zip(expectedContexts).foreach { case (actualCtx, expectedCtx) =>
           actualCtx.toStringDecodeGenotypes shouldBe expectedCtx.toStringDecodeGenotypes
@@ -298,12 +298,12 @@ class PhaseBlockTest extends ErrorLogLevel {
 
   "PhaseBlock.toOverlapDetector" should "create an empty detector if no variants are given" in {
     val builder = new VariantContextSetBuilder()
-    PhaseBlock.buildOverlapDetector(iterator=builder.iterator, dict=builder.header.getSequenceDictionary).getAll shouldBe 'empty
+    PhaseBlock.buildOverlapDetector(iterator=builder.iterator, dict=builder.header.getSequenceDictionary).getAll.isEmpty shouldBe true
   }
 
   it should "create an empty detector when variants do not have the phase set tag" in {
     val builder  = new VariantContextSetBuilder().addVariant(start=1, variantAlleles=List("A", "C"), genotypeAlleles=List("A", "C"), phased=true)
-    PhaseBlock.buildOverlapDetector(iterator=builder.iterator, dict=builder.header.getSequenceDictionary).getAll shouldBe 'empty
+    PhaseBlock.buildOverlapDetector(iterator=builder.iterator, dict=builder.header.getSequenceDictionary).getAll.isEmpty shouldBe true
   }
 
   it should "create a detector for a single variant" in {
@@ -767,7 +767,7 @@ class PhaseCigarTest extends ErrorLogLevel {
   }
 
   "Cigar.toShortSwitchErrorIndices" should "find no indices for an empty cigar" in {
-    PhaseCigar(cigar=Seq.empty).toShortSwitchErrorIndices()shouldBe 'empty
+    PhaseCigar(cigar=Seq.empty).toShortSwitchErrorIndices().isEmpty shouldBe true
   }
 
   it should "find an error at the first or last cigar element if the mismatch is isolated" in {
@@ -790,12 +790,12 @@ class PhaseCigarTest extends ErrorLogLevel {
   }
 
   it should "ignore variant sites only in the truth or call set" in {
-    PhaseCigar(cigar=Seq(CallOnly, Match)).toShortSwitchErrorIndices()shouldBe 'empty
-    PhaseCigar(cigar=Seq(TruthOnly, Match)).toShortSwitchErrorIndices()shouldBe 'empty
+    PhaseCigar(cigar=Seq(CallOnly, Match)).toShortSwitchErrorIndices().isEmpty shouldBe true
+    PhaseCigar(cigar=Seq(TruthOnly, Match)).toShortSwitchErrorIndices().isEmpty shouldBe true
   }
 
   it should "not count adjacent mismatches" in {
-    PhaseCigar(cigar=Seq(Mismatch, Mismatch)).toShortSwitchErrorIndices()shouldBe 'empty
+    PhaseCigar(cigar=Seq(Mismatch, Mismatch)).toShortSwitchErrorIndices().isEmpty shouldBe true
   }
 
   "Cigar.toLongSwitchErrorsAndSites" should "find no errors and no sites for an empty cigar" in {
@@ -946,7 +946,7 @@ class PhaseCigarTest extends ErrorLogLevel {
     PhaseCigar.contextsToMatchingOperator(truth=None, call=Some(ctxStart)) shouldBe Some(CallOnly)
 
     // No truth, call is not the start of a phase block
-    PhaseCigar.contextsToBlockEndOperator(truth=None, call=Some(ctxNoStart)) shouldBe 'empty
+    PhaseCigar.contextsToBlockEndOperator(truth=None, call=Some(ctxNoStart)).isEmpty shouldBe true
     PhaseCigar.contextsToMatchingOperator(truth=None, call=Some(ctxNoStart)) shouldBe Some(CallOnly)
 
     // Truth is the start of a phase block, no call
@@ -954,7 +954,7 @@ class PhaseCigarTest extends ErrorLogLevel {
     PhaseCigar.contextsToMatchingOperator(truth=Some(ctxStart), call=None) shouldBe Some(TruthOnly)
 
     // Truth is the start of a phase block, no call
-    PhaseCigar.contextsToBlockEndOperator(truth=Some(ctxNoStart), call=None) shouldBe 'empty
+    PhaseCigar.contextsToBlockEndOperator(truth=Some(ctxNoStart), call=None).isEmpty shouldBe true
     PhaseCigar.contextsToMatchingOperator(truth=Some(ctxNoStart), call=None) shouldBe Some(TruthOnly)
 
     // Truth and call, both start of a phase block
@@ -970,7 +970,7 @@ class PhaseCigarTest extends ErrorLogLevel {
     PhaseCigar.contextsToMatchingOperator(truth=Some(ctxStart), call=Some(ctxNoStart)) shouldBe Some(Match)
 
     // Truth and call, neither are the start of a phase block
-    PhaseCigar.contextsToBlockEndOperator(truth=Some(ctxNoStart), call=Some(ctxNoStart)) shouldBe 'empty
+    PhaseCigar.contextsToBlockEndOperator(truth=Some(ctxNoStart), call=Some(ctxNoStart)).isEmpty shouldBe true
     PhaseCigar.contextsToMatchingOperator(truth=Some(ctxNoStart), call=Some(ctxNoStart)) shouldBe Some(Match)
   }
 

--- a/src/test/scala/com/fulcrumgenomics/vcf/ByIntervalListVariantContextIteratorTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/vcf/ByIntervalListVariantContextIteratorTest.scala
@@ -56,61 +56,61 @@ class ByIntervalListVariantContextIteratorTest extends UnitSpec {
   }
 
   "ByIntervalListVariantContextIterator" should "return no variants if the interval list is empty" in {
-    Stream(true, false).foreach { useIndex =>
+    Iterator(true, false).foreach { useIndex =>
       val builder = new VariantContextSetBuilder().addVariant(refIdx=0, start=1, variantAlleles=List("A"), genotypeAlleles=List("A"))
       val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=emtpyIntervalList(), useIndex=useIndex)
-      iterator shouldBe 'empty
+      iterator.isEmpty shouldBe true
     }
   }
 
   it should "return no variants if the variants are empty" in {
-    Stream(true, false).foreach { useIndex =>
+    Iterator(true, false).foreach { useIndex =>
       val builder = new VariantContextSetBuilder()
       val intervalList = emtpyIntervalList()
       intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 1, 1000, false, "foo"))
       val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=emtpyIntervalList(), useIndex=useIndex)
-      iterator shouldBe 'empty
+      iterator.isEmpty shouldBe true
     }
   }
 
   it should "return a variant context if it overlaps an interval" in {
-    Stream(true, false).foreach { useIndex =>
+    Iterator(true, false).foreach { useIndex =>
       val builder = new VariantContextSetBuilder().addVariant(refIdx=0, start=500, variantAlleles=List("A"), genotypeAlleles=List("A"))
       val intervalList = emtpyIntervalList()
       intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 1, 1000, false, "foo"))
       val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=intervalList, useIndex=useIndex)
-      iterator shouldBe 'nonEmpty
+      iterator.isEmpty shouldBe false
       val actual = iterator.next()
       val expected = builder.head
       actual.getContig shouldBe expected.getContig
       actual.getStart shouldBe expected.getStart
       actual.getEnd shouldBe expected.getEnd
-      iterator shouldBe 'empty
+      iterator.isEmpty shouldBe true
     }
   }
 
   it should "not return a variant context if it doesn't overlap an interval (same chromosome)" in {
-    Stream(true, false).foreach { useIndex =>
+    Iterator(true, false).foreach { useIndex =>
       val builder = new VariantContextSetBuilder().addVariant(refIdx=0, start=500, variantAlleles=List("A"), genotypeAlleles=List("A"))
       val intervalList = emtpyIntervalList()
       intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 750, 1000, false, "foo"))
       val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=intervalList, useIndex=useIndex)
-      iterator shouldBe 'empty
+      iterator.isEmpty shouldBe true
     }
   }
 
   it should "not return a variant context if it doesn't overlap an interval (different chromosome)" in {
-    Stream(true, false).foreach { useIndex =>
+    Iterator(true, false).foreach { useIndex =>
       val builder = new VariantContextSetBuilder().addVariant(refIdx=0, start=500, variantAlleles=List("A"), genotypeAlleles=List("A"))
       val intervalList = emtpyIntervalList()
       intervalList.add(new Interval(dict.getSequence(1).getSequenceName, 1, 1000, false, "foo"))
       val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=intervalList, useIndex=useIndex)
-      iterator shouldBe 'empty
+      iterator.isEmpty shouldBe true
     }
   }
 
   it should "throw an exception when next() is call but hasNext() is false" in {
-    Stream(true, false).foreach { useIndex =>
+    Iterator(true, false).foreach { useIndex =>
       val builder = new VariantContextSetBuilder().addVariant(refIdx=0, start=1, variantAlleles=List("A"), genotypeAlleles=List("A"))
       val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=emtpyIntervalList(), useIndex=useIndex)
       iterator.hasNext shouldBe false
@@ -119,35 +119,35 @@ class ByIntervalListVariantContextIteratorTest extends UnitSpec {
   }
 
   it should "return a variant context if it encloses an interval" in {
-    Stream(true, false).foreach { useIndex =>
+    Iterator(true, false).foreach { useIndex =>
       val builder = new VariantContextSetBuilder().addVariant(refIdx=0, start=495, variantAlleles=List("AAAAA", "A"), genotypeAlleles=List("A"))
       val intervalList = emtpyIntervalList()
       intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 496, 496, false, "foo"))
       val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=intervalList, useIndex=useIndex)
-      iterator shouldBe 'nonEmpty
+      iterator.isEmpty shouldBe false
       val actual = iterator.next()
       val expected = builder.head
       actual.getContig shouldBe expected.getContig
       actual.getStart shouldBe expected.getStart
       actual.getEnd shouldBe expected.getEnd
-      iterator shouldBe 'empty
+      iterator.isEmpty shouldBe true
     }
   }
 
   it should "return a variant context only once if it overlaps multiple intervals" in {
-    Stream(true, false).foreach { useIndex =>
+    Iterator(true, false).foreach { useIndex =>
       val builder = new VariantContextSetBuilder().addVariant(refIdx=0, start=495, variantAlleles=List("AAAAA", "A"), genotypeAlleles=List("A"))
       val intervalList = emtpyIntervalList()
       intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 496, 496, false, "foo"))
       intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 500, 500, false, "foo"))
       val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=intervalList, useIndex=useIndex)
-      iterator shouldBe 'nonEmpty
+      iterator.isEmpty shouldBe false
       val actual = iterator.next()
       val expected = builder.head
       actual.getContig shouldBe expected.getContig
       actual.getStart shouldBe expected.getStart
       actual.getEnd shouldBe expected.getEnd
-      iterator shouldBe 'empty
+      iterator.isEmpty shouldBe true
     }
   }
 
@@ -160,18 +160,18 @@ class ByIntervalListVariantContextIteratorTest extends UnitSpec {
     intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 500, 500, false, "foo"))
     val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=intervalList, useIndex=true)
     // OK, since we are overlapping the first interval
-    iterator shouldBe 'nonEmpty
+    iterator.isEmpty shouldBe false
     // NOK, since the intervals were overlapping when we pre-fetch the second variant context
     an[Exception] should be thrownBy iterator.next()
   }
 
   it should "ignore a variant context if does not overlap an interval" in {
-    Stream(true, false).foreach { useIndex =>
+    Iterator(true, false).foreach { useIndex =>
       val builder = new VariantContextSetBuilder().addVariant(refIdx=0, start=495, variantAlleles=List("A", "C"), genotypeAlleles=List("C"))
       val intervalList = emtpyIntervalList()
       intervalList.add(new Interval(dict.getSequence(0).getSequenceName, 500, 500, false, "foo"))
       val iterator = toIterator(reader=builder.toVcfFileReader(), intervalList=intervalList, useIndex=useIndex)
-      iterator shouldBe 'empty
+      iterator.isEmpty shouldBe true
     }
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/vcf/HapCutToVcfTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/vcf/HapCutToVcfTest.scala
@@ -157,7 +157,7 @@ class HapCutToVcfTest extends UnitSpec with ParallelTestExecution {
     reader.close()  }
 
   "HapCutToVcf" should "convert a HAPCUT1 file to VCF in both GATK and VCF-spec phasing format" in {
-    Stream(true, false).foreach { gatkPhasingFormat =>
+    Iterator(true, false).foreach { gatkPhasingFormat =>
       val expectedOutput = if (gatkPhasingFormat) hapCut1GatkVcf else hapCut1Vcf
       val out = makeTempFile("hap_cut_to_vcf.hapcut", ".vcf")
 
@@ -192,7 +192,7 @@ class HapCutToVcfTest extends UnitSpec with ParallelTestExecution {
   }
 
   it should "convert a HAPCUT2 file to VCF in both GATK and VCF-spec phasing format" in {
-    Stream(true, false).foreach { gatkPhasingFormat =>
+    Iterator(true, false).foreach { gatkPhasingFormat =>
       val expectedOutput = if (gatkPhasingFormat) hapCut2GatkVcf else hapCut2Vcf
       val out = makeTempFile("hap_cut_to_vcf.hapcut2", ".vcf")
 
@@ -259,7 +259,7 @@ class HapCutToVcfTest extends UnitSpec with ParallelTestExecution {
   }
 
   it should "convert an empty HAPCUT1/HAPCUT2 file to VCF in both GATK and VCF-spec phasing format" in {
-    Stream(true, false).foreach { gatkPhasingFormat =>
+    Iterator(true, false).foreach { gatkPhasingFormat =>
       val out       = makeTempFile("hap_cut_to_vcf.hapcut", ".vcf")
       val hapCutOut = makeTempFile("hap_cut_to_vcf.hapcut", ".hapcut")
 

--- a/src/test/scala/com/fulcrumgenomics/vcf/VariantMaskTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/vcf/VariantMaskTest.scala
@@ -41,7 +41,7 @@ class VariantMaskTest extends UnitSpec {
     builder.toTempFile()
   }
 
-  val dict = SAMSequenceDictionaryExtractor.extractDictionary(ref.toFile)
+  val dict = SAMSequenceDictionaryExtractor.extractDictionary(ref)
 
   "VariantMask" should "mask SNPs as individual bases" in {
     val builder = new VariantContextSetBuilder().setSequenceDictionary(dict)

--- a/src/test/scala/com/fulcrumgenomics/vcf/filtration/EndRepairArtifactLikelihoodFilterTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/vcf/filtration/EndRepairArtifactLikelihoodFilterTest.scala
@@ -24,6 +24,7 @@
 
 package com.fulcrumgenomics.vcf.filtration
 
+import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.bam.{BaseEntry, Pileup, PileupBuilder, PileupEntry}
 import com.fulcrumgenomics.testing.SamBuilder.{Minus, Plus}
 import com.fulcrumgenomics.testing.{SamBuilder, UnitSpec, VariantContextSetBuilder}


### PR DESCRIPTION
This one is uglier.  I had to resort to having a single 2.12 vs. 2.13 specific source file to work around the fact that `IterableView` is gone in 2.13 and `View` didn't exist in `2.12`.

There are still a ton of deprecation warnings too.  But things are at least working, and we can chip away at the deprecations.