### PR TITLE
Don't try to index BAM files that can't be indexed with HTSJDK.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,6 +95,7 @@ lazy val commonSettings = Seq(
   fork in Test         := true,
   resolvers            += Resolver.sonatypeRepo("public"),
   resolvers            += Resolver.mavenLocal,
+  resolvers            += "broad-snapshots" at "https://artifactory.broadinstitute.org/artifactory/libs-snapshot/",
   shellPrompt          := { state => "%s| %s> ".format(GitCommand.prompt.apply(state), version.value) },
   updateOptions        := updateOptions.value.withCachedResolution(true)
 ) ++ Defaults.coreDefaultSettings
@@ -126,7 +127,7 @@ lazy val root = Project(id="fgbio", base=file("."))
       "org.scala-lang.modules"    %% "scala-collection-compat" % "2.1.1",
       "com.fulcrumgenomics"       %% "commons"        % "1.0.0",
       "com.fulcrumgenomics"       %% "sopt"           % "1.0.0",
-      "com.github.samtools"       %  "htsjdk"         % "2.19.0" excludeAll(htsjdkExcludes: _*),
+      "com.github.samtools"       %  "htsjdk"         % "2.20.2-2-g2a6e2c2-SNAPSHOT" excludeAll(htsjdkExcludes: _*),
       "org.apache.commons"        %  "commons-math3"  % "3.6.1",
       "com.beachape"              %% "enumeratum"     % "1.5.13",
       "com.intel.gkl"             %  "gkl"            % "0.8.6",

--- a/src/main/scala/com/fulcrumgenomics/bam/api/SamWriter.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/api/SamWriter.scala
@@ -84,11 +84,10 @@ object SamWriter extends LazyLogging {
     }
 
     // Only index the output file if the sort order is right, indexing is requested, and no chrom is too long
-    val actuallyIndex = {
+    val actuallyIndex = if (header.getSortOrder != SortOrder.coordinate || !index) false else {
       val hasChromsTooLong = header.getSequenceDictionary.getSequences.exists(_.getSequenceLength > GenomicIndexUtil.BIN_GENOMIC_SPAN)
-      val wouldHaveIndexed = header.getSortOrder == SortOrder.coordinate && index
-      if (wouldHaveIndexed && hasChromsTooLong) logger.warning(s"Cannot index $path as one or more chromosomes is too long.")
-      wouldHaveIndexed && !hasChromsTooLong
+      if (hasChromsTooLong) logger.warning(s"Cannot index $path as one or more chromosomes is too long.")
+      !hasChromsTooLong
     }
 
     val factory = new SAMFileWriterFactory()
@@ -102,7 +101,6 @@ object SamWriter extends LazyLogging {
     new SamWriter(writer=factory.makeWriter(header, true, path.toFile, ref.map(_.toFile).orNull),
       sorter=sorter, sortProgress=sortProgress, writeProgress=writeProgress)
   }
-
 }
 
 /** Provides the ability to write [[SamRecord]]s to an output Path. */


### PR DESCRIPTION
@nh13 The change here is quite simple.  HTSJDK blows up if you ask it to index on the fly and hand it reference sequences that are beyond what BAI can handle.  There's no CSI writing support yet either.

I'd also like to wait until https://github.com/samtools/htsjdk/pull/1410 is merged, and update our HTSJDK dependency in this same PR if possible.