### PR TITLE
Updates to FastqSource

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/fastq/TrimFastq.scala
+++ b/src/main/scala/com/fulcrumgenomics/fastq/TrimFastq.scala
@@ -56,7 +56,7 @@ class TrimFastq
     var discarded: Long = 0
     val progress = new ProgressLogger(this.logger, noun="records", verb="Wrote")
 
-    val sources = input.map(FastqSource(_))
+    val sources = input.map(FastqSource(_).iterator)
     val writers = output.map(FastqWriter(_))
     while (allHaveNext(sources)) {
       val recs = sources.map(_.next())

--- a/src/test/scala/com/fulcrumgenomics/fastq/FastqIoTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/fastq/FastqIoTest.scala
@@ -59,14 +59,15 @@ class FastqIoTest extends UnitSpec {
     Io.writeLines(fq, FastqIoTest.someFastq)
 
     Seq(FastqSource(fq), FastqSource(fq.toFile), FastqSource(Io.toInputStream(fq)), FastqSource(FastqIoTest.someFastq)).foreach(source => {
-      source.hasNext shouldBe true
-      source.next shouldBe FastqIoTest.someFastqRecords(0)
-      source.hasNext shouldBe true
-      source.next shouldBe FastqIoTest.someFastqRecords(1)
-      source.hasNext shouldBe true
-      source.next shouldBe FastqIoTest.someFastqRecords(2)
-      source.hasNext shouldBe false
-      an[NoSuchElementException] shouldBe thrownBy { source.next() }
+      val iter = source.iterator
+      iter.hasNext shouldBe true
+      iter.next shouldBe FastqIoTest.someFastqRecords(0)
+      iter.hasNext shouldBe true
+      iter.next shouldBe FastqIoTest.someFastqRecords(1)
+      iter.hasNext shouldBe true
+      iter.next shouldBe FastqIoTest.someFastqRecords(2)
+      iter.hasNext shouldBe false
+      an[NoSuchElementException] shouldBe thrownBy { iter.next() }
     })
   }
 


### PR DESCRIPTION
- do not close the input stream when built from it
- extend View to make FastqSource non-strict

Note: the PR https://github.com/fulcrumgenomics/fgbio/pull/53 was inspired by `FastqSource`, so I've tried to make similar changes to `FastqSource` here that were agreed upon in the aforementioned PR.