### PR TITLE
Do not return zero-length alignments

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/alignment/Aligner.scala
+++ b/src/main/scala/com/fulcrumgenomics/alignment/Aligner.scala
@@ -491,7 +491,7 @@ class Aligner(val scorer: AlignmentScorer,
           forloop(from = 1, until = tLen + 1) { j =>
             val direction = AllDirections.maxBy(d => matrices(d).scoring(i, j))
             val score = matrices(direction).scoring(i, j)
-            if (score > maxScore) {
+            if (score > maxScore || maxD == Done) {
               maxScore = score
               maxI = i
               maxJ = j
@@ -527,7 +527,7 @@ class Aligner(val scorer: AlignmentScorer,
         forloop(from = 1, until = qLen + 1) { i =>
           forloop(from = 1, until = tLen + 1) { j =>
             val direction = AllDirections.maxBy(d => matrices(d).scoring(i, j))
-            if (matrices(direction).scoring(i, j) >= minScore) hits += MatrixLocation(i, j, direction)
+            if (matrices(direction).scoring(i, j) >= minScore && matrices(direction).trace(i, j) != Done) hits += MatrixLocation(i, j, direction)
           }
         }
     }

--- a/src/test/scala/com/fulcrumgenomics/alignment/AlignerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/alignment/AlignerTest.scala
@@ -506,6 +506,31 @@ class AlignerTest extends UnitSpec {
     }
   }
 
+  it should "ignore zero-length alignments" in {
+    val query  = "TTTTT"
+    val target = "AAAAA"
+
+    // all by score
+    {
+      val results = Aligner(5, -4, -10, -5, mode = Local).align(query, target, 0).sortBy(-_.score)
+      results.foreach { r =>
+        r.queryStart should be <= r.queryEnd
+        r.targetStart should be <= r.targetEnd
+        r.score should be >= 0
+      }
+    }
+
+    // only the best, which is actually an empty alignment
+    {
+      val result = Aligner(5, -4, -10, -5, mode = Local).align(query, target)
+      result.queryStart shouldBe 2
+      result.queryEnd shouldBe 1
+      result.targetStart shouldBe 2
+      result.targetEnd shouldBe 1
+      result.score shouldBe 0
+    }
+  }
+
   /** Timing test - change "ignore" to "it" to enable. */
   ignore should "perform lots of glocal alignments" in {
     val count = 25000


### PR DESCRIPTION
This occurs when performing local alignment and setting the minimum
score to zero or smaller.