### PR TITLE
Add the `primary` keyword for accessing a SamRecord's secondary flag

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/bam/api/SamRecord.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/api/SamRecord.scala
@@ -124,8 +124,8 @@ trait SamRecord {
 
   @inline final def secondary: Boolean = isSecondaryAlignment
   @inline final def secondary_=(secondary: Boolean):Unit = setSecondaryAlignment(secondary)
-  @inline final def primary: Boolean = !isSecondaryAlignment
-  @inline final def primary_=(primary: Boolean):Unit = setSecondaryAlignment(!primary)
+  @inline final def primary: Boolean = !this.secondary
+  @inline final def primary_=(primary: Boolean):Unit = this.secondary(!primary)
 
   @inline final def pf: Boolean = !getReadFailsVendorQualityCheckFlag
   @inline final def pf_=(pf: Boolean):Unit = setReadFailsVendorQualityCheckFlag(!pf)

--- a/src/main/scala/com/fulcrumgenomics/bam/api/SamRecord.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/api/SamRecord.scala
@@ -124,6 +124,8 @@ trait SamRecord {
 
   @inline final def secondary: Boolean = isSecondaryAlignment
   @inline final def secondary_=(secondary: Boolean):Unit = setSecondaryAlignment(secondary)
+  @inline final def primary: Boolean = !isSecondaryAlignment
+  @inline final def primary_=(primary: Boolean):Unit = setSecondaryAlignment(!primary)
 
   @inline final def pf: Boolean = !getReadFailsVendorQualityCheckFlag
   @inline final def pf_=(pf: Boolean):Unit = setReadFailsVendorQualityCheckFlag(!pf)


### PR DESCRIPTION
This minor change introduces the ability to get and set the secondary bit flag of a `SamRecord` using the `primary` keyword.

For example the following two statements would be equivalent:

```scala
rec.primary = true
```

and 

```scala
rec.secondary = false
```