### PR TITLE
Two fixes to RefFlatSource:

### DIFF
--- a/src/test/scala/com/fulcrumgenomics/util/RefFlatSourceTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/util/RefFlatSourceTest.scala
@@ -82,7 +82,7 @@ class RefFlatSourceTest extends UnitSpec {
 
       //verify the first exon in the first transcript
       val exon = transcript.exons.head
-      exon shouldBe Exon(141638944, 141639396)
+      exon shouldBe Exon(141654484, 141655128)
     })
   }
 


### PR DESCRIPTION
- Exons were not being put into transcripts in transcription order which is required (but not verified in Transcript)
- Gene start/end were being taken as the min of the transcript starts/ends, but for end it should be max