### PR TITLE
Changed the gene annotation case classes and the RefFlatSource to res…

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/util/GeneAnnotations.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/GeneAnnotations.scala
@@ -25,32 +25,92 @@
 
 package com.fulcrumgenomics.util
 
-import htsjdk.samtools.util.{CoordMath, Interval}
+import htsjdk.samtools.util.{CoordMath, Locatable}
+import com.fulcrumgenomics.FgBioDef._
 
 /** Stores classes useful for storing annotation information for genes and their transcripts and exons. */
 object GeneAnnotations {
+  /**
+    * A gene with a collection of gene loci.
+    */
+  case class Gene(name: String, loci: Seq[GeneLocus]) extends Iterable[Transcript] {
+    def iterator: Iterator[Transcript] = this.loci.iterator.flatten
 
-  /** A gene with zero or more transcripts, that all are on the same transcription strand. */
-  case class Gene(contig: String, start: Int, end: Int, negativeStrand: Boolean, name: String, transcripts: Seq[Transcript])
-    extends Interval(contig, start, end, negativeStrand, name) with Iterable[Transcript] {
-    def iterator: Iterator[Transcript] = transcripts.iterator
+    /** Returns the locus with the maximum transcript mappings. */
+    def primaryLocus: GeneLocus = loci.maxBy(_.size)
   }
 
-  /** A transcript associated with a given gene (which stores the transcription strand).  Contains zero or more exons.
-    * The exons should be given in transcript order. */
-  case class Transcript(name: String, start: Int, end: Int, cdsStart: Int, cdsEnd: Int, exons: Seq[Exon]) {
+
+  /**
+    * A gene locus representing a set of transcripts that are mapped to the same location on the genome.
+    *
+    * @param transcripts the set of transcripts at the locus
+    */
+  case class GeneLocus(transcripts: Seq[Transcript]) extends Locatable with Iterable[Transcript] {
+    require(transcripts.nonEmpty, "GeneLocus cannot be generated from an empty set of transcripts.")
+    require(transcripts.forall(t => t.chrom == transcripts.head.chrom))
+    require(transcripts.forall(t => t.negativeStrand == transcripts.head.negativeStrand))
+
+    val chrom: String = transcripts.head.chrom
+    val start: Int = transcripts.minBy(_.start).start
+    val end:   Int = transcripts.maxBy(_.end).end
+    val negativeStrand: Boolean = transcripts.head.negativeStrand
+    def positiveStrand: Boolean = !negativeStrand
+
+    // Locatable implementation
+    override def getContig: String = chrom
+    override def getStart: Int = start
+    override def getEnd: Int = end
+
+    override def iterator: Iterator[Transcript] = this.transcripts.iterator
+  }
+
+
+  /**
+    * A transcript [mapping] associated with a given gene locus.  Contains zero or more exons.
+    * The exons should be given in the order of transcription.
+    */
+  case class Transcript(name: String,
+                        chrom: String,
+                        start: Int,
+                        end: Int,
+                        cdsStart: Option[Int],
+                        cdsEnd: Option[Int],
+                        negativeStrand: Boolean,
+                        exons: Seq[Exon]) extends Locatable {
     if (exons.length > 1) {
       val exonsOverlap = genomicOrder.sliding(2).map { e => (e.head, e.last) }.exists { case (e1, e2) => CoordMath.overlaps(e1.start, e1.end, e2.start, e2.end) }
       require(!exonsOverlap, s"exons overlap for transcript: $name")
     }
+
+    require(cdsStart.isDefined == cdsEnd.isDefined, s"cdsStart and cdsEnd must either both or neither be defined on tx: $name.")
+
+    // Locatable implementation
+    override def getContig: String = chrom
+    override def getStart: Int = start
+    override def getEnd: Int = end
+
+    def positiveStrand: Boolean = !negativeStrand
+
     /** The order in which exons appear in the transcripts */
     def transcriptOrder: Iterator[Exon] = exons.iterator
+
     /** The order in which exons appear in the genome */
     def genomicOrder: Iterator[Exon] = exons.sortBy { exon => (exon.start, exon.end) }.iterator
+
+    /** The length of the transcript mapping on the genome (including introns). */
+    def lengthOnGenome: Int = end - start + 1
+
+    /** The length of the transcribed product after introns are removed. */
+    def transcribedLength: Int = exons.sumBy(_.length)
+
+    /** True if the transcript is coding, false otherwise. */
+    def isCoding: Boolean = cdsStart.isDefined
   }
 
   /** Defines an exonic sequence within a transcript. */
   case class Exon(start: Int, end: Int) {
     require(start <= end, "start is greater than end when creating an exon")
+    def length: Int = end - start + 1
   }
 }

--- a/src/main/scala/com/fulcrumgenomics/util/GeneAnnotations.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/GeneAnnotations.scala
@@ -34,6 +34,7 @@ object GeneAnnotations {
     * A gene with a collection of gene loci.
     */
   case class Gene(name: String, loci: Seq[GeneLocus]) extends Iterable[Transcript] {
+    /** Iterate over all transcripts from all GeneLoci (each a collection of transcripts). */
     def iterator: Iterator[Transcript] = this.loci.iterator.flatten
 
     /** Returns the locus with the maximum transcript mappings. */
@@ -51,16 +52,16 @@ object GeneAnnotations {
     require(transcripts.forall(t => t.chrom == transcripts.head.chrom))
     require(transcripts.forall(t => t.negativeStrand == transcripts.head.negativeStrand))
 
-    val chrom: String = transcripts.head.chrom
-    val start: Int = transcripts.minBy(_.start).start
-    val end:   Int = transcripts.maxBy(_.end).end
+    val chrom: String           = transcripts.head.chrom
+    val start: Int              = transcripts.minBy(_.start).start
+    val end:   Int              = transcripts.maxBy(_.end).end
     val negativeStrand: Boolean = transcripts.head.negativeStrand
     def positiveStrand: Boolean = !negativeStrand
 
     // Locatable implementation
     override def getContig: String = chrom
-    override def getStart: Int = start
-    override def getEnd: Int = end
+    override def getStart: Int     = start
+    override def getEnd: Int       = end
 
     override def iterator: Iterator[Transcript] = this.transcripts.iterator
   }
@@ -74,8 +75,8 @@ object GeneAnnotations {
                         chrom: String,
                         start: Int,
                         end: Int,
-                        cdsStart: Option[Int],
-                        cdsEnd: Option[Int],
+                        cdsStart: Option[Int] = None,
+                        cdsEnd: Option[Int]   = None,
                         negativeStrand: Boolean,
                         exons: Seq[Exon]) extends Locatable {
     if (exons.length > 1) {

--- a/src/main/scala/com/fulcrumgenomics/util/RefFlatSource.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/RefFlatSource.scala
@@ -125,7 +125,7 @@ class RefFlatSource private(lines: Iterator[String],
     val _genes = new DelimitedDataParser(lines=_lines, delimiter='\t').flatMap { row =>
       val geneName       = row.string("geneName")
       val transcriptName = row.string("name")
-      val contig         = row.string("chrom")
+      val contig         = row.string("chrom").intern()
       val strand         = row.string("strand")
       val exonCount      = row.string("exonCount").toInt
       val exonStarts     = row.string("exonStarts").split(',').filter(_.nonEmpty).map(_.toInt)

--- a/src/main/scala/com/fulcrumgenomics/util/RefFlatSource.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/RefFlatSource.scala
@@ -119,9 +119,6 @@ class RefFlatSource private(lines: Iterator[String],
 
 
     // Each line is a gene and transcript.  We want to group all transcripts from the same gene.
-    var numDifferentChromosomes = 0
-    var numDifferentStrands     = 0
-    var numTranscripts          = 0
     val _genes = new DelimitedDataParser(lines=_lines, delimiter='\t').flatMap { row =>
       val geneName       = row.string("geneName")
       val transcriptName = row.string("name")
@@ -184,9 +181,6 @@ class RefFlatSource private(lines: Iterator[String],
 
         Gene(name=name, loci=groups.map(g => GeneLocus(g.toSeq)).toSeq)
       }
-
-    logger.info(f"Filtered out $numDifferentChromosomes out of $numTranscripts (${numDifferentChromosomes/numTranscripts.toDouble*100}%.2f%%) transcript(s) due to being on a different chromosome.")
-    logger.info(f"Filtered out $numDifferentStrands out of $numTranscripts (${numDifferentStrands/numTranscripts.toDouble*100}%.2f%%) transcript(s) due to being on a different strands.")
 
     _genes
   }

--- a/src/main/scala/com/fulcrumgenomics/util/RefFlatSource.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/RefFlatSource.scala
@@ -29,9 +29,10 @@ import java.io.{Closeable, File, InputStream}
 
 import com.fulcrumgenomics.commons.CommonsDef.FilePath
 import com.fulcrumgenomics.commons.util.{DelimitedDataParser, LazyLogging}
-import com.fulcrumgenomics.util.GeneAnnotations.{Exon, Gene, Transcript}
+import com.fulcrumgenomics.util.GeneAnnotations.{Exon, Gene, GeneLocus, Transcript}
 import htsjdk.samtools.SAMSequenceDictionary
 
+import scala.collection.mutable.ArrayBuffer
 import scala.io.Source
 
 object RefFlatSource {
@@ -122,13 +123,13 @@ class RefFlatSource private(lines: Iterator[String],
     var numDifferentStrands     = 0
     var numTranscripts          = 0
     val _genes = new DelimitedDataParser(lines=_lines, delimiter='\t').flatMap { row =>
-      val geneName       = row[String]("geneName")
-      val transcriptName = row[String]("name")
-      val contig         = row[String]("chrom")
-      val strand         = row[String]("strand")
-      val exonCount      = row[Int]("exonCount")
-      val exonStarts     = row[String]("exonStarts").split(',').filter(_.nonEmpty).map(_.toInt)
-      val exonEnds       = row[String]("exonEnds").split(',').filter(_.nonEmpty).map(_.toInt)
+      val geneName       = row.string("geneName")
+      val transcriptName = row.string("name")
+      val contig         = row.string("chrom")
+      val strand         = row.string("strand")
+      val exonCount      = row.string("exonCount").toInt
+      val exonStarts     = row.string("exonStarts").split(',').filter(_.nonEmpty).map(_.toInt)
+      val exonEnds       = row.string("exonEnds").split(',').filter(_.nonEmpty).map(_.toInt)
       val isNegative     = strand == "-"
 
       if (dict.exists(_.getSequence(contig) == null)) { // skip unrecognized sequences
@@ -144,63 +145,44 @@ class RefFlatSource private(lines: Iterator[String],
           if (isNegative) tmp.sortBy(e => -e.start) else tmp.sortBy(_.start)
         }
 
+        // Detect where there is no coding region and set cds start and end appropriately
+        val (cdsStart, cdsEnd) = (row[Int]("cdsStart"), row[Int]("cdsEnd")) match {
+          case (s, e) if s == e => (None, None)
+          case (s, e)           => (Some(s+1), Some(e))
+        }
+
         val transcript = Transcript(
-          name     = transcriptName,
-          start    = row[Int]("txStart") + 1,
-          end      = row[Int]("txEnd"),
-          cdsStart = row[Int]("cdsStart") + 1,
-          cdsEnd   = row[Int]("cdsEnd"),
-          exons    = exons
+          name           = transcriptName,
+          chrom          = contig,
+          start          = row[Int]("txStart") + 1,
+          end            = row[Int]("txEnd"),
+          cdsStart       = cdsStart,
+          cdsEnd         = cdsEnd,
+          negativeStrand = isNegative,
+          exons          = exons
         )
 
-        val gene = Gene(
-          contig         = contig,
-          start          = -1,
-          end            = -1,
-          negativeStrand = strand == "-",
-          name           = geneName,
-          transcripts    = Seq(transcript)
-        )
-
-        Some(gene)
+        val geneLocus = GeneLocus(Seq(transcript))
+        Some(Gene(name=geneName, loci=Seq(geneLocus)))
       }
     }
       .toSeq
       .groupBy(_.name)
       .map { case (name, _genes) =>
-        val contig         = _genes.head.contig
-        val negativeStrand = _genes.head.negativeStrand
+        // Group the transcripts into groups that are:
+        //   - On the same chromosome
+        //   - One the same strand
+        //   - Overlap at least one other transcript in the same group
+        val groups = new ArrayBuffer[ArrayBuffer[Transcript]]()
 
-        val transcripts = _genes.flatMap { gene =>
-          require(gene.transcripts.length == 1, s"Found more than one transcript for gene ${gene.name}.")
-          if (gene.contig != contig) {
-            val transcript = gene.head
-            numDifferentChromosomes += 1
-            logger.info(s"Filtering out transcript '${transcript.name}' for gene ${gene.name}' due to being on a different chromosomes (${gene.contig}) than the first transcript seen ($contig).")
-            None
-          }
-          else if (gene.negativeStrand != negativeStrand) {
-            val transcript = gene.head
-            val originalStrand = if (negativeStrand)      "-" else "+"
-            val currentStrand  = if (gene.negativeStrand) "-" else "+"
-            numDifferentStrands += 1
-            logger.info(s"Filtering out transcript '${transcript.name}' for gene ${gene.name}' due to being on a different strand ($currentStrand) than the first transcript seen ($originalStrand).")
-            None
-          }
-          else {
-            numTranscripts += 1
-            gene.transcripts
+        _genes.flatMap(_.iterator).sortBy(tx => -tx.lengthOnGenome).foreach { tx =>
+          groups.find { group => group.exists(t => t.negativeStrand == tx.negativeStrand && t.overlaps(tx)) } match {
+            case Some(group) => group += tx
+            case None        => groups += ArrayBuffer(tx)
           }
         }
 
-        Gene(
-          contig         = contig,
-          start          = transcripts.map(_.start).min,
-          end            = transcripts.map(_.end).max,
-          negativeStrand = negativeStrand,
-          name           = name,
-          transcripts    = transcripts
-        )
+        Gene(name=name, loci=groups.map(g => GeneLocus(g.toSeq)).toSeq)
       }
 
     logger.info(f"Filtered out $numDifferentChromosomes out of $numTranscripts (${numDifferentChromosomes/numTranscripts.toDouble*100}%.2f%%) transcript(s) due to being on a different chromosome.")

--- a/src/test/scala/com/fulcrumgenomics/util/GeneAnnotationsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/util/GeneAnnotationsTest.scala
@@ -34,6 +34,6 @@ class GeneAnnotationsTest extends UnitSpec {
   }
 
   "GeneAnnotations.Transcript" should "fail if exons overlap" in {
-    an[Exception] should be thrownBy Transcript("", 0, 0, 0, 0, Seq(Exon(1,10), Exon(10, 20)))
+    an[Exception] should be thrownBy Transcript("tx", "chr1", 1, 20, None, None, negativeStrand=false, exons=Seq(Exon(1,10), Exon(10, 20)))
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/util/RefFlatSourceTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/util/RefFlatSourceTest.scala
@@ -64,11 +64,12 @@ class RefFlatSourceTest extends UnitSpec {
 
       // verify the first gene
       val gene = genes.head
-      gene.contig shouldBe "chr1"
-      gene.start shouldBe 141638944
-      gene.end shouldBe 141655128
-      gene.negativeStrand shouldBe true
       gene.name shouldBe "ANKRD20A12P"
+      gene.loci.size shouldBe 1
+      gene.loci.head.chrom shouldBe "chr1"
+      gene.loci.head.start shouldBe 141638944
+      gene.loci.head.end shouldBe 141655128
+      gene.loci.head.negativeStrand shouldBe true
       gene.size shouldBe 1
 
       // verify the first transcript in the first gene
@@ -76,8 +77,8 @@ class RefFlatSourceTest extends UnitSpec {
       transcript.name shouldBe "NR_046228"
       transcript.start shouldBe 141638944
       transcript.end shouldBe 141655128
-      transcript.cdsStart shouldBe 141655129
-      transcript.cdsEnd shouldBe 141655128
+      transcript.cdsStart shouldBe None
+      transcript.cdsEnd shouldBe None
       transcript.exons.size shouldBe 5
 
       //verify the first exon in the first transcript
@@ -86,24 +87,24 @@ class RefFlatSourceTest extends UnitSpec {
     })
   }
 
-  it should "filter genes where chromosomes differ across transcripts" in {
+  it should "separate loci where genes have transcripts that are not overlapping" in {
     val lines = Iterator(
       Seq("ACKR4", "NM_178445-1", "chr1", "+", "133801670", "133804175", "133801931", "133802984", "1", "133801670", "133804175").mkString("\t"),
       Seq("ACKR4", "NM_178445-2", "chr3", "+", "133801670", "133804175", "133801931", "133802984", "1", "133801670", "133804175").mkString("\t")
     )
     val source = RefFlatSource(lines, dict=None).toSeq
     source should have size 1
-    source.head should have size 1
+    source.head.loci should have size 2
   }
 
-  it should "filter genes where strands differ across transcripts" in {
+  it should "separate loci where genes have transcripts on different strands" in {
     val lines = Iterator(
       Seq("ACKR4", "NM_178445-1", "chr3", "+", "133801670", "133804175", "133801931", "133802984", "1", "133801670", "133804175").mkString("\t"),
       Seq("ACKR4", "NM_178445-2", "chr3", "-", "133801670", "133804175", "133801931", "133802984", "1", "133801670", "133804175").mkString("\t")
     )
     val source = RefFlatSource(lines, dict=None).toSeq
     source should have size 1
-    source.head should have size 1
+    source.head.loci should have size 2
   }
 
   it should "fail if the # of exon starts or ends do not equal the exon count for a transcript" in {


### PR DESCRIPTION
…olve two issues:

1. RefFlatSource would drop transcript mappings if there were mappings to > 1 chrom or > 1 strand for a given gene
2. RefFlatSource would combine transcript mappings at wildly different locations on the same chrom/strand

This necessitated changing the case classes a bit to insert a GeneLocus between Gene and Transcript, as a collection of transcripts at a common locus.

Also performed some other tidying up while I was in there.