### PR TITLE
uniquify aliases

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/fasta/CollectAlternateContigNames.scala
+++ b/src/main/scala/com/fulcrumgenomics/fasta/CollectAlternateContigNames.scala
@@ -182,7 +182,7 @@ class CollectAlternateContigNames
               None
             case alternate => Some(alternate)
           }
-      }
+      }.distinct
       if (sequenceRoles.nonEmpty && !this.sequenceRoles.contains(role)) {
         skipReasons += SkipReason(name=name, role=role, msg=s"Skipping contig name '$name' with mismatching sequencing role: $role.")
       }


### PR DESCRIPTION
When `AssignedMolecule` and `SequenceName` are given together.  Could add a test...but...it's bed time.

```
# Sequence-Name Sequence-Role   Assigned-Molecule   Assigned-Molecule-Location/Type GenBank-Accn    Relationship    RefSeq-Accn Assembly-Unit   Sequence-Length UCSC-style-name
1   assembled-molecule  1   Chromosome  CM000663.1  =   NC_000001.10    Primary Assembly    249250621   chr1
```

Currently will fail on `chr1` as `1` is the alias for both `AssignedMolecule` and `SequenceName`