### PR TITLE
Add the sort and default-contigs options to UpdateFastaContigName

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/fasta/UpdateFastaContigNames.scala
+++ b/src/main/scala/com/fulcrumgenomics/fasta/UpdateFastaContigNames.scala
@@ -24,13 +24,15 @@
 
 package com.fulcrumgenomics.fasta
 
+import java.io.BufferedWriter
+
 import com.fulcrumgenomics.FgBioDef.PathToSequenceDictionary
 import com.fulcrumgenomics.cmdline.{ClpGroups, FgBioTool}
 import com.fulcrumgenomics.commons.CommonsDef._
 import com.fulcrumgenomics.commons.util.LazyLogging
 import com.fulcrumgenomics.sopt.{arg, clp}
 import com.fulcrumgenomics.util.{Io, ProgressLogger}
-import htsjdk.samtools.reference.{FastaSequenceIndex, ReferenceSequenceFileFactory}
+import htsjdk.samtools.reference.{FastaSequenceIndex, ReferenceSequence, ReferenceSequenceFile, ReferenceSequenceFileFactory}
 
 @clp(description =
   """
@@ -38,6 +40,12 @@ import htsjdk.samtools.reference.{FastaSequenceIndex, ReferenceSequenceFileFacto
     |
     |The name of each sequence must match one of the names (including aliases) in the given sequence dictionary.  The
     |new name will be the primary (non-alias) name in the sequence dictionary.
+    |
+    |By default, the sort order of the contigs will be the same as the input FASTA.  Use the `--sort` option to sort by
+    |the input sequence dictionary.  Furthermore, the sequence dictionary may contain **more** contigs than the input
+    |FASTA, and they wont be used.  Use the `--skip-missing` option to skip contigs in the input FASTA that cannot be
+    |renamed (i.e. who are not present in the input sequence dictionary).  Finally, use the `--default-contigs` to
+    |append contigs not present in the input FASTA but present in the sequence dictionary.
   """,
   group = ClpGroups.Fasta)
 class UpdateFastaContigNames
@@ -45,49 +53,128 @@ class UpdateFastaContigNames
  @arg(flag='d', doc="The path to the sequence dictionary with contig aliases.") val dict: PathToSequenceDictionary,
  @arg(flag='o', doc="Output FASTA.") val output: PathToFasta,
  @arg(flag='l', doc="Line length or sequence lines.") val lineLength: Int = 100,
- @arg(doc="Skip missing source contigs.") val skipMissing: Boolean = false
+ @arg(doc="Skip missing source contigs.") val skipMissing: Boolean = false,
+ @arg(doc="Sort the contigs based on the input sequence dictionary") sort: Boolean = false,
+ @arg(doc="Add sequences from this FASTA when contigs in the sequence dictionary are missing from the input FASTA")
+ defaultContigs: Option[PathToFasta] = None
 ) extends FgBioTool with LazyLogging {
+  import com.fulcrumgenomics.fasta.Converters.FromSAMSequenceDictionary
 
-  Io.assertReadable(input)
   Io.assertReadable(Seq(input, dict))
+  defaultContigs.foreach(Io.assertReadable)
   Io.assertCanWriteFile(output)
+
+  /** Little class to store the sequence metadata and reference sequence to output.
+    *
+    * The reference sequence to output is stored as a method, so we can lazily retrieve it and not incur large memory
+    * overhead.
+    *
+    * @param info the sequence metadata to output
+    * @param toSequence method that returns the reference sequence to output
+    */
+  private case class OutputSequence(info: SequenceMetadata, toSequence: () => ReferenceSequence) {
+    /** Writes the output sequence */
+    def write(writer: BufferedWriter, progress: ProgressLogger): Unit = {
+      val ref = toSequence()
+      writer.append('>').append(info.name).append('\n')
+      val bases = ref.getBases
+      var baseCounter = 0
+      forloop(from = 0, until = bases.length) { baseIdx =>
+        writer.write(bases(baseIdx))
+        progress.record(info.name, baseIdx + 1)
+        baseCounter += 1
+        if (baseCounter >= lineLength) {
+          writer.newLine()
+          baseCounter = 0
+        }
+      }
+      if (baseCounter > 0) writer.newLine()
+    }
+  }
 
   override def execute(): Unit = {
     val progress = ProgressLogger(logger, noun="bases", verb="written", unit=10e7.toInt)
     val dict     = SequenceDictionary(this.dict)
-    val refFile  = ReferenceSequenceFileFactory.getReferenceSequenceFile(input, true, true)
     val out      = Io.toWriter(output)
 
-    val srcContigs = refFile.getSequenceDictionary match {
-      case null =>
-        require(refFile.isIndexed,
-          "Reference sequence file must have a sequence dictionary or be indexed.  Try 'picard CreateSequenceDictionary' or 'samtools faidx <ref.fasta>'.")
-        new FastaSequenceIndex(ReferenceSequenceFileFactory.getFastaIndexFileName(this.input)) map(_.getContig)
-      case dict => dict.getSequences.map(_.getSequenceName)
+    val (srcDict, srcRefFile) = getDictAndFile(fasta=this.input)
+    val defaultDictAndRefFile = this.defaultContigs.map(fasta => getDictAndFile(fasta=fasta))
+
+    // Make sure the default FASTA and the input dict are the same
+    defaultDictAndRefFile.foreach { case (defaultDict, _) =>
+      require(dict.sameAs(defaultDict), "Input sequence dictionary mismatch and default FASTA mismatch")
     }
 
-    srcContigs.foreach { srcName =>
-      dict.get(srcName) match {
-        case None if skipMissing => logger.warning(s"Did not find contig $srcName in the list of original names.")
-        case None                => throw new IllegalStateException(s"Did not find contig $srcName in the list of original names.")
-        case Some(info)          =>
-          val ref = refFile.getSequence(srcName)
-          out.append('>').append(info.name).append('\n')
-          val bases = ref.getBases
-          var baseCounter = 0
-          forloop(from = 0, until = bases.length) { baseIdx =>
-            out.write(bases(baseIdx))
-            progress.record(info.name, baseIdx + 1)
-            baseCounter += 1
-            if (baseCounter >= lineLength) {
-              out.newLine()
-              baseCounter = 0
-            }
-          }
-          if (baseCounter > 0) out.newLine()
+    // Get the contigs from the input FASTA to output.
+    // Note: we do not pre-load the sequences, as to preserve memory
+    val srcSequences: Seq[OutputSequence] = srcDict.iterator.flatMap { srcInfo =>
+      // Check if the sequence dictionary can rename this contig, and if not, either log or fail depending on --skip-missing
+      val dictInfo = dict.get(srcInfo.name) match {
+        case None if skipMissing => logger.warning(s"Did not find contig ${srcInfo.name} in the sequence dictionary."); None
+        case None                => throw new IllegalStateException(s"Did not find contig ${srcInfo.name} in the sequence dictionary.")
+        case Some(info)          => Some(info)
+      }
+      dictInfo.map(info => OutputSequence(info=info, toSequence=() => srcRefFile.getSequence(srcInfo.name)))
+    }.toSeq
+
+    // Get any default contigs that we need to add/append to the output
+    // Note: we do not pre-load the sequences, as to preserve memory
+    val defaultSequences: Seq[OutputSequence] = {
+      defaultDictAndRefFile match {
+        case None                      => Seq.empty
+        case Some((_, defaultRefFile)) =>
+          // Build the list of contig names that will be renamed (i.e. outputted)
+          val namesThatCanBeRenamed = srcSequences.map(_.info.name).toSet
+          // Keep the contigs in the input sequence dictionary that are not going be used to rename
+          val contigs = dict
+            .filterNot(info => namesThatCanBeRenamed.contains(info.name))
+            .map(info => OutputSequence(info=info, toSequence=() => defaultRefFile.getSequence(info.name)))
+            .toSeq
+          logger.info(s"Will add/append ${contigs.length} contigs to the output.")
+          contigs
       }
     }
+
+    // Order the contigs based on if we want to sort by the input sequence dictionary or not
+    val sequences: Seq[OutputSequence] = {
+      if (sort) {
+        logger.info("Sorting the contigs using the input sequence dictionary")
+        (srcSequences ++ defaultSequences).sortBy(_.info.index)
+      }
+      else {
+        logger.info("Sorting the contigs using the input FASTA")
+        srcSequences ++ defaultSequences
+      }
+    }
+
+    // Write them out
+    sequences.foreach(_.write(writer=out, progress=progress))
+    logger.info(s"Wrote ${sequences.length} contigs.")
+
+    srcRefFile.safelyClose()
+    defaultDictAndRefFile.foreach(_._2.safelyClose())
     out.close()
   }
 
+
+  /** Gets the sequence dictionary and referene sequence file for a given FASTA */
+  private def getDictAndFile(fasta: PathToFasta): (SequenceDictionary, ReferenceSequenceFile) = {
+    val refFile = ReferenceSequenceFileFactory.getReferenceSequenceFile(fasta, true, true)
+    val dict    = Option(refFile.getSequenceDictionary) match {
+      case Some(dict) => dict.fromSam
+      case None       =>
+        require(refFile.isIndexed,
+          s"Reference sequence file must have a sequence dictionary or be indexed." +
+          s"  Try 'picard CreateSequenceDictionary' or 'samtools faidx <ref.fasta>'. $fasta"
+        )
+        // Build a very basic sequence dictionary from the fasta index
+        val infos = new FastaSequenceIndex(ReferenceSequenceFileFactory
+          .getFastaIndexFileName(this.input))
+          .map { entry =>
+            SequenceMetadata(name=entry.getContig, length=entry.getSize.toInt, index=entry.getSequenceIndex)
+          }.toSeq
+        SequenceDictionary(infos:_*)
+    }
+    (dict, refFile)
+  }
 }

--- a/src/main/scala/com/fulcrumgenomics/fasta/UpdateFastaContigNames.scala
+++ b/src/main/scala/com/fulcrumgenomics/fasta/UpdateFastaContigNames.scala
@@ -79,7 +79,7 @@ class UpdateFastaContigNames
     /** Writes the output sequence */
     def write(writer: BufferedWriter, progress: ProgressLogger): Unit = {
       val ref = sequence
-      writer.write(s">${ref.getName}\n")
+      writer.write(s">${info.name}\n")
       ref.getBaseString.toIterable.grouped(80).foreach { line =>
         writer.write(line.unwrap)
         writer.write('\n')

--- a/src/main/scala/com/fulcrumgenomics/fasta/UpdateFastaContigNames.scala
+++ b/src/main/scala/com/fulcrumgenomics/fasta/UpdateFastaContigNames.scala
@@ -80,8 +80,10 @@ class UpdateFastaContigNames
     def write(writer: BufferedWriter, progress: ProgressLogger): Unit = {
       val ref = sequence
       writer.write(s">${info.name}\n")
-      ref.getBaseString.toIterable.grouped(80).foreach { line =>
-        writer.write(line.unwrap)
+      ref.getBaseString.toIterable.grouped(80).foreach { line: Seq[Char] =>
+        forloop(from = 0, until = line.length) { i =>
+          writer.write(line(i))
+        }
         writer.write('\n')
       }
     }

--- a/src/main/scala/com/fulcrumgenomics/fasta/UpdateFastaContigNames.scala
+++ b/src/main/scala/com/fulcrumgenomics/fasta/UpdateFastaContigNames.scala
@@ -80,12 +80,18 @@ class UpdateFastaContigNames
     def write(writer: BufferedWriter, progress: ProgressLogger): Unit = {
       val ref = sequence
       writer.write(s">${info.name}\n")
-      ref.getBaseString.toIterable.grouped(80).foreach { line: Seq[Char] =>
-        forloop(from = 0, until = line.length) { i =>
-          writer.write(line(i))
+      val bases = ref.getBases
+      var baseCounter = 0
+      forloop(from = 0, until = bases.length) { baseIdx =>
+        writer.write(bases(baseIdx))
+        progress.record(info.name, baseIdx + 1)
+        baseCounter += 1
+        if (baseCounter >= lineLength) {
+          writer.newLine()
+          baseCounter = 0
         }
-        writer.write('\n')
       }
+      if (baseCounter > 0) writer.newLine()
     }
   }
 

--- a/src/test/scala/com/fulcrumgenomics/fasta/UpdateFastaContigNamesTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/fasta/UpdateFastaContigNamesTest.scala
@@ -134,7 +134,7 @@ import scala.collection.mutable.ListBuffer
       input          = input,
       dict           = dict,
       output         = output,
-      sort           = true,
+      sortByDict     = true,
       defaultContigs = Some(default)
     )
     executeFgbioTool(tool)

--- a/src/test/scala/com/fulcrumgenomics/fasta/UpdateFastaContigNamesTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/fasta/UpdateFastaContigNamesTest.scala
@@ -26,7 +26,7 @@ package com.fulcrumgenomics.fasta
 
 import com.fulcrumgenomics.FgBioDef.{PathToFasta, PathToSequenceDictionary}
 import com.fulcrumgenomics.commons.io.PathUtil
-import com.fulcrumgenomics.testing.UnitSpec
+import com.fulcrumgenomics.testing.{ReferenceSetBuilder, UnitSpec}
 
 import scala.collection.mutable.ListBuffer
 
@@ -97,5 +97,57 @@ import scala.collection.mutable.ListBuffer
     executeFgbioTool(tool)
 
     getNames(output) should contain theSameElementsInOrderAs Seq("1", "2")
+  }
+
+  it should "add default contigs and sort" in {
+    val output = makeTempFile("test.", ".fasta")
+    // two contigs that will be remapped
+    val input = {
+      val builder = new ReferenceSetBuilder()
+      builder.add("chr2").add("GGGGG", 1000)
+      builder.add("chr4").add("TTTTT", 1000)
+      builder.toTempFile()
+    }
+    val default = {
+      val builder = new ReferenceSetBuilder()
+      builder.add("1").add("AAAAA", 1000)
+      builder.add("2").add("CCCCC", 1000)
+      builder.add("3").add("AAAAA", 1000)
+      builder.add("4").add("CCCCC", 1000)
+      builder.add("5").add("AAAAA", 1000)
+      builder.toTempFile()
+    }
+    val dict = {
+      val path = makeTempFile("test.", "in.dict")
+      val infos = ListBuffer[SequenceMetadata](
+        SequenceMetadata(name="1", length=5000, aliases=Seq("chr1")),
+        SequenceMetadata(name="2", length=5000, aliases=Seq("chr2")),
+        SequenceMetadata(name="3", length=5000, aliases=Seq("chr3")),
+        SequenceMetadata(name="4", length=5000, aliases=Seq("chr4")),
+        SequenceMetadata(name="5", length=5000, aliases=Seq("chr5")),
+      )
+      SequenceDictionary(infos.toSeq:_*).write(path)
+      path
+    }
+
+    val tool = new UpdateFastaContigNames(
+      input          = input,
+      dict           = dict,
+      output         = output,
+      sort           = true,
+      defaultContigs = Some(default)
+    )
+    executeFgbioTool(tool)
+
+    val names = ReferenceSequenceIterator(path=output).map(_.getName)
+    names.toSeq should contain theSameElementsInOrderAs Seq("1", "2", "3", "4", "5")
+
+    val refSeqMap = ReferenceSequenceIterator(path=output).map(seq => seq.getName -> seq.getBaseString).toMap
+
+    refSeqMap("1") shouldBe ("AAAAA" * 1000) // defaulted
+    refSeqMap("2") shouldBe ("GGGGG" * 1000) // has a default, but from the input FASTA
+    refSeqMap("3") shouldBe ("AAAAA" * 1000) // defaulted
+    refSeqMap("4") shouldBe ("TTTTT" * 1000) // has a default, but from the input FASTA
+    refSeqMap("5") shouldBe ("AAAAA" * 1000) // defaulted
   }
 }


### PR DESCRIPTION
The `--sort` option will output the contigs in the sequence dictionary
order.

The `--default-contigs` option will add missing contigs in the input
FASTA to the output FASTA.  This is useful when renaming a FASTA where
some contigs are missing (ex. alt scaffolds in Ensembl vs. UCSC).

---

I have a case where the Ensembl provided VCF needs to have it's contigs renamed, and have missing contigs added from a secondary FASTA.