### PR TITLE
Add the option to sort the output in UpdateDelimitedFileContigNames

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/util/UpdateDelimitedFileContigNames.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/UpdateDelimitedFileContigNames.scala
@@ -211,8 +211,7 @@ object UpdateDelimitedFileContigNames {
     def encode(a: LineInfo): Array[Byte] = f"${a.key.lineno}$delimiter${a.line}".getBytes
     override def decode(bs: Array[Byte], start: Int, length: Int): LineInfo = {
       val line = new String(bs, start, length)
-      val numFields = StringUtil.split(line=line, delimiter=delimiter, arr=fields, concatenateRemaining=true)
-      require(numFields >= maxColumn + 1, f"Too few columns '$numFields'")
+      StringUtil.split(line=line, delimiter=delimiter, arr=fields, concatenateRemaining=true)
       val lineno   = fields(0).toInt
       val contig   = fields(contigColumnIndex + 1)
       val position = if (positionColumnIndex >= 0) fields(positionColumnIndex + 1).toInt else 0

--- a/src/test/scala/com/fulcrumgenomics/util/UpdateDelimitedFileContigNamesTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/util/UpdateDelimitedFileContigNamesTest.scala
@@ -58,7 +58,8 @@ class UpdateDelimitedFileContigNamesTest extends UnitSpec {
                       skipMissing: Boolean = false,
                       sortOrder: SortOrder = SortOrder.Unsorted,
                       contig: Option[Int] = None,
-                      position: Option[Int] = None): Unit = {
+                      position: Option[Int] = None,
+                      maxObjectsInRam: Int = 1e6.toInt): Unit = {
     val input    = makeTempFile("test.", "in.txt")
     val output   = makeTempFile("test.", "out.txt")
 
@@ -75,7 +76,8 @@ class UpdateDelimitedFileContigNamesTest extends UnitSpec {
       skipMissing         = skipMissing,
       sortOrder           = sortOrder,
       contig              = contig,
-      position            = position
+      position            = position,
+      maxObjectsInRam     = maxObjectsInRam
     )
 
     executeFgbioTool(tool)
@@ -278,6 +280,20 @@ class UpdateDelimitedFileContigNamesTest extends UnitSpec {
       sortOrder   = SortOrder.ByCoordinate,
       contig      = Some(2),
       position    = Some(1)
+    )
+  }
+
+  it should "spill to disk when sorting" in {
+    val actual   = Seq.range(0, 1000).map { i => f"1-old,0,2-old,$i" }
+    val expected = Seq.range(0, 1000).map { i => f"1-new,0,2-new,$i" }
+    runTest(
+      delimiter       = ',',
+      columns         = Seq(0, 2),
+      actual          = actual,
+      expected        = expected,
+      sortOrder       = SortOrder.ByCoordinate,
+      position        = Some(1),
+      maxObjectsInRam = 10
     )
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/util/UpdateDelimitedFileContigNamesTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/util/UpdateDelimitedFileContigNamesTest.scala
@@ -55,7 +55,10 @@ class UpdateDelimitedFileContigNamesTest extends UnitSpec {
                       expected: Seq[String],
                       outputFirstNumLines: Int = 0,
                       comment: String = "#",
-                      skipMissing: Boolean = false): Unit = {
+                      skipMissing: Boolean = false,
+                      sortOrder: SortOrder = SortOrder.Unsorted,
+                      contig: Option[Int] = None,
+                      position: Option[Int] = None): Unit = {
     val input    = makeTempFile("test.", "in.txt")
     val output   = makeTempFile("test.", "out.txt")
 
@@ -69,7 +72,10 @@ class UpdateDelimitedFileContigNamesTest extends UnitSpec {
       comment             = comment,
       output              = output,
       outputFirstNumLines = outputFirstNumLines,
-      skipMissing         = skipMissing
+      skipMissing         = skipMissing,
+      sortOrder           = sortOrder,
+      contig              = contig,
+      position            = position
     )
 
     executeFgbioTool(tool)
@@ -174,6 +180,104 @@ class UpdateDelimitedFileContigNamesTest extends UnitSpec {
       actual      = actual,
       expected    = expected,
       skipMissing = true
+    )
+  }
+
+  it should "sort by contig name only" in {
+    val actual = Seq(
+      "1-old,0",
+      "3-old,4",
+      "3-old,3",
+      "2-old,2"
+    )
+    val expected = Seq(
+      "1-new,0",
+      "2-new,2",
+      "3-new,4",
+      "3-new,3"
+    )
+    // --contig not specified
+    runTest(
+      delimiter   = ',',
+      columns     = Seq(0),
+      actual      = actual,
+      expected    = expected,
+      sortOrder   = SortOrder.ByContigOnly
+    )
+    // --contig specified
+    runTest(
+      delimiter   = ',',
+      columns     = Seq(0),
+      actual      = actual,
+      expected    = expected,
+      sortOrder   = SortOrder.ByContigOnly,
+      contig      = Some(0)
+    )
+  }
+
+  it should "sort by coordinate" in {
+    val actual = Seq(
+      "1-old,0,2-old,1",
+      "3-old,4,2-old,2",
+      "3-old,1,2-old,3",
+      "2-old,2,2-old,4",
+      "2-old,2,2-old,5"
+    )
+    // sorts by col0, col1, then line number (col3)s
+    val expectedCol0 = Seq(
+      "1-new,0,2-new,1",
+      "2-new,2,2-new,4",
+      "2-new,2,2-new,5",
+      "3-new,1,2-new,3",
+      "3-new,4,2-new,2"
+    )
+    // col2 has the same value for all, so sorting by position in col1
+    val expectedCol2 = Seq(
+      "1-new,0,2-new,1",
+      "3-new,1,2-new,3",
+      "2-new,2,2-new,4",
+      "2-new,2,2-new,5",
+      "3-new,4,2-new,2"
+    )
+    // --contig is not specified, so defaults to column 0
+    runTest(
+      delimiter   = ',',
+      columns     = Seq(0, 2),
+      actual      = actual,
+      expected    = expectedCol0,
+      sortOrder   = SortOrder.ByCoordinate,
+      position    = Some(1)
+    )
+    // --contig is specified as column 0
+    runTest(
+      delimiter   = ',',
+      columns     = Seq(0, 2),
+      actual      = actual,
+      expected    = expectedCol0,
+      sortOrder   = SortOrder.ByCoordinate,
+      contig      = Some(0),
+      position    = Some(1)
+    )
+    // --contig is not specified, so defaults to column 0
+    runTest(
+      delimiter   = ',',
+      columns     = Seq(0, 2),
+      actual      = actual,
+      expected    = expectedCol2,
+      sortOrder   = SortOrder.ByCoordinate,
+      contig      = Some(2),
+      position    = Some(1)
+    )
+    // tests that when all values are the same, we sort by line number
+    val clones = Seq.range(0, 100).map(_ => "1-new,0,2-new,1")
+    runTest(
+      delimiter   = ',',
+      columns     = Seq(0, 2),
+      actual      = clones,
+      expected    = clones,
+      sortOrder   = SortOrder.ByCoordinate,
+      contig      = Some(2),
+      position    = Some(1)
     )
   }
 }


### PR DESCRIPTION
The --sort-order option controls if the output should be sorted by:
1. Contig only - preserves the input order for lines with the same contig
2. Coordinate - preserves the input order for line with the same coordiante