### PR TITLE
[feature] add an option do not collapse substitution types

### DIFF
--- a/src/main/resources/com/fulcrumgenomics/bam/ErrorRateByReadPosition.R
+++ b/src/main/resources/com/fulcrumgenomics/bam/ErrorRateByReadPosition.R
@@ -48,7 +48,7 @@ error_rate_plot = ggplot(data) + aes(x=position) +
   geom_line(aes(y=c_to_a_error_rate, color="C>A")) +
   geom_line(aes(y=c_to_g_error_rate, color="C>G")) +
   geom_line(aes(y=c_to_t_error_rate, color="C>T"))
-if ("collapsed" %in% names(data) && data$collapsed[1] == "true") {
+if ("collapsed" %in% names(data) && data$collapsed[1] == "false") {
   error_rate_plot = error_rate_plot +
     geom_line(aes(y=g_to_a_error_rate, color="G>A")) +
     geom_line(aes(y=g_to_c_error_rate, color="G>C")) +

--- a/src/main/resources/com/fulcrumgenomics/bam/ErrorRateByReadPosition.R
+++ b/src/main/resources/com/fulcrumgenomics/bam/ErrorRateByReadPosition.R
@@ -48,7 +48,7 @@ error_rate_plot = ggplot(data) + aes(x=position) +
   geom_line(aes(y=c_to_a_error_rate, color="C>A")) +
   geom_line(aes(y=c_to_g_error_rate, color="C>G")) +
   geom_line(aes(y=c_to_t_error_rate, color="C>T"))
-if ("collapsed" %in% names(data) && data$collapsed[1] == "false") {
+if ("collapsed" %in% names(data) && data$collapsed[[1]] == "false") {
   error_rate_plot = error_rate_plot +
     geom_line(aes(y=g_to_a_error_rate, color="G>A")) +
     geom_line(aes(y=g_to_c_error_rate, color="G>C")) +

--- a/src/main/resources/com/fulcrumgenomics/bam/ErrorRateByReadPosition.R
+++ b/src/main/resources/com/fulcrumgenomics/bam/ErrorRateByReadPosition.R
@@ -39,18 +39,30 @@ ggplot(data) + aes(x=position) +
   labs(x="Position in Read", y="Error Rate", title=paste(name, "-", "Error Rate by Position In Read")) +
   theme(plot.title = element_text(hjust = 0.5))
 
-ggplot(data) + aes(x=position) +
+# The error rate plot is conditional on the presence and value of the collapsed column, which is not present in previous
+# versions of fgbio
+error_rate_plot = ggplot(data) + aes(x=position) +
   geom_line(aes(y=a_to_c_error_rate, color="A>C")) +
   geom_line(aes(y=a_to_g_error_rate, color="A>G")) +
   geom_line(aes(y=a_to_t_error_rate, color="A>T")) +
   geom_line(aes(y=c_to_a_error_rate, color="C>A")) +
   geom_line(aes(y=c_to_g_error_rate, color="C>G")) +
-  geom_line(aes(y=c_to_t_error_rate, color="C>T")) +
+  geom_line(aes(y=c_to_t_error_rate, color="C>T"))
+if ("collapsed" %in% names(data) && data$collapsed[1] == "true") {
+  error_rate_plot = error_rate_plot +
+    geom_line(aes(y=g_to_a_error_rate, color="G>A")) +
+    geom_line(aes(y=g_to_c_error_rate, color="G>C")) +
+    geom_line(aes(y=g_to_t_error_rate, color="G>T")) +
+    geom_line(aes(y=t_to_a_error_rate, color="T>A")) +
+    geom_line(aes(y=t_to_c_error_rate, color="T>C")) +
+    geom_line(aes(y=t_to_g_error_rate, color="T>G"))
+}
+error_rate_plot = error_rate_plot +
   facet_wrap("read_number") +
   scale_y_sqrt() + 
   labs(x="Position in Read", y="Error Rate", title=paste(name, "-", "Error Rate by Position in Read and Type")) +
   theme(plot.title = element_text(hjust = 0.5))
-
+print(error_rate_plot)
 
 # The cumulative plot is more awkward because cumsum will do the wrong thing if we use ggplots aes(color=read_number),
 # the R2 numbers will include the total at the end of R1!!  So instead we plot each read number separately!

--- a/src/main/scala/com/fulcrumgenomics/bam/ErrorRateByReadPosition.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ErrorRateByReadPosition.scala
@@ -31,11 +31,11 @@ import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.bam.api.SamSource
 import com.fulcrumgenomics.cmdline.{ClpGroups, FgBioTool}
 import com.fulcrumgenomics.commons.io.{Io, PathUtil}
-import com.fulcrumgenomics.commons.util.LazyLogging
+import com.fulcrumgenomics.commons.util.{LazyLogging, SimpleCounter}
 import com.fulcrumgenomics.fasta.SequenceDictionary
 import com.fulcrumgenomics.sopt._
 import com.fulcrumgenomics.util.Metric.Count
-import com.fulcrumgenomics.util.{Metric, ProgressLogger, Rscript}
+import com.fulcrumgenomics.util.{Metric, ProgressLogger, Rscript, Sequences}
 import com.fulcrumgenomics.vcf.{ByIntervalListVariantContextIterator, VariantMask}
 import htsjdk.samtools.SAMRecord
 import htsjdk.samtools.filter.{DuplicateReadFilter, FailsVendorReadQualityFilter, SamRecordFilter, SecondaryOrSupplementaryFilter}
@@ -88,7 +88,11 @@ class ErrorRateByReadPosition
   @arg(flag='l', doc="Optional list of intervals to restrict analysis to.") val intervals: Option[PathToIntervals] = None,
   @arg(flag='d', doc="Include duplicate reads, otherwise ignore.") val includeDuplicates: Boolean = false,
   @arg(flag='m', doc="The minimum mapping quality for a read to be included.") val minMappingQuality: Int = 20,
-  @arg(flag='q', doc="The minimum base quality for a base to be included.") val minBaseQuality: Int = 0
+  @arg(flag='q', doc="The minimum base quality for a base to be included.") val minBaseQuality: Int = 0,
+  @arg(doc="Collapse substitution types based on the reference or expected base, with only six substitution" +
+    " types being reported: `A>C`, `A>G`, `A>T`, `C>A`, `C>G` and `C>T`.For example, `T>G` is grouped in with `A>C`." +
+    " Otherwise, all possible substitution types will be reported."
+  ) val collapse: Boolean = true
 ) extends FgBioTool with LazyLogging {
 
   private val ScriptPath = "com/fulcrumgenomics/bam/ErrorRateByReadPosition.R"
@@ -140,9 +144,9 @@ class ErrorRateByReadPosition
           val readBase = SequenceUtil.upperCase(rec.getReadBase)
           val readNum  = readNumber(rec.getRecord)
           val cycle    = if (rec.getRecord.getReadNegativeStrandFlag) rec.getRecord.getReadLength - rec.getOffset else rec.getOffset + 1
-          val counter  = counters(readNum).getOrElseUpdate(cycle, new ObsCounter(readNum, cycle))
+          val counter  = counters(readNum).getOrElseUpdate(cycle, new ObsCounter(readNum, cycle, collapse))
 
-          if (refBase == 'A' || refBase == 'C') counter.count(refBase.toChar, readBase.toChar)
+          if (!collapse || refBase == 'A' || refBase == 'C') counter.count(refBase.toChar, readBase.toChar)
           else counter.count(SequenceUtil.complement(refBase).toChar, SequenceUtil.complement(readBase).toChar)
         }
       }
@@ -153,7 +157,7 @@ class ErrorRateByReadPosition
 
     // Ensure that all the maps have values up to the max
     for ((counter, readNum) <- counters.filter(_.nonEmpty).zipWithIndex; cycle <- 1 to counter.keys.max) {
-      counter.getOrElseUpdate(cycle, new ObsCounter(readNum, cycle))
+      counter.getOrElseUpdate(cycle, new ObsCounter(readNum, cycle, collapse))
     }
 
     counters.flatMap(c => c.values.map(_.toMetric)).sortBy(m => (m.read_number, m.position))
@@ -197,48 +201,62 @@ class ErrorRateByReadPosition
   def readNumber(rec: SAMRecord): Int = if (!rec.getReadPairedFlag) 0 else if (rec.getFirstOfPairFlag) 1 else 2
 }
 
-private class ObsCounter(readNumber: Int, position: Int) {
-  var a_ref_obs: Long  = 0
-  var c_ref_obs: Long  = 0
-  var a_to_c_obs: Long = 0
-  var a_to_g_obs: Long = 0
-  var a_to_t_obs: Long = 0
-  var c_to_a_obs: Long = 0
-  var c_to_g_obs: Long = 0
-  var c_to_t_obs: Long = 0
+/** Counter for substitutions for a given read number and position in that read.
+  *
+  * @param readNumber the read number
+  * @param position the position in the read
+  * @param collapse true to collapse substitution types, false otherwise
+  */
+private class ObsCounter(readNumber: Int, position: Int, collapse: Boolean) extends SimpleCounter[(Char, Char)] {
+  private val Dna: Seq[Char] = IndexedSeq('A', 'C', 'G', 'T')
 
-  /** Increments the appropriate counter. */
-  def count(ref: Char, read: Char): Unit = (ref, read) match {
-    case ('A', 'A') => a_ref_obs  += 1
-    case ('A', 'C') => a_to_c_obs += 1
-    case ('A', 'G') => a_to_g_obs += 1
-    case ('A', 'T') => a_to_t_obs += 1
-    case ('C', 'A') => c_to_a_obs += 1
-    case ('C', 'C') => c_ref_obs  += 1
-    case ('C', 'G') => c_to_g_obs += 1
-    case ('C', 'T') => c_to_t_obs += 1
-    case _          => unreachable("Should never be invoked with a case other than the above.")
+  @inline def count(ref: Char, read: Char): Unit   = this.count((ref, read))
+  @inline def countOf(ref: Char, read: Char): Long = this.countOf((ref, read))
+
+  @inline private def total(ref: Char): Long   = Dna.map(read => countOf(ref, read)).sum
+  @inline private def totalRef(ref: Char): Long = countOf(ref, ref)
+
+  @inline private def errorRate(ref: Char, read: Char): Double = {
+    val totalRef = this.total(ref)
+    if (totalRef == 0) 0 else countOf(ref=ref, read=read) / totalRef.toDouble
   }
 
+  @inline private def getErrorRate(ref: Char, read: Char): Option[Double] = {
+    if (!collapse || ref == 'A' || ref == 'C') Some(errorRate(ref=ref, read=read))
+    else None
+  }
 
   def toMetric: ErrorRateByReadPositionMetric = {
-    val totalA = a_ref_obs + a_to_c_obs + a_to_g_obs + a_to_t_obs
-    val totalC = c_ref_obs + c_to_a_obs + c_to_g_obs + c_to_t_obs
-    val total  = totalA + totalC
-    val errors = total - a_ref_obs - c_ref_obs
+    // Double check that we have zero counts for G>X and T>X when we collapse substitution types
+    if (collapse) {
+      Seq('G', 'T').foreach { ref =>
+        Dna.foreach { read =>
+          require(this.countOf(ref=ref, read=read) == 0,
+            s"Bug: collapse is true but found a non-zero count for $ref>$read")
+        }
+      }
+    }
 
+    val total  = Dna.map(ref => this.total(ref=ref)).sum
+    val errors = total - Dna.map(ref => this.totalRef(ref=ref)).sum
     new ErrorRateByReadPositionMetric(
       read_number = readNumber,
       position    = position,
       bases_total = total,
       errors      = errors,
       error_rate  = if (total == 0) 0 else errors / total.toDouble,
-      a_to_c_error_rate = if (totalA == 0) 0 else a_to_c_obs / totalA.toDouble,
-      a_to_g_error_rate = if (totalA == 0) 0 else a_to_g_obs / totalA.toDouble,
-      a_to_t_error_rate = if (totalA == 0) 0 else a_to_t_obs / totalA.toDouble,
-      c_to_a_error_rate = if (totalC == 0) 0 else c_to_a_obs / totalC.toDouble,
-      c_to_g_error_rate = if (totalC == 0) 0 else c_to_g_obs / totalC.toDouble,
-      c_to_t_error_rate = if (totalC == 0) 0 else c_to_t_obs / totalC.toDouble
+      a_to_c_error_rate = errorRate('A', 'C'),
+      a_to_g_error_rate = errorRate('A', 'G'),
+      a_to_t_error_rate = errorRate('A', 'T'),
+      c_to_a_error_rate = errorRate('C', 'A'),
+      c_to_g_error_rate = errorRate('C', 'G'),
+      c_to_t_error_rate = errorRate('C', 'T'),
+      g_to_a_error_rate = getErrorRate('G', 'A'),
+      g_to_c_error_rate = getErrorRate('G', 'C'),
+      g_to_t_error_rate = getErrorRate('G', 'T'),
+      t_to_a_error_rate = getErrorRate('T', 'A'),
+      t_to_c_error_rate = getErrorRate('T', 'C'),
+      t_to_g_error_rate = getErrorRate('T', 'G'),
     )
   }
 }
@@ -251,21 +269,28 @@ object ErrorRateByReadPositionMetric {
 /**
   * Metrics produced by `ErrorRateByReadPosition` describing the number of base observations and
   * substitution errors at each position within each sequencing read.  Error rates are given for
-  * the overall substitution error rate and also for each kind of substitution separately. Instead
-  * of reporting 12 substitution rates, 6 are reported where complementary substitutions are grouped
-  * together, e.g. `T>G` substitutions are reported as `A>C`.
+  * the overall substitution error rate and also for each kind of substitution separately.
+  *
+  * If `collapsed` is `true`, then complementary substitutions are grouped together into the first 6 error rates.
+  * e.g. `T>G` substitutions are reported as `A>C`.  Otherwise, all 12 substitution rates are reported.
   *
   * @param read_number The read number (0 for fragments, 1 for first of pair, 2 for second of pair).
   * @param position The position or cycle within the read (1-based).
   * @param bases_total The total number of bases observed at this position.
   * @param errors The total number of errors or non-reference basecalls observed at this position.
   * @param error_rate The overall error rate at position.
-  * @param a_to_c_error_rate The rate of `A>C` (and `T>G`) errors at the position.
-  * @param a_to_g_error_rate The rate of `A>G` (and `T>C`) errors at the position.
-  * @param a_to_t_error_rate The rate of `A>T` (and `T>A`) errors at the position.
-  * @param c_to_a_error_rate The rate of `C>A` (and `G>T`) errors at the position.
-  * @param c_to_g_error_rate The rate of `C>G` (and `G>C`) errors at the position.
-  * @param c_to_t_error_rate The rate of `C>T` (and `G>A`) errors at the position.
+  * @param a_to_c_error_rate The rate of `A>C` (and `T>G` when collapsed) errors at the position.
+  * @param a_to_g_error_rate The rate of `A>G` (and `T>C` when collapsed) errors at the position.
+  * @param a_to_t_error_rate The rate of `A>T` (and `T>A` when collapsed) errors at the position.
+  * @param c_to_a_error_rate The rate of `C>A` (and `G>T` when collapsed) errors at the position.
+  * @param c_to_g_error_rate The rate of `C>G` (and `G>C` when collapsed) errors at the position.
+  * @param c_to_t_error_rate The rate of `C>T` (and `G>A` when collapsed) errors at the position.
+  * @param g_to_a_error_rate The rate of `G>A` errors at the position.
+  * @param g_to_c_error_rate The rate of `G>C` errors at the position.
+  * @param g_to_t_error_rate The rate of `G>T` errors at the position.
+  * @param t_to_a_error_rate The rate of `T>A` errors at the position.
+  * @param t_to_c_error_rate The rate of `T>C` errors at the position.
+  * @param t_to_g_error_rate The rate of `T>T` errors at the position.
   */
 case class ErrorRateByReadPositionMetric
 ( read_number: Int,
@@ -278,5 +303,12 @@ case class ErrorRateByReadPositionMetric
   a_to_t_error_rate: Double,
   c_to_a_error_rate: Double,
   c_to_g_error_rate: Double,
-  c_to_t_error_rate: Double
+  c_to_t_error_rate: Double,
+  g_to_a_error_rate: Option[Double] = None,
+  g_to_c_error_rate: Option[Double] = None,
+  g_to_t_error_rate: Option[Double] = None,
+  t_to_a_error_rate: Option[Double] = None,
+  t_to_c_error_rate: Option[Double] = None,
+  t_to_g_error_rate: Option[Double] = None,
+  collapsed: Boolean = true
 ) extends Metric

--- a/src/main/scala/com/fulcrumgenomics/bam/ErrorRateByReadPosition.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ErrorRateByReadPosition.scala
@@ -43,6 +43,7 @@ import htsjdk.samtools.reference.ReferenceSequenceFileWalker
 import htsjdk.samtools.util.{IntervalList, SamLocusIterator, SequenceUtil}
 import htsjdk.variant.vcf.VCFFileReader
 
+import scala.annotation.switch
 import scala.collection.mutable
 import scala.util.Failure
 
@@ -207,13 +208,26 @@ class ErrorRateByReadPosition
   * @param position the position in the read
   * @param collapse true to collapse substitution types, false otherwise
   */
-private class ObsCounter(readNumber: Int, position: Int, collapse: Boolean) extends SimpleCounter[(Char, Char)] {
-  private val Dna: Seq[Char] = IndexedSeq('A', 'C', 'G', 'T')
+private class ObsCounter(readNumber: Int, position: Int, collapse: Boolean) {
+  private val Dna: Seq[Char]             = IndexedSeq('A', 'C', 'G', 'T')
+  private val counts: Array[Array[Long]] = new Array[Long](4).map(_ => new Array[Long](4))
 
-  @inline def count(ref: Char, read: Char): Unit   = this.count((ref, read))
-  @inline def countOf(ref: Char, read: Char): Long = this.countOf((ref, read))
+  /** Maps A/C/G/T to an index 0-3 and throws an exception for any other base. */
+  @inline private def index(base: Char): Int = (base: @switch) match {
+    case 'A' => 0
+    case 'C' => 1
+    case 'G' => 2
+    case 'T' => 3
+    case _   => throw new IllegalArgumentException(s"Invalid base: $base")
+  }
 
-  @inline private def total(ref: Char): Long   = Dna.map(read => countOf(ref, read)).sum
+  @inline def count(ref: Char, read: Char): Unit =
+    try { this.counts(index(ref))(index(read)) += 1 } catch { case _: IllegalArgumentException => () }
+
+  @inline def countOf(ref: Char, read: Char): Long =
+    try { this.counts(index(ref))(index(read)) } catch { case _: IllegalArgumentException => 0 }
+
+  @inline private def total(ref: Char): Long    = this.counts(index(ref)).sum
   @inline private def totalRef(ref: Char): Long = countOf(ref, ref)
 
   @inline private def errorRate(ref: Char, read: Char): Double = {

--- a/src/main/scala/com/fulcrumgenomics/bam/ErrorRateByReadPosition.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ErrorRateByReadPosition.scala
@@ -271,6 +271,7 @@ private class ObsCounter(readNumber: Int, position: Int, collapse: Boolean) {
       t_to_a_error_rate = getErrorRate('T', 'A'),
       t_to_c_error_rate = getErrorRate('T', 'C'),
       t_to_g_error_rate = getErrorRate('T', 'G'),
+      collapsed         = collapse
     )
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/bam/ErrorRateByReadPositionTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/ErrorRateByReadPositionTest.scala
@@ -34,11 +34,29 @@ import com.fulcrumgenomics.fasta.SequenceDictionary
 import com.fulcrumgenomics.testing.{ReferenceSetBuilder, SamBuilder, UnitSpec, VariantContextSetBuilder}
 import com.fulcrumgenomics.util.{Metric, Rscript}
 import htsjdk.samtools.util.{Interval, IntervalList}
+import com.fulcrumgenomics.util.Metric.Count
+import org.scalatest.OptionValues
+
+
+// Old-style metrics that did not include the optional non-collapsed substitution types
+private case class DeprecatedErrorRateByReadPositionMetric
+( read_number: Int,
+  position: Int,
+  bases_total: Count,
+  errors: Count,
+  error_rate: Double,
+  a_to_c_error_rate: Double,
+  a_to_g_error_rate: Double,
+  a_to_t_error_rate: Double,
+  c_to_a_error_rate: Double,
+  c_to_g_error_rate: Double,
+  c_to_t_error_rate: Double
+) extends Metric
 
 /**
   * Tests for ErrorRateByReadPosition.
   */
-class ErrorRateByReadPositionTest extends UnitSpec {
+class ErrorRateByReadPositionTest extends UnitSpec with OptionValues {
   /////////////////////////////////////////////////////////////////////////////
   // Make a reference and a set of variants for use in the tests
   /////////////////////////////////////////////////////////////////////////////
@@ -66,6 +84,7 @@ class ErrorRateByReadPositionTest extends UnitSpec {
   private def outputAndPrefix: (Path, Path) = {
     val out = makeTempFile("ErrorRateByReadPositionTest.", ErrorRateByReadPositionMetric.FileExtension)
     val pre = PathUtil.pathTo(out.toString.replace(ErrorRateByReadPositionMetric.FileExtension, ""))
+    pre.toFile.deleteOnExit()
     (out, pre)
   }
 
@@ -162,7 +181,7 @@ class ErrorRateByReadPositionTest extends UnitSpec {
     builder.addFrag(contig=3, start=490, bases="AGGGGGGGGGAGGGGGGGGG")
     builder.addFrag(contig=4, start=490, bases="CTTTTTTTTTTTTTTTTTTT")
 
-    val (out, pre) = outputAndPrefix
+    val (_, pre) = outputAndPrefix
     val metrics = new ErrorRateByReadPosition(input=builder.toTempFile(), output=Some(pre), ref=ref, variants=Some(vcf)).computeMetrics()
     metrics.find(_.position == 1).get.error_rate shouldBe 1.0
     metrics.find(_.position == 11).get.error_rate shouldBe 0.0
@@ -172,24 +191,57 @@ class ErrorRateByReadPositionTest extends UnitSpec {
     }
   }
 
-  it should "run end to end and maybe generate a PDF" in {
+  it should "only collapse substitution types when --collapse is false" in {
     val builder = newSamBuilder
-    1 to 99 foreach {i => builder.addPair(contig=1, start1=i, start2=i+50, bases1="A"*20, bases2="A"*20) }
-    builder.addPair(contig=1, start1=100, start2=200, bases1="AAAAAAAAATTAAAAAAAAA", bases2="AAAAAAAAATTAAAAAAAAA")
+    builder.addFrag(contig=1, start=490, bases="GAAAAAAAAAGAAAAAAAAA")
+    builder.addFrag(contig=2, start=490, bases="TCCCCCCCCCTCCCCCCCCC")
+    builder.addFrag(contig=3, start=490, bases="AGGGGGGGGGAGGGGGGGGG")
+    builder.addFrag(contig=4, start=490, bases="CTTTTTTTTTTTTTTTTTTT")
 
-    val (out, pre) = outputAndPrefix
-    new ErrorRateByReadPosition(input=builder.toTempFile(), output=Some(pre), ref=ref).execute()
-    val metrics = Metric.read[ErrorRateByReadPositionMetric](out)
-    metrics.size shouldBe 40
-    metrics.map(_.bases_total).sum shouldBe 4000
-    metrics.foreach { m =>
-      if (m.position == 10 || m.position == 11) m.error_rate shouldBe 0.01
-      else m.error_rate shouldBe 0.0
+    Seq(true, false).foreach { collapse =>
+      val (_, pre) = outputAndPrefix
+      val metrics = new ErrorRateByReadPosition(input=builder.toTempFile(), output=Some(pre), ref=ref, variants=None, collapse=collapse).computeMetrics()
+      metrics.find(_.position == 1).get.error_rate shouldBe 1.0
+      metrics.find(_.position == 11).get.error_rate shouldBe 0.75
+      metrics.filter(m => m.position != 1 && m.position != 11).foreach { m =>
+        m.bases_total shouldBe 4
+        m.error_rate  shouldBe 0.0
+      }
+
+      val metricPosition1 = metrics.find(_.position == 1).get
+      metricPosition1.a_to_g_error_rate shouldBe 1.0
+      metricPosition1.c_to_t_error_rate shouldBe 1.0
+      if (collapse) {
+        metricPosition1.g_to_a_error_rate.isEmpty shouldBe true
+        metricPosition1.t_to_c_error_rate.isEmpty shouldBe true
+      }
+      else {
+        metricPosition1.g_to_a_error_rate.value shouldBe 1.0
+        metricPosition1.t_to_c_error_rate.value shouldBe 1.0
+      }
     }
+  }
 
-    if (Rscript.Available) {
-      val plot = PathUtil.pathTo(s"${pre}${ErrorRateByReadPositionMetric.PlotExtension}")
-      Files.exists(plot) shouldBe true
+  it should "run end to end and maybe generate a PDF" in {
+    Seq(true, false).foreach { collapse =>
+      val builder = newSamBuilder
+      1 to 99 foreach {i => builder.addPair(contig=1, start1=i, start2=i+50, bases1="A"*20, bases2="A"*20) }
+      builder.addPair(contig=1, start1=100, start2=200, bases1="AAAAAAAAATTAAAAAAAAA", bases2="AAAAAAAAATTAAAAAAAAA")
+
+      val (out, pre) = outputAndPrefix
+      new ErrorRateByReadPosition(input=builder.toTempFile(), output=Some(pre), ref=ref, collapse=collapse).execute()
+      val metrics = Metric.read[ErrorRateByReadPositionMetric](out)
+      metrics.size shouldBe 40
+      metrics.map(_.bases_total).sum shouldBe 4000
+      metrics.foreach { m =>
+        if (m.position == 10 || m.position == 11) m.error_rate shouldBe 0.01
+        else m.error_rate shouldBe 0.0
+      }
+
+      if (Rscript.Available) {
+        val plot = PathUtil.pathTo(s"${pre}${ErrorRateByReadPositionMetric.PlotExtension}")
+        Files.exists(plot) shouldBe true
+      }
     }
   }
 
@@ -257,5 +309,48 @@ class ErrorRateByReadPositionTest extends UnitSpec {
     ms(16).a_to_g_error_rate shouldBe 0.5
     ms(17).errors shouldBe 1
     ms(17).a_to_c_error_rate shouldBe 0.5
+  }
+
+  // This test cases makes sure that we can read in metric files that used the old-style metrics, which did not contain
+  // the optional exhaustive substitution types, rather contained the collapsed substitution types.
+  it should "read in old-style metrics" in {
+    val oldMetric = DeprecatedErrorRateByReadPositionMetric(
+      read_number = 1,
+      position    = 2,
+      bases_total = 3L,
+      errors      = 4L,
+      error_rate  = 0.1,
+      a_to_c_error_rate = 0.2,
+      a_to_g_error_rate = 0.3,
+      a_to_t_error_rate = 0.4,
+      c_to_a_error_rate = 0.5,
+      c_to_g_error_rate = 0.6,
+      c_to_t_error_rate = 0.7
+    )
+    val path = makeTempFile("metrics.", ".txt")
+    Metric.write(path=path, oldMetric)
+
+    val newMetrics = Metric.read[ErrorRateByReadPositionMetric](path=path)
+    newMetrics.length shouldBe 1
+    val newMetric = newMetrics.head
+
+    newMetric.read_number shouldBe oldMetric.read_number
+    newMetric.position shouldBe oldMetric.position
+    newMetric.bases_total shouldBe oldMetric.bases_total
+    newMetric.errors shouldBe oldMetric.errors
+    newMetric.error_rate shouldBe oldMetric.error_rate
+    newMetric.a_to_c_error_rate shouldBe oldMetric.a_to_c_error_rate
+    newMetric.a_to_g_error_rate shouldBe oldMetric.a_to_g_error_rate
+    newMetric.a_to_t_error_rate shouldBe oldMetric.a_to_t_error_rate
+    newMetric.c_to_a_error_rate shouldBe oldMetric.c_to_a_error_rate
+    newMetric.c_to_g_error_rate shouldBe oldMetric.c_to_g_error_rate
+    newMetric.c_to_t_error_rate shouldBe oldMetric.c_to_t_error_rate
+    newMetric.g_to_a_error_rate.isEmpty shouldBe true
+    newMetric.g_to_c_error_rate.isEmpty shouldBe true
+    newMetric.g_to_t_error_rate.isEmpty shouldBe true
+    newMetric.t_to_a_error_rate.isEmpty shouldBe true
+    newMetric.t_to_c_error_rate.isEmpty shouldBe true
+    newMetric.t_to_g_error_rate.isEmpty shouldBe true
+    newMetric.collapsed shouldBe true
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/bam/ErrorRateByReadPositionTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/ErrorRateByReadPositionTest.scala
@@ -111,7 +111,7 @@ class ErrorRateByReadPositionTest extends UnitSpec with OptionValues {
 
   it should "compute the error rate for some simple paired end reads" in {
     val builder = newSamBuilder
-    1 to 9 foreach {i => builder.addPair(name="$i", contig=1, start1=100, start2=200, bases1="A"*20, bases2="A"*20) }
+    1 to 9 foreach {i => builder.addPair(name=s"$i", contig=1, start1=100, start2=200, bases1="A"*20, bases2="A"*20) }
     builder.addPair("err", contig=1, start1=300, start2=400).foreach { rec =>
       if (rec.firstOfPair) rec.bases = "AAAAAAAAAAAAAAAAACGT"
       else rec.bases = "AAAAAAAAAAAAAAAAACGT"


### PR DESCRIPTION
This is by default "off" in `fgbio ErrorRateByReadPosition`.