### PR TITLE
Updates to make the VCF api code considerably faster when reading VCFs with may samples

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/vcf/api/Genotype.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/Genotype.scala
@@ -42,7 +42,7 @@ final case class Genotype(alleles: AlleleSet,
   require(calls.nonEmpty, "Genotype must have ploidy of at least 1!.")
 
   /** The indices of the calls within the AlleleSet. If any allele is no-called, that is returned as -1. */
-  private [api] val callIndices: IndexedSeq[Int] = calls.map(c => if (c == NoCallAllele) -1 else alleles.indexOf(c))
+  private [api] lazy val callIndices: IndexedSeq[Int] = calls.map(c => if (c == NoCallAllele) -1 else alleles.indexOf(c))
 
   /** Returns the separator that should be used between alleles when displaying the genotype. */
   private def separator: String = if (phased) "|" else "/"

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/GenotypeMap.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/GenotypeMap.scala
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2020 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.fulcrumgenomics.vcf.api
+
+import com.fulcrumgenomics.FgBioDef._
+
+/**
+  * Map used to store genotypes and ensure that they are stored in the order they were read in the VCF. This class
+  * is immutable.  To avoid copying of the gts array, once passed to this class no other references to the gts
+  * should be retained.
+  *
+  * @param gts the genotypes for the samples
+  * @param sampleIndex a mapping of sample name to index within the genotypes
+  */
+class GenotypeMap private[api] (private val gts: Array[Genotype],
+                                private val sampleIndex: Map[String, Int]) extends Map[String, Genotype] {
+
+  override def removed(key: String): Map[String, Genotype] = throw new UnsupportedOperationException
+  override def updated[V1 >: Genotype](key: String, value: V1): Map[String, V1] = throw new UnsupportedOperationException
+  override def get(key: String): Option[Genotype] = sampleIndex.get(key).map(i => gts(i))
+  override def apply(key: String): Genotype = gts(sampleIndex(key))
+  override def iterator: Iterator[(String, Genotype)] = gts.iterator.map(gt => (gt.sample, gt))
+}

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/VcfConversions.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/VcfConversions.scala
@@ -36,7 +36,7 @@ import htsjdk.variant.vcf._
 
 import scala.collection.JavaConverters.mapAsJavaMapConverter
 import scala.collection.immutable.ListMap
-import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable
 
 /**
   * Object that provides methods for converting from fgbio's scala VCF classes to HTSJDK's
@@ -44,6 +44,16 @@ import scala.collection.mutable.ArrayBuffer
   * package and should not be exposed publicly.
   */
 private[api] object VcfConversions {
+  /** Map used when there are no attributes to be copied. */
+  private val NoAttrs = Map.empty[String, Any]
+
+  /** Class to allow wrapping an Array into an immutable IndexedSeq without copying. */
+  private class ArrayIndexedSeq[T](private val array: Array[T]) extends scala.collection.immutable.IndexedSeq[T] {
+    override final def apply(i: Int): T = this.array(i)
+    override final def length: Int = this.array.length
+    override final def nonEmpty: Boolean = this.array.length > 0
+  }
+
   /** Converts a String into Option[String]. Returns `None` if the input string is either
     * `null`, the empty string or [[Variant.Missing]].
     */
@@ -75,7 +85,6 @@ private[api] object VcfConversions {
         // This is a horrible hack necessary because HTSJDK doesn't parse compound header lines unless
         // they are one of INFO/CONTIG/FILTER/ALT, and there's no way to get HTSJDK to report the version of the file!
         val attrs = VCFHeaderLineTranslator.parseLine(VCFHeaderVersion.VCF4_2, line.getValue, util.Collections.emptyList())
-        val id = attrs.get("ID")
         val scalaAttrs = attrs.entrySet().filter(_.getKey != "ID").map(entry => entry.getKey -> entry.getValue).toMap
         VcfGeneralHeader(line.getKey, attrs.get("ID"), scalaAttrs)
       case line: VCFHeaderLine =>
@@ -88,7 +97,7 @@ private[api] object VcfConversions {
       formats = formats,
       filters = in.getFilterLines.toIndexedSeq.sortBy(_.getID).map(f => VcfFilterHeader(f.getID, f.getDescription)),
       others   = others,
-      samples = in.getSampleNamesInOrder.toIndexedSeq
+      samples = in.getGenotypeSamples.toIndexedSeq
     )
   }
 
@@ -200,35 +209,47 @@ private[api] object VcfConversions {
     */
   def toScalaVariant(in: VariantContext, header: VcfHeader): Variant = try {
     // Build up the allele set
-    val ref       = Allele(in.getReference.getDisplayString)
-    val alts      = in.getAlternateAlleles.map(a => Allele(a.getDisplayString)).toIndexedSeq
-    val alleles   = AlleleSet(ref, alts)
-    val alleleMap = alleles.map(a => a.toString -> a).toMap
+    val scalaAlleles = in.getAlleles.iterator.map(a => Allele(a.getDisplayString)).toIndexedSeq
+    val alleleMap    = in.getAlleles.iterator().zip(scalaAlleles).toMap
+    val alleles      = AlleleSet(scalaAlleles.head, scalaAlleles.tail)
 
     // Build up the genotypes
-    val gts = in.getGenotypes.map { g =>
-      val calls = g.getAlleles.map(a => if(a.isNoCall) NoCallAllele else alleleMap(a.getDisplayString)).toIndexedSeq
-      val attrs = {
-        val buffer = new ArrayBuffer[(String,Any)](g.getExtendedAttributes.size() + 4)
-        if (g.hasAD) buffer.append("AD" -> g.getAD.toIndexedSeq)
-        if (g.hasDP) buffer.append("DP" -> g.getDP)
-        if (g.hasGQ) buffer.append("GQ" -> g.getGQ)
-        if (g.hasPL) buffer.append("PL" -> g.getPL.toIndexedSeq)
+    val gts = new Array[Genotype](in.getNSamples)
+    forloop (from=0, until=in.getNSamples) { i =>
+      val g = in.getGenotype(i)
+
+      val calls = {
+        val buffer = new Array[Allele](g.getPloidy)
+        val javaAlleles = g.getAlleles
+        forloop (from=0, until=buffer.length) { i =>
+          val a = javaAlleles.get(i)
+          buffer(i) = if(a.isNoCall) NoCallAllele else alleleMap(a)
+        }
+
+        new ArrayIndexedSeq(buffer)
+      }
+
+      val attrs = if (g.getExtendedAttributes.isEmpty && !g.hasAD && !g.hasDP && !g.hasGQ && !g.hasPL) NoAttrs else {
+        val builder = Map.newBuilder[String, Any]
+        if (g.hasAD) builder += ("AD" -> g.getAD.toIndexedSeq)
+        if (g.hasDP) builder += ("DP" -> g.getDP)
+        if (g.hasGQ) builder += ("GQ" -> g.getGQ)
+        if (g.hasPL) builder += ("PL" -> g.getPL.toIndexedSeq)
 
         g.getExtendedAttributes.keySet().foreach { key =>
           val value = g.getExtendedAttribute(key)
 
           header.format.get(key) match {
-            case Some(hd) => toTypedValue(value, hd.kind, hd.count).foreach(v => buffer.append(key -> v))
+            case Some(hd) => toTypedValue(value, hd.kind, hd.count).foreach(v => builder += (key -> v))
             case None     => throw new IllegalStateException(s"Format field $key not described in header.")
           }
         }
 
-        buffer.toMap
+        builder.result()
       }
 
-      Genotype(alleles, g.getSampleName, calls, g.isPhased, attrs)
-    }.toIndexedSeq
+      gts(i) = Genotype(alleles, g.getSampleName, calls, g.isPhased, attrs)
+    }
 
     // Build up the variant
     val info = {
@@ -259,7 +280,7 @@ private[api] object VcfConversions {
       qual      = if (in.hasLog10PError) Some(in.getPhredScaledQual) else None,
       filters   = filters,
       attrs     = ListMap(info:_*),
-      genotypes = gts.iterator.map(g => g.sample -> g).toMap
+      genotypes = new GenotypeMap(gts, header.sampleIndex)
     )
   }
   catch {

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/VcfHeader.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/VcfHeader.scala
@@ -150,6 +150,9 @@ case class VcfHeader(contigs: IndexedSeq[VcfContigHeader],
                      samples: IndexedSeq[String]
                     ) {
 
+  /** A mapping of sample name to the index in samples. */
+  private[api] val sampleIndex = samples.zipWithIndex.toMap
+
   /** The contig lines represented as a SAM sequence dictionary. */
   val dict: SequenceDictionary = {
     val infos = contigs.map { c =>

--- a/src/test/scala/com/fulcrumgenomics/vcf/api/GenotypeMapTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/vcf/api/GenotypeMapTest.scala
@@ -1,0 +1,66 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2020 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.fulcrumgenomics.vcf.api
+
+import com.fulcrumgenomics.FgBioDef._
+import com.fulcrumgenomics.testing.UnitSpec
+
+class GenotypeMapTest extends UnitSpec {
+  private val Alleles = AlleleSet("A", "C", "G", "T")
+  private val A = Alleles(0)
+  private val C = Alleles(1)
+  private val G = Alleles(2)
+  private val T = Alleles(3)
+
+  private val Genotypes = Array(
+      Genotype(Alleles, "x", IndexedSeq(A, C)),
+      Genotype(Alleles, "y", IndexedSeq(G, T)),
+      Genotype(Alleles, "z", IndexedSeq(A, G)),
+      Genotype(Alleles, "a", IndexedSeq(A, A)),
+      Genotype(Alleles, "1", IndexedSeq(G, G))
+    )
+
+  "GenotypeMap" should "maintain ordering" in {
+    val map = new GenotypeMap(Genotypes, Genotypes.zipWithIndex.map { case (g, i) => g.sample -> i }.toMap)
+    map.keysIterator.toIndexedSeq   should contain theSameElementsInOrderAs Seq("x", "y", "z", "a", "1")
+    map.valuesIterator.toIndexedSeq should contain theSameElementsInOrderAs Genotypes
+    map.iterator.toIndexedSeq       should contain theSameElementsInOrderAs Genotypes.map(g => (g.sample, g))
+  }
+
+  it should "support generating new maps with removed and updated elements" in {
+    val map = new GenotypeMap(Genotypes, Genotypes.zipWithIndex.map { case (g, i) => g.sample -> i }.toMap)
+
+    val rem = map.removed("a")
+    rem.keysIterator.toIndexedSeq should contain theSameElementsInOrderAs IndexedSeq("x", "y", "z", "1")
+    rem.iterator.foreach { case (s, gt) => s shouldBe gt.sample }
+
+    val upd = map.updated("a", Genotype(Alleles, "a", IndexedSeq(A, C)))
+    upd.foreach { case (sample, gt) =>
+      sample shouldBe gt.sample
+      if (sample == "a") gt.gtWithBases shouldBe "A/C"
+      else gt shouldBe map(sample)
+    }
+  }
+}


### PR DESCRIPTION
All of this is to make reading large VCFs with many samples not have significant overhead vs. using the HTSJDK api directly.  

I tested the runtime using a ~9k sample VCF with just GT in the genotype columns.  Before this PR reading with the HTSJDK API directly (and decoding genotypes) took ~10s, and the scala API took approximately 60s.  After these changes the scala API is down to ~15s.

@nh13 I think your review is optional, but I would appreciate a quick skim to see if you find anything objectionable.