### PR TITLE
[feature] Add a tool to get percentage of bases falling in each interval by name.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
+++ b/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
@@ -86,12 +86,13 @@ class AnnotateByIntervalList
     // an interval for each template. For single ended reads the interval is just the read.
     val templateIntervals = records.filter { record =>
       if (record.mateMapped) {
-        val equalStartTieBreaker =
+        val equalStartTieBreaker = {
           if (Math.min(record.start, record.end) == Math.min(record.mateStart, record.mateEnd.getOrElse(Int.MaxValue))) {
             record.firstOfPair
           } else {
             true
           }
+        }
         // Take only the first read by coordinate order
         Math.min(record.start, record.end) < Math.min(record.mateStart, record.mateEnd.getOrElse(Int.MaxValue)) &&
         // if mate start == start pick first of pair

--- a/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
+++ b/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
@@ -17,7 +17,7 @@ import htsjdk.samtools.util.{CoordMath, Interval, IntervalList, OverlapDetector}
 @clp(group = ClpGroups.Fastq, description =
   """
     |Collects base and read coverage statistics across intervals by name.
-    |A regular expression is used to classify the name of the intervals to be counted and how they should be grouped.
+    |A regular expression may used to classify the name of the intervals to be counted and how they should be grouped.  Otherwise, the name is used as-is.
     |
     |For example for the following interval list:
     |

--- a/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
+++ b/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
@@ -35,7 +35,7 @@ import htsjdk.samtools.util.{CoordMath, Interval, IntervalList, OverlapDetector}
     |
     |Using the the regex `([^;]*).*` would produce 3 separate interval counts CDS, utr and intron.
     |
-    |Counts template bases (paired-end) or read bases (single end) that are fully enclosed within an interval.
+    |Template bases (paired-end) or read bases (single end) are only counted if they fully enclosed within an interval.
     |By default if a read is enclosed by multiple intervals it will be counted for both intervals. This behavior
     |can be changed using a different `OverlapAssociationStrategy`
   """)

--- a/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
+++ b/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
@@ -105,8 +105,8 @@ class AnnotateByIntervalList
       // Interval should be end of read one to the beginning of read two
       new Interval(
         record.refName,
-        Math.max(record.start, record.end) + 1,
-        Math.min(record.mateStart, record.mateEnd.getOrElse(Int.MaxValue)) - 1
+        Math.max(record.start, record.mateStart) + 1,
+        Math.max(record.mateStart, record.mateEnd.getOrElse(exception) - 1
       )
     )
 

--- a/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
+++ b/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
@@ -84,7 +84,7 @@ class AnnotateByIntervalList
 
     // First we filter to ensure that we only pick one read in a template and then iterate over those reads to create
     // an interval for each template. For single ended reads the interval is just the read.
-    val templateIntervals = records.filter(record => {
+    val templateIntervals = records.filter { record =>
       if (record.mateMapped) {
         val equalStartTieBreaker =
           if (Math.min(record.start, record.end) == Math.min(record.mateStart, record.mateEnd.getOrElse(Int.MaxValue))) {

--- a/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
+++ b/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
@@ -16,7 +16,7 @@ import htsjdk.samtools.util.{CoordMath, Interval, IntervalList, OverlapDetector}
 
 @clp(group = ClpGroups.Fastq, description =
   """
-    |Get percentage of bases falling in each interval by name.
+    |Collects base and read coverage statistics across intervals by name.
     |A regular expression is used to classify the name of the intervals to be counted and how they should be grouped.
     |
     |For example for the following interval list:

--- a/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
+++ b/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
@@ -1,0 +1,149 @@
+package com.fulcrumgenomics.rnaseq
+
+import java.util
+
+import com.fulcrumgenomics.bam.api.SamSource
+import com.fulcrumgenomics.cmdline.{ClpGroups, FgBioTool}
+import com.fulcrumgenomics.commons.CommonsDef.{FilePath, PathToBam, PathToIntervals}
+import com.fulcrumgenomics.commons.util.{LazyLogging, SimpleCounter}
+import com.fulcrumgenomics.sopt.{arg, clp}
+import htsjdk.samtools.util.{Interval, IntervalList, OverlapDetector, SamLocusIterator}
+import com.fulcrumgenomics.FgBioDef.IteratorToJavaCollectionsAdapter
+import com.fulcrumgenomics.FgBioDef.javaIterableToIterator
+import com.fulcrumgenomics.commons.io.Io
+import com.fulcrumgenomics.util.{Metric, ProgressLogger}
+import htsjdk.samtools.SAMSequenceDictionary
+import htsjdk.samtools.filter.{DuplicateReadFilter, FailsVendorReadQualityFilter, SamRecordFilter, SecondaryOrSupplementaryFilter}
+
+/** Metric for [[AnnotateByIntervalList]].
+  *
+  * @param name the name of the intervals
+  * @param bases the number of bases mapping to intervals with the given name.
+  * @param span the number of unique genomic loci/bases coverage by intervals with the given name.
+  * @param frac_genome the fraction of unique genomic loci/bases coverage by intervals with the given name.
+  * @param frac_total_bases the fraction of mapped bases covered by intervals with the given name.
+  * @param mean_coverage the mean coverage of intervals with the given name.
+  */
+case class CoverageByIntervalMetrics
+( name: String,
+  bases: Long,
+  span: Long,
+  frac_genome: Double,
+  frac_total_bases: Double,
+  mean_coverage: Double
+) extends Metric
+
+
+@clp(group=ClpGroups.Fastq, description=
+  """
+    |Get percentage of bases falling in each interval type.
+  """)
+class AnnotateByIntervalList
+(
+  @arg(flag='i', doc="Mapped BAM file.") val input: PathToBam,
+  @arg(flag='l', doc="Path to intervals") val intervals: PathToIntervals,
+  @arg(flag='o', doc="Path to the output metrics file") val output: FilePath,
+  @arg(flag='R', doc="The regular expression to use to classify the name of the interval") val nameRegex: Option[String] = None,
+  @arg(flag='u', doc="The name of the intervals not in the given set of intervals") val unmatched: String = "unmatched",
+  @arg(flag='m', doc="The minimum mapping quality for a read to be included.") val minMappingQuality: Int = 20,
+  @arg(flag='q', doc="The minimum base quality for a base to be included.") val minBaseQuality: Int = 0
+) extends FgBioTool with LazyLogging {
+
+  Io.assertReadable(this.input)
+  Io.assertReadable(this.intervals)
+  Io.assertCanWriteFile(this.output)
+
+  override def execute(): Unit = {
+    val progress = ProgressLogger(logger, verb="Processed", noun="loci", unit=1000000)
+    val reader = SamSource(this.input)
+    val dict = reader.dict
+    val (counter, overlapDetector) = {
+      val _counter  = new SimpleCounter[String]()
+      val intervals = buildIntervals(dict)
+      intervals.foreach { intv => _counter.count(intv.getName, 0) }
+      val _overlapDetector = OverlapDetector.create[Interval](intervals.toIterator.toJavaList)
+      (_counter, _overlapDetector)
+    }
+    val iterator = {
+      val iter = new SamLocusIterator(reader.toSamReader)
+      val filters = new util.ArrayList[SamRecordFilter]()
+      filters.add(new SecondaryOrSupplementaryFilter)
+      filters.add(new FailsVendorReadQualityFilter)
+      filters.add(new DuplicateReadFilter)
+      iter.setSamFilters(filters)
+      iter.setMappingQualityScoreCutoff(this.minMappingQuality)
+      iter.setQualityScoreCutoff(this.minBaseQuality)
+      iter.setEmitUncoveredLoci(false)
+      iter.setIncludeIndels(false)
+      iter
+    }
+
+    var numLociMultiMatched: Long = 0
+
+    iterator.foreach { locus: SamLocusIterator.LocusInfo =>
+      val coverage          = locus.size
+      val locusInterval     = new Interval(locus.getSequenceName, locus.getPosition, locus.getPosition)
+      val overlaps          = overlapDetector.getOverlaps(locusInterval).toSeq
+      if (overlaps.isEmpty) {
+        counter.count(this.unmatched, coverage)
+      } else {
+        val names = overlaps.map(_.getName).distinct 
+        if (names.length > 1) {
+          logger.warning(
+            s"Found more than one interval that matched locus '${locus.getSequenceName}:${locus.getPosition}' : ${names.mkString(", ")}"
+          )
+          numLociMultiMatched += 1
+        }
+        names.foreach { name => counter.count(name, coverage) }
+      }
+      progress.record(locus.getSequenceName, locus.getPosition)
+    }
+    reader.close()
+
+    logger.info(f"Found $numLociMultiMatched%,d loci with multiple classifications.")
+
+    // Get the total # of bases covered by each set of intervals
+    val lengthByIntervalName = new SimpleCounter[String]()
+    overlapDetector.getAll.toSeq.groupBy(_.getName).foreach { case (name, intvs) =>
+      val intervalList = new IntervalList(dict)
+      intervalList.addall(intvs.toIterator.toJavaList)
+      val length = intervalList.uniqued().map(_.length()).sum
+      lengthByIntervalName.count(name, length)
+    }
+    lengthByIntervalName.count(this.unmatched, dict.getReferenceLength - lengthByIntervalName.total)
+
+    val totalBases = counter.total.toDouble
+    val metrics = counter.map { case (name, bases) =>
+      // The total # of genomic bases covered by the intervals with the given name
+      val span = lengthByIntervalName.countOf(name)
+
+      CoverageByIntervalMetrics(
+        name             = name,
+        bases            = bases,
+        span             = span,
+        frac_genome      = span / dict.getReferenceLength.toDouble,
+        frac_total_bases = if (totalBases > 0) bases / totalBases else 0f,
+        mean_coverage    = if (span > 0) bases / span.toDouble else 0f
+      )
+    }.toSeq.sortBy(_.name)
+    Metric.write(this.output, metrics)
+  }
+
+  private def buildIntervals(dict: SAMSequenceDictionary): List[Interval] = {
+    val inputIntervalList = IntervalList.fromPath(this.intervals)
+    this.nameRegex.map(_.r) match {
+      case None => inputIntervalList.uniqued(true).toList
+      case Some(regex) =>
+        val intvs = inputIntervalList.map { i =>
+          val name = i.getName match {
+            case regex(n) => n
+            case _        => throw new IllegalArgumentException(s"Could not match name '${i.getName}' with regex '${this.nameRegex}'")
+          }
+          new Interval(i.getContig, i.getStart, i.getEnd, i.isNegativeStrand, name)
+        }.toJavaList
+        val intervalList = new IntervalList(dict)
+        intervalList.addall(intvs)
+        intervalList.toList
+    }
+  }
+}

--- a/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
+++ b/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
@@ -41,7 +41,7 @@ import htsjdk.samtools.util.{CoordMath, Interval, IntervalList, OverlapDetector}
   """)
 class AnnotateByIntervalList
 (
-  @arg(flag = 'i', doc = "Mapped BAM file.") val input: PathToBam,
+  @arg(flag = 'i', doc = "Path to a mapped BAM file.") val input: PathToBam,
   @arg(flag = 'l', doc = "Path to intervals") val intervals: PathToIntervals,
   @arg(flag = 'o', doc = "Path to the output metrics file") val output: FilePath,
   @arg(flag = 'R', doc = "The regular expression to use to classify the name of the interval") val nameRegex: Option[String] = None,

--- a/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
+++ b/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
@@ -79,7 +79,7 @@ class AnnotateByIntervalList
       || record.secondary
       || record.supplementary
       || !record.pf
-      || !record.isFrPair
+      || (record.paired && !record.isFrPair)
       || record.mapq < minMappingQuality)
 
     // First we filter to ensure that we only pick one read in a template and then iterate over those reads to create

--- a/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
+++ b/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
@@ -46,8 +46,8 @@ class AnnotateByIntervalList
   @arg(flag = 'o', doc = "Path to the output metrics file") val output: FilePath,
   @arg(flag = 'R', doc = "The regular expression to use to classify the name of the interval") val nameRegex: Option[String] = None,
   @arg(flag = 'u', doc = "The name of the intervals not in the given set of intervals") val unmatched: String = "unmatched",
-  @arg(flag = 'm', doc = "The minimum mapping quality for a read to be included.") val minMappingQuality: Int = 20,
-  @arg(flag = 'q', doc = "The minimum base quality for a base to be included.") val minBaseQuality: Int = 0,
+  @arg(flag = 'm', doc = "The minimum mapping quality for a read to be included") val minMappingQuality: Int = 20,
+  @arg(flag = 'q', doc = "The minimum base quality for a base to be included") val minBaseQuality: Int = 0,
   @arg(flag = 'a', doc = "The strategy to determine which interval overlapping templates should be associated with")
   val overlapAssociationStrategy: OverlapAssociationStrategy = OverlapAssociationStrategy.Duplicate
 ) extends FgBioTool with LazyLogging {

--- a/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
+++ b/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
@@ -151,7 +151,8 @@ class AnnotateByIntervalList
       }
       progress.record(templateInterval.getContig, templateInterval.getStart)
     }
-    reader.close()
+    progress.logLast()
+    reader.safelyClose()
 
     logger.info(f"Found $numLociMultiMatched%,d templates with multiple classifications.")
 

--- a/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
+++ b/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
@@ -37,7 +37,7 @@ import htsjdk.samtools.util.{CoordMath, Interval, IntervalList, OverlapDetector}
     |
     |Template bases (paired-end) or read bases (single end) are only counted if they fully enclosed within an interval.
     |By default if a read is enclosed by multiple intervals it will be counted for both intervals. This behavior
-    |can be changed using a different `OverlapAssociationStrategy`
+    |can be changed using a different `--overlap-association-strategy`.
   """)
 class AnnotateByIntervalList
 (

--- a/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
+++ b/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
@@ -190,7 +190,7 @@ class AnnotateByIntervalList
   private def buildIntervals(dict: SAMSequenceDictionary): List[Interval] = {
     val inputIntervalList = IntervalList.fromPath(this.intervals)
     this.nameRegex.map(_.r) match {
-      case None => inputIntervalList.uniqued(true).toList
+      case None        => inputIntervalList.uniqued(true).toList
       case Some(regex) =>
         val intervals = inputIntervalList.map { i =>
           val name = i.getName match {

--- a/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
+++ b/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
@@ -1,7 +1,30 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2020 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.fulcrumgenomics.rnaseq
 
-import com.fulcrumgenomics.FgBioDef.{FgBioEnum, IteratorToJavaCollectionsAdapter, javaIterableToIterator}
-import com.fulcrumgenomics.bam.api.SamSource
+import com.fulcrumgenomics.FgBioDef._
+import com.fulcrumgenomics.bam.api.{SamRecord, SamSource}
 import com.fulcrumgenomics.cmdline.{ClpGroups, FgBioTool}
 import com.fulcrumgenomics.commons.CommonsDef.{FilePath, PathToBam, PathToIntervals}
 import com.fulcrumgenomics.commons.io.Io
@@ -48,6 +71,7 @@ class AnnotateByIntervalList
   @arg(flag = 'u', doc = "The name of the intervals not in the given set of intervals") val unmatched: String = "unmatched",
   @arg(flag = 'm', doc = "The minimum mapping quality for a read to be included") val minMappingQuality: Int = 20,
   @arg(flag = 'q', doc = "The minimum base quality for a base to be included") val minBaseQuality: Int = 0,
+  @arg(flag = 's', doc = "The maximum insert size for an un-fragmented template") val maxInsertSize: Int = 1000,
   @arg(flag = 'a', doc = "The strategy to determine which interval overlapping templates should be associated with")
   val overlapAssociationStrategy: OverlapAssociationStrategy = OverlapAssociationStrategy.Duplicate
 ) extends FgBioTool with LazyLogging {
@@ -61,100 +85,80 @@ class AnnotateByIntervalList
     val reader = SamSource(this.input)
     val dict = reader.dict
 
-    val (baseCounter, uniqueBaseCounter, templateCounter, uniqueTemplateCounter, overlapDetector) = {
-      val _baseCounter            = new SimpleCounter[String]()
-      val _uniqueBaseCounter      = new SimpleCounter[String]()
-      val _templateCounter        = new SimpleCounter[String]()
-      val _uniqueTemplateCounter  = new SimpleCounter[String]()
-      val intervals               = buildIntervals(dict.asSam)
-      intervals.foreach { interval => _baseCounter.count(interval.getName, 0) }
+    val (counters, overlapDetector) = {
+      val baseCounter            = new SimpleCounter[String]()
+      val uniqueBaseCounter      = new SimpleCounter[String]()
+      val templateCounter        = new SimpleCounter[String]()
+      val uniqueTemplateCounter  = new SimpleCounter[String]()
+      val intervals              = buildIntervals(dict.asSam)
+      intervals.foreach { interval => baseCounter.count(interval.getName, 0) }
 
       val _overlapDetector = OverlapDetector.create[Interval](intervals.iterator.toJavaList)
-      (_baseCounter, _uniqueBaseCounter, _templateCounter, _uniqueTemplateCounter, _overlapDetector)
+      val _counters: Map[CounterType, SimpleCounter[String]] = Map(
+        CounterType.Base            -> baseCounter,
+        CounterType.UniqueBase      -> uniqueBaseCounter,
+        CounterType.Template        -> templateCounter,
+        CounterType.UniqueTemplate  -> uniqueTemplateCounter
+      )
+
+      (_counters, _overlapDetector)
     }
 
-    // Templates are assigned to an interval together.
+    // Templates are assigned to an interval together
     val iterator = reader.iterator
-    val records = iterator.filterNot(record => record.duplicate
-      || record.secondary
-      || record.supplementary
-      || !record.pf
-      || (record.paired && !record.isFrPair)
-      || record.mapq < minMappingQuality)
 
-    // First we filter to ensure that we only pick one read in a template and then iterate over those reads to create
-    // an interval for each template. For single ended reads the interval is just the read.
-    val templateIntervals = records.filter { record =>
-      if (record.mateMapped) {
-        val equalStartTieBreaker = {
-          if (Math.min(record.start, record.end) == Math.min(record.mateStart, record.mateEnd.getOrElse(Int.MaxValue))) {
-            record.firstOfPair
-          } else {
-            true
-          }
-        }
-        // Take only the first read by coordinate order
-        Math.min(record.start, record.end) < Math.min(record.mateStart, record.mateEnd.getOrElse(Int.MaxValue)) &&
-        // if mate start == start pick first of pair
-        equalStartTieBreaker
-      } else {
-        //If we are single ended then just take the record
-        true
-      }
-    }).map(record =>
+    val records = iterator.filterNot { rec =>
+      rec.duplicate || rec.secondary || rec.supplementary || !rec.pf || (rec.paired && !rec.isFrPair) || rec.mapq < minMappingQuality || pairStartTieBreaker(rec)
+    }
+
+    val enclosingIntervalToRecords: Map[Interval, SamRecord] = records.map(record =>
       // Interval should be end of read one to the beginning of read two
       new Interval(
         record.refName,
-        Math.max(record.start, record.mateStart) + 1,
-        Math.max(record.mateStart, record.mateEnd.getOrElse(exception) - 1
-      )
-    )
+        // Single end read mateStart will be set to 0
+        Math.min(record.start, record.mateStart),
+        // Set mate end to math min if it isn't defined (single end read)
+        Math.max(record.end, record.mateEnd.getOrElse(Int.MinValue))
+      ) -> record
+    ).toMap
 
-    var numLociMultiMatched: Long = 0
+    enclosingIntervalToRecords.foreach { intervalToRecord =>
+      // Overlaps should only be flagged when they enclose the template bases
+      val recordInterval = intervalToRecord._1
+      val record = intervalToRecord._2
 
-    templateIntervals.foreach { templateInterval =>
-      // Overlaps should only be flagged when they enclose the template bases.
-      val overlaps = overlapDetector.getOverlaps(templateInterval).toSeq
-        .filter(interval => CoordMath.encloses(interval.getStart, interval.getEnd,
-          templateInterval.getStart, templateInterval.getEnd))
+      val overlaps = overlapDetector.getOverlaps(recordInterval).toSeq.filter { interval =>
+        CoordMath.encloses(
+          interval.getStart,
+          interval.getEnd,
+          recordInterval.getStart,
+          recordInterval.getEnd)
+      }
 
       if (overlaps.isEmpty) {
-        baseCounter.count(this.unmatched, templateInterval.getLengthOnReference)
-        templateCounter.count(this.unmatched, 1)
+        counters(CounterType.Base).count(this.unmatched, getCountOfSequencedBases(record))
+        counters(CounterType.Template).count(this.unmatched, 1)
       } else {
         val names: Seq[String] = overlaps.map(_.getName).distinct
 
-        def countForNames(namesToCount: Seq[String]): Unit = {
-          namesToCount.foreach { name =>
-            val bases = overlaps.filter(_.getName == name).map(_.getIntersectionLength(templateInterval)).sum
-            baseCounter.count(name, bases)
-            templateCounter.count(name, 1)
-            // If we only have one enclosing interval count unique bases and templates as well.
-            if (namesToCount.length == 1) {
-              uniqueBaseCounter.count(name, bases)
-              uniqueTemplateCounter.count(name, 1)
-            }
-          }
-        }
-
         if (names.length > 1) {
-          // If there are multiple enclosing intervals by name use an associate strategy.
+          // If there are multiple enclosing intervals by name use an associate strategy
           overlapAssociationStrategy match {
-            case Duplicate      => countForNames(names)
-            case MostSpecific   => countForNames(Seq(overlaps.minBy(_.length).getName))
-            case LeastSpecific  => countForNames(Seq(overlaps.maxBy(_.length).getName))
+            case Duplicate      => countForNames(namesToCount = names, record = record, counters = counters)
+            case MostSpecific   => countForNames(namesToCount = Seq(overlaps.minBy(_.length).getName), record = record, counters = counters)
+            case LeastSpecific  => countForNames(namesToCount = Seq(overlaps.maxBy(_.length).getName), record = record, counters = counters)
           }
-          numLociMultiMatched += 1
         } else {
           // When there is only one interval matched we associate all intersected bases with the single interval
-          countForNames(names)
+          countForNames(namesToCount = names, record = record, counters = counters)
         }
       }
-      progress.record(templateInterval.getContig, templateInterval.getStart)
+      progress.record(recordInterval.getContig, recordInterval.getStart)
     }
     progress.logLast()
-    reader.safelyClose()
+    reader.close()
 
+    val numLociMultiMatched = counters(CounterType.Template).total - counters(CounterType.UniqueTemplate).total
     logger.info(f"Found $numLociMultiMatched%,d templates with multiple classifications.")
 
     // Get the total # of bases covered by each set of intervals
@@ -168,24 +172,68 @@ class AnnotateByIntervalList
     }
     lengthByIntervalName.count(this.unmatched, dict.length - lengthByIntervalName.total)
 
-    val totalBases  = baseCounter.total.toDouble
-    val metrics     = baseCounter.map { case (name, bases) =>
+    val totalBases  = counters(CounterType.Base).total.toDouble
+    val metrics     = counters(CounterType.Base).map { case (name, bases) =>
       // The total # of genomic bases covered by the intervals with the given name
       val span = lengthByIntervalName.countOf(name)
 
       CoverageByIntervalMetrics(
         name              = name,
         bases             = bases,
-        unique_bases      = uniqueBaseCounter.countOf(name),
+        unique_bases      = counters(CounterType.UniqueBase).countOf(name),
         span              = span,
         frac_genome       = span / dict.length.toDouble,
         frac_total_bases  = if (totalBases > 0) bases / totalBases else 0f,
         mean_coverage     = if (span > 0) bases / span.toDouble else 0f,
-        templates         = templateCounter.countOf(name),
-        unique_templates  = uniqueTemplateCounter.countOf(name)
+        templates         = counters(CounterType.Template).countOf(name),
+        unique_templates  = counters(CounterType.UniqueTemplate).countOf(name)
       )
     }.toSeq.sortBy(_.name)
     Metric.write(this.output, metrics)
+  }
+
+  /**
+    * If a record is paired, both reads are mapped and on the same contig and their start positions are identical,
+    * then return true if for the second of the pair. This method is meant to be used in a `filterNot` such that
+    * the first of the pair will be selected.
+    * @param rec The record to check both reads for identical starts on
+    * @return Returns true if both reads are mapped on the same contig and have the same start location.
+    */
+  private def pairStartTieBreaker(rec: SamRecord): Boolean = {
+    rec.paired && rec.mapped && rec.mateMapped && rec.refName == rec.mateRefName && rec.start == rec.mateStart && rec.secondOfPair
+  }
+
+  /**
+    * Gets the count of sequenced bases for a record. This does not include soft clipped bases.
+    * @param record The record to count bases for.
+    * @return The count of sequenced bases for this record.
+    */
+  private def getCountOfSequencedBases(record: SamRecord): Int = {
+    val mateSequencedBases = if (record.mateMapped) {
+      // If the mate is mapped and there is no mateEnd it should fail with the require, but just to be safe set
+      // length to 0
+      record.mateEnd.getOrElse(record.mateStart) - record.mateStart + 1
+    } else {
+      0
+    }
+    (record.end - record.start + 1) + mateSequencedBases
+  }
+
+  private def countForNames(
+    namesToCount: Seq[String],
+    record: SamRecord,
+    counters: Map[CounterType, SimpleCounter[String]],
+  ): Unit = {
+    namesToCount.foreach { name =>
+      val bases = getCountOfSequencedBases(record)
+      counters(CounterType.Base).count(name, bases)
+      counters(CounterType.Template).count(name, 1)
+      // If we only have one enclosing interval count unique bases and templates as well
+      if (namesToCount.length == 1) {
+        counters(CounterType.UniqueBase).count(name, bases)
+        counters(CounterType.UniqueTemplate).count(name, 1)
+      }
+    }
   }
 
   private def buildIntervals(dict: SAMSequenceDictionary): List[Interval] = {
@@ -231,18 +279,35 @@ case class CoverageByIntervalMetrics(
   unique_templates: Long
 ) extends Metric
 
+
+sealed trait CounterType extends EnumEntry
+object CounterType extends FgBioEnum[CounterType] {
+  def values: IndexedSeq[CounterType] = findValues
+  case object Base extends CounterType
+  case object UniqueBase extends CounterType
+  case object Template extends CounterType
+  case object UniqueTemplate extends CounterType
+}
 /**
   * Enum for determining how to associate a read that is enclosed in more than a single interval.
-  * - Duplicate counting associates the template base with all enclosing intervals.
-  * - MostSpecific counting associates the template bases with the smallest enclosing interval.
-  * - LeastSpecific counting associates the template bases with the largest enclosing interval.
   */
 sealed trait OverlapAssociationStrategy extends EnumEntry
 
 object OverlapAssociationStrategy extends FgBioEnum[OverlapAssociationStrategy] {
   def values: IndexedSeq[OverlapAssociationStrategy] = findValues
 
+  /**
+    * Duplicate counting associates the template base with all enclosing intervals.
+    */
   case object Duplicate extends OverlapAssociationStrategy
+
+  /**
+    * MostSpecific counting associates the template bases with the smallest enclosing interval.
+    */
   case object MostSpecific extends OverlapAssociationStrategy
+
+  /**
+    * LeastSpecific counting associates the template bases with the largest enclosing interval.
+    */
   case object LeastSpecific extends OverlapAssociationStrategy
 }

--- a/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
+++ b/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
@@ -14,21 +14,42 @@ import enumeratum.EnumEntry
 import htsjdk.samtools.SAMSequenceDictionary
 import htsjdk.samtools.util.{CoordMath, Interval, IntervalList, OverlapDetector}
 
-@clp(group=ClpGroups.Fastq, description=
+@clp(group = ClpGroups.Fastq, description =
   """
-    |Get percentage of bases falling in each interval type.
+    |Get percentage of bases falling in each interval by name.
+    |A regular expression is used to classify the name of the intervals to be counted and how they should be grouped.
+    |
+    |For example for the following interval list:
+    |
+    |```
+    |chr1    981971  982021  +       utr
+    |chr1    982022  982065  +       intron
+    |chr1    982066  982117  -       CDS;1
+    |chr1    998963  999059  +       utr
+    |chr1    999060  999432  -       CDS;2
+    |chr1    999433  999526  +       intron
+    |chr1    999527  999613  -       CDS;3
+    |chr1    999614  999692  +       intron
+    |chr1    999693  999973  -       CDS;4
+    |```
+    |
+    |Using the the regex `([^;]*).*` would produce 3 separate interval counts CDS, utr and intron.
+    |
+    |Counts template bases (paired-end) or read bases (single end) that are fully enclosed within an interval.
+    |By default if a read is enclosed by multiple intervals it will be counted for both intervals. This behavior
+    |can be changed using a different `OverlapAssociationStrategy`
   """)
 class AnnotateByIntervalList
 (
-  @arg(flag='i', doc="Mapped BAM file.") val input: PathToBam,
-  @arg(flag='l', doc="Path to intervals") val intervals: PathToIntervals,
-  @arg(flag='o', doc="Path to the output metrics file") val output: FilePath,
-  @arg(flag='R', doc="The regular expression to use to classify the name of the interval") val nameRegex: Option[String] = None,
-  @arg(flag='u', doc="The name of the intervals not in the given set of intervals") val unmatched: String = "unmatched",
-  @arg(flag='m', doc="The minimum mapping quality for a read to be included.") val minMappingQuality: Int = 20,
-  @arg(flag='q', doc="The minimum base quality for a base to be included.") val minBaseQuality: Int = 0,
-  @arg(flag='a', doc="The strategy to determine which interval overlapping templates should be associated with")
-    val overlapAssociationStrategy: OverlapAssociationStrategy = OverlapAssociationStrategy.Duplicate
+  @arg(flag = 'i', doc = "Mapped BAM file.") val input: PathToBam,
+  @arg(flag = 'l', doc = "Path to intervals") val intervals: PathToIntervals,
+  @arg(flag = 'o', doc = "Path to the output metrics file") val output: FilePath,
+  @arg(flag = 'R', doc = "The regular expression to use to classify the name of the interval") val nameRegex: Option[String] = None,
+  @arg(flag = 'u', doc = "The name of the intervals not in the given set of intervals") val unmatched: String = "unmatched",
+  @arg(flag = 'm', doc = "The minimum mapping quality for a read to be included.") val minMappingQuality: Int = 20,
+  @arg(flag = 'q', doc = "The minimum base quality for a base to be included.") val minBaseQuality: Int = 0,
+  @arg(flag = 'a', doc = "The strategy to determine which interval overlapping templates should be associated with")
+  val overlapAssociationStrategy: OverlapAssociationStrategy = OverlapAssociationStrategy.Duplicate
 ) extends FgBioTool with LazyLogging {
 
   Io.assertReadable(this.input)
@@ -36,41 +57,45 @@ class AnnotateByIntervalList
   Io.assertCanWriteFile(this.output)
 
   override def execute(): Unit = {
-    val progress = ProgressLogger(logger, verb="Processed", noun="loci", unit=1000000)
+    val progress = ProgressLogger(logger, verb = "Processed", noun = "loci", unit = 1000000)
     val reader = SamSource(this.input)
     val dict = reader.dict
 
     val (baseCounter, uniqueBaseCounter, templateCounter, uniqueTemplateCounter, overlapDetector) = {
-      val _baseCounter         = new SimpleCounter[String]()
-      val _uniqueBaseCounter  = new SimpleCounter[String]()
-      val _templateCounter = new SimpleCounter[String]()
-      val _uniqueTemplateCounter = new SimpleCounter[String]()
-      val intervals = buildIntervals(dict.asSam)
+      val _baseCounter            = new SimpleCounter[String]()
+      val _uniqueBaseCounter      = new SimpleCounter[String]()
+      val _templateCounter        = new SimpleCounter[String]()
+      val _uniqueTemplateCounter  = new SimpleCounter[String]()
+      val intervals               = buildIntervals(dict.asSam)
       intervals.foreach { interval => _baseCounter.count(interval.getName, 0) }
+
       val _overlapDetector = OverlapDetector.create[Interval](intervals.iterator.toJavaList)
       (_baseCounter, _uniqueBaseCounter, _templateCounter, _uniqueTemplateCounter, _overlapDetector)
     }
 
-    //Templates are assigned to an interval together.
+    // Templates are assigned to an interval together.
     val iterator = reader.iterator
     val records = iterator.filterNot(record => record.duplicate
-        || record.secondary
-        || record.supplementary
-        || !record.pf
-        || !record.isFrPair
-        || record.mapq < minMappingQuality)
+      || record.secondary
+      || record.supplementary
+      || !record.pf
+      || !record.isFrPair
+      || record.mapq < minMappingQuality)
 
-    // First we filter to ensure that we only pick one read in a template and then iterate over those templates to create
-    // a set of intervals. For single ended reads the interval is just the read.
-    val templateIntervals = records.filter( record => {
-      if(record.mateMapped) {
-        val equalStarts = if (Math.min(record.start, record.end) == Math.min(record.mateStart, record.mateEnd.getOrElse(Int.MaxValue))){
-          record.firstOfPair
-        } else { true }
+    // First we filter to ensure that we only pick one read in a template and then iterate over those reads to create
+    // an interval for each template. For single ended reads the interval is just the read.
+    val templateIntervals = records.filter(record => {
+      if (record.mateMapped) {
+        val equalStartTieBreaker =
+          if (Math.min(record.start, record.end) == Math.min(record.mateStart, record.mateEnd.getOrElse(Int.MaxValue))) {
+            record.firstOfPair
+          } else {
+            true
+          }
         // Take only the first read by coordinate order
         Math.min(record.start, record.end) < Math.min(record.mateStart, record.mateEnd.getOrElse(Int.MaxValue)) &&
         // if mate start == start pick first of pair
-        equalStarts
+        equalStartTieBreaker
       } else {
         //If we are single ended then just take the record
         true
@@ -80,13 +105,14 @@ class AnnotateByIntervalList
       new Interval(
         record.refName,
         Math.max(record.start, record.end) + 1,
-        Math.min(record.mateStart, record.mateEnd.getOrElse(Int.MaxValue)) -1
+        Math.min(record.mateStart, record.mateEnd.getOrElse(Int.MaxValue)) - 1
       )
     )
 
     var numLociMultiMatched: Long = 0
 
     templateIntervals.foreach { templateInterval =>
+      // Overlaps should only be flagged when they enclose the template bases.
       val overlaps = overlapDetector.getOverlaps(templateInterval).toSeq
         .filter(interval => CoordMath.encloses(interval.getStart, interval.getEnd,
           templateInterval.getStart, templateInterval.getEnd))
@@ -95,14 +121,15 @@ class AnnotateByIntervalList
         baseCounter.count(this.unmatched, templateInterval.getLengthOnReference)
         templateCounter.count(this.unmatched, 1)
       } else {
-        val names:Seq[String] = overlaps.map(_.getName).distinct
+        val names: Seq[String] = overlaps.map(_.getName).distinct
 
         def countForNames(namesToCount: Seq[String]): Unit = {
           namesToCount.foreach { name =>
             val bases = overlaps.filter(_.getName == name).map(_.getIntersectionLength(templateInterval)).sum
             baseCounter.count(name, bases)
             templateCounter.count(name, 1)
-            if(namesToCount.length == 1) {
+            // If we only have one enclosing interval count unique bases and templates as well.
+            if (namesToCount.length == 1) {
               uniqueBaseCounter.count(name, bases)
               uniqueTemplateCounter.count(name, 1)
             }
@@ -110,15 +137,11 @@ class AnnotateByIntervalList
         }
 
         if (names.length > 1) {
-          // If there is an overlap use the association strategy to determine which bases are associated with
-          // which interval.
+          // If there are multiple enclosing intervals by name use an associate strategy.
           overlapAssociationStrategy match {
-            // Duplicate counting associates the template base with all enclosing intervals.
-            case Duplicate  => countForNames(names)
-            // MostSpecific counting associates the template bases with the smallest enclosing interval.
-            case MostSpecific       => countForNames(Seq(overlaps.minBy(_.length).getName))
-              // LeastSpecific counting associates the template bases with the largest enclosing interval.
-            case LeastSpecific       => countForNames(Seq(overlaps.maxBy(_.length).getName))
+            case Duplicate      => countForNames(names)
+            case MostSpecific   => countForNames(Seq(overlaps.minBy(_.length).getName))
+            case LeastSpecific  => countForNames(Seq(overlaps.maxBy(_.length).getName))
           }
           numLociMultiMatched += 1
         } else {
@@ -130,33 +153,34 @@ class AnnotateByIntervalList
     }
     reader.close()
 
-    logger.info(f"Found $numLociMultiMatched%,d loci with multiple classifications.")
+    logger.info(f"Found $numLociMultiMatched%,d templates with multiple classifications.")
 
     // Get the total # of bases covered by each set of intervals
     val lengthByIntervalName = new SimpleCounter[String]()
     overlapDetector.getAll.toSeq.groupBy(_.getName).foreach { case (name, intvs) =>
       val intervalList = new IntervalList(dict.asSam)
       intervalList.addall(intvs.iterator.toJavaList)
+
       val length = intervalList.uniqued().map(_.length()).sum
       lengthByIntervalName.count(name, length)
     }
     lengthByIntervalName.count(this.unmatched, dict.length - lengthByIntervalName.total)
 
-    val totalBases = baseCounter.total.toDouble
-    val metrics = baseCounter.map { case (name, bases) =>
+    val totalBases  = baseCounter.total.toDouble
+    val metrics     = baseCounter.map { case (name, bases) =>
       // The total # of genomic bases covered by the intervals with the given name
       val span = lengthByIntervalName.countOf(name)
 
       CoverageByIntervalMetrics(
-        name             = name,
-        bases            = bases,
-        unique_bases     = uniqueBaseCounter.countOf(name),
-        span             = span,
-        frac_genome      = span / dict.length.toDouble,
-        frac_total_bases = if (totalBases > 0) bases / totalBases else 0f,
-        mean_coverage    = if (span > 0) bases / span.toDouble else 0f,
-        templates        = templateCounter.countOf(name),
-        unique_templates = uniqueTemplateCounter.countOf(name)
+        name              = name,
+        bases             = bases,
+        unique_bases      = uniqueBaseCounter.countOf(name),
+        span              = span,
+        frac_genome       = span / dict.length.toDouble,
+        frac_total_bases  = if (totalBases > 0) bases / totalBases else 0f,
+        mean_coverage     = if (span > 0) bases / span.toDouble else 0f,
+        templates         = templateCounter.countOf(name),
+        unique_templates  = uniqueTemplateCounter.countOf(name)
       )
     }.toSeq.sortBy(_.name)
     Metric.write(this.output, metrics)
@@ -170,7 +194,7 @@ class AnnotateByIntervalList
         val intervals = inputIntervalList.map { i =>
           val name = i.getName match {
             case regex(n) => n
-            case _        => throw new IllegalArgumentException(s"Could not match name '${i.getName}' with regex '${this.nameRegex}'")
+            case _ => throw new IllegalArgumentException(s"Could not match name '${i.getName}' with regex '${this.nameRegex}'")
           }
           new Interval(i.getContig, i.getStart, i.getEnd, i.isNegativeStrand, name)
         }.toJavaList
@@ -183,15 +207,18 @@ class AnnotateByIntervalList
 
 /** Metric for [[AnnotateByIntervalList]].
   *
-  * @param name the name of the intervals
-  * @param bases the number of bases mapping to intervals with the given name.
-  * @param span the number of unique genomic loci/bases coverage by intervals with the given name.
-  * @param frac_genome the fraction of unique genomic loci/bases coverage by intervals with the given name.
+  * @param name             the name of the intervals
+  * @param bases            the number of bases mapping to intervals with the given name.
+  * @param unique_bases     the number of bases mapping exclusively to intervals with the given name,
+  * @param span             the number of unique genomic loci/bases coverage by intervals with the given name.
+  * @param frac_genome      the fraction of unique genomic loci/bases coverage by intervals with the given name.
   * @param frac_total_bases the fraction of mapped bases covered by intervals with the given name.
-  * @param mean_coverage the mean coverage of intervals with the given name.
+  * @param mean_coverage    the mean coverage of intervals with the given name.
+  * @param templates        the number of templates mapping to the intervals with the given name
+  * @param unique_templates the number of templates mapping exclusively to the intervals with the given name
   */
-case class CoverageByIntervalMetrics
-( name: String,
+case class CoverageByIntervalMetrics(
+  name: String,
   unique_bases: Long,
   bases: Long,
   span: Long,
@@ -202,9 +229,17 @@ case class CoverageByIntervalMetrics
   unique_templates: Long
 ) extends Metric
 
+/**
+  * Enum for determining how to associate a read that is enclosed in more than a single interval.
+  * - Duplicate counting associates the template base with all enclosing intervals.
+  * - MostSpecific counting associates the template bases with the smallest enclosing interval.
+  * - LeastSpecific counting associates the template bases with the largest enclosing interval.
+  */
 sealed trait OverlapAssociationStrategy extends EnumEntry
+
 object OverlapAssociationStrategy extends FgBioEnum[OverlapAssociationStrategy] {
   def values: IndexedSeq[OverlapAssociationStrategy] = findValues
+
   case object Duplicate extends OverlapAssociationStrategy
   case object MostSpecific extends OverlapAssociationStrategy
   case object LeastSpecific extends OverlapAssociationStrategy

--- a/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
+++ b/src/main/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalList.scala
@@ -195,7 +195,7 @@ class AnnotateByIntervalList
         val intervals = inputIntervalList.map { i =>
           val name = i.getName match {
             case regex(n) => n
-            case _ => throw new IllegalArgumentException(s"Could not match name '${i.getName}' with regex '${this.nameRegex}'")
+            case _        => throw new IllegalArgumentException(s"Could not match name '${i.getName}' with regex '${this.nameRegex}'")
           }
           new Interval(i.getContig, i.getStart, i.getEnd, i.isNegativeStrand, name)
         }.toJavaList

--- a/src/main/scala/com/fulcrumgenomics/util/AssignPrimers.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/AssignPrimers.scala
@@ -220,7 +220,8 @@ class AmpliconLabeller(val amplicons: Iterator[Amplicon] = Iterator.empty,
   }
 }
 
-/**
+/** Metrics produced by `AssignPrimers` that detail how many reads were assigned to a given primer and/or amplicon.
+  *
   * @param identifier the amplicon identifier this metric collects over
   * @param left the number of reads assigned to the left primer
   * @param right the number of reads assigned to the right primer

--- a/src/test/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalListTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalListTest.scala
@@ -1,0 +1,26 @@
+package com.fulcrumgenomics.rnaseq
+
+import java.nio.file.Files
+
+import com.fulcrumgenomics.commons.CommonsDef.{FilePath, PathPrefix}
+import com.fulcrumgenomics.commons.io.{Io, PathUtil}
+import com.fulcrumgenomics.commons.util.DelimitedDataParser
+import com.fulcrumgenomics.testing.{SamBuilder, UnitSpec}
+import com.fulcrumgenomics.util.Metric
+import htsjdk.samtools.{SAMSequenceDictionary, SAMSequenceRecord}
+import org.scalatest.OptionValues
+
+import scala.io.Source
+
+class AnnotateIntervalListTest extends UnitSpec with OptionValues {
+  private def emtpyIntervalList(): IntervalList = {
+    val header = new SAMFileHeader
+    header.setSequenceDictionary(this.dict)
+    new IntervalList(header)
+  }
+
+  "AnnotateIntervalList" should "annotate reads with annotations from and interval list" in {
+
+  }
+
+}

--- a/src/test/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalListTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalListTest.scala
@@ -1,3 +1,26 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2020 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.fulcrumgenomics.rnaseq
 
 import com.fulcrumgenomics.fasta.Converters.FromSAMSequenceDictionary
@@ -33,7 +56,7 @@ class AnnotateByIntervalListTest extends UnitSpec with ErrorLogLevel with Option
     new AnnotateByIntervalList(builder.toTempFile(), intervalPath, tmpOutput).execute()
 
     val metrics = Metric.read[CoverageByIntervalMetrics](tmpOutput)
-    metrics.filter(_.name == "interval1").head.bases shouldBe 150
+    metrics.filter(_.name == "interval1").head.bases shouldBe 100
   }
 
   "AnnotateByIntervalList" should "not associate template bases if the template is not fully enclosed in an interval" in {
@@ -66,7 +89,7 @@ class AnnotateByIntervalListTest extends UnitSpec with ErrorLogLevel with Option
     new AnnotateByIntervalList(builder.toTempFile(), intervalPath, tmpOutput, nameRegex = Some("(^interval.).*")).execute()
 
     val metrics = Metric.read[CoverageByIntervalMetrics](tmpOutput)
-    metrics.filter(_.name == "interval1").head.bases shouldBe 150
+    metrics.filter(_.name == "interval1").head.bases shouldBe 100
     metrics.filter(_.name == "interval2").head.bases shouldBe 0
   }
 
@@ -84,9 +107,9 @@ class AnnotateByIntervalListTest extends UnitSpec with ErrorLogLevel with Option
     new AnnotateByIntervalList(builder.toTempFile(), intervalPath, tmpOutput, nameRegex = Some("(^interval.).*")).execute()
 
     val metrics = Metric.read[CoverageByIntervalMetrics](tmpOutput)
-    metrics.filter(_.name == "interval1").head.bases shouldBe 150
+    metrics.filter(_.name == "interval1").head.bases shouldBe 100
     metrics.filter(_.name == "interval1").head.unique_bases shouldBe 0
-    metrics.filter(_.name == "interval2").head.bases shouldBe 150
+    metrics.filter(_.name == "interval2").head.bases shouldBe 100
     metrics.filter(_.name == "interval2").head.unique_bases shouldBe 0
   }
 
@@ -107,8 +130,8 @@ class AnnotateByIntervalListTest extends UnitSpec with ErrorLogLevel with Option
     val metrics = Metric.read[CoverageByIntervalMetrics](tmpOutput)
     metrics.filter(_.name == "interval1").head.bases shouldBe 0
     metrics.filter(_.name == "interval1").head.unique_bases shouldBe 0
-    metrics.filter(_.name == "interval2").head.bases shouldBe 150
-    metrics.filter(_.name == "interval2").head.unique_bases shouldBe 150
+    metrics.filter(_.name == "interval2").head.bases shouldBe 100
+    metrics.filter(_.name == "interval2").head.unique_bases shouldBe 100
   }
 
   "AnnotateByIntervalList" should "associate bases with the largest interval (least specific counts)" in {
@@ -126,7 +149,7 @@ class AnnotateByIntervalListTest extends UnitSpec with ErrorLogLevel with Option
       overlapAssociationStrategy = OverlapAssociationStrategy.LeastSpecific).execute()
 
     val metrics = Metric.read[CoverageByIntervalMetrics](tmpOutput)
-    metrics.filter(_.name == "interval1").head.bases shouldBe 150
+    metrics.filter(_.name == "interval1").head.bases shouldBe 100
     metrics.filter(_.name == "interval2").head.bases shouldBe 0
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalListTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalListTest.scala
@@ -86,7 +86,9 @@ class AnnotateByIntervalListTest extends UnitSpec with ErrorLogLevel with Option
 
     val metrics = Metric.read[CoverageByIntervalMetrics](tmpOutput)
     metrics.filter(_.name == "interval1").head.bases shouldBe 150
+    metrics.filter(_.name == "interval1").head.unique_bases shouldBe 0
     metrics.filter(_.name == "interval2").head.bases shouldBe 150
+    metrics.filter(_.name == "interval2").head.unique_bases shouldBe 0
   }
 
   "AnnotateByIntervalList" should "associate bases with the smallest interval (most specific counts)" in {
@@ -105,7 +107,9 @@ class AnnotateByIntervalListTest extends UnitSpec with ErrorLogLevel with Option
 
     val metrics = Metric.read[CoverageByIntervalMetrics](tmpOutput)
     metrics.filter(_.name == "interval1").head.bases shouldBe 0
+    metrics.filter(_.name == "interval1").head.unique_bases shouldBe 0
     metrics.filter(_.name == "interval2").head.bases shouldBe 150
+    metrics.filter(_.name == "interval2").head.unique_bases shouldBe 150
   }
 
   "AnnotateByIntervalList" should "associate bases with the largest interval (least specific counts)" in {

--- a/src/test/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalListTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalListTest.scala
@@ -1,26 +1,107 @@
 package com.fulcrumgenomics.rnaseq
 
-import java.nio.file.Files
-
-import com.fulcrumgenomics.commons.CommonsDef.{FilePath, PathPrefix}
-import com.fulcrumgenomics.commons.io.{Io, PathUtil}
-import com.fulcrumgenomics.commons.util.DelimitedDataParser
-import com.fulcrumgenomics.testing.{SamBuilder, UnitSpec}
-import com.fulcrumgenomics.util.Metric
-import htsjdk.samtools.{SAMSequenceDictionary, SAMSequenceRecord}
+import com.fulcrumgenomics.fasta.Converters.FromSAMSequenceDictionary
+import com.fulcrumgenomics.testing.{ErrorLogLevel, ReferenceSetBuilder, SamBuilder, UnitSpec}
+import com.fulcrumgenomics.util.{IntervalListWriter, Metric}
+import htsjdk.samtools.SAMSequenceDictionary
+import htsjdk.samtools.reference.ReferenceSequenceFileFactory
+import htsjdk.samtools.util.Interval
+import org.scalatest.Matchers.convertToAnyShouldWrapper
 import org.scalatest.OptionValues
 
-import scala.io.Source
+class AnnotateByIntervalListTest extends UnitSpec with ErrorLogLevel with OptionValues {
+  private val (ref, refPath) = {
+    val builder = new ReferenceSetBuilder
+    builder.add("chr1").add("AAAAAAAAAA", 50) // 500 bases
+    builder.add("chr2").add("CCCCCCCCCC", 50) // 500 bases
 
-class AnnotateIntervalListTest extends UnitSpec with OptionValues {
-  private def emtpyIntervalList(): IntervalList = {
-    val header = new SAMFileHeader
-    header.setSequenceDictionary(this.dict)
-    new IntervalList(header)
+    val refPath = builder.toTempFile()
+    val ref = ReferenceSequenceFileFactory.getReferenceSequenceFile(refPath)
+    (ref, refPath)
   }
 
-  "AnnotateIntervalList" should "annotate reads with annotations from and interval list" in {
+  val dict: SAMSequenceDictionary = ref.getSequenceDictionary
 
+  "AnnotateByIntervalList" should "associate template bases with interval if read one overlaps a single interval" in {
+    val builder = new SamBuilder(readLength=50, sd=Some(dict.fromSam))
+    val intervalPath = makeTempFile("annotatebyinterval", "interval_list")
+    val tmpOutput = makeTempFile("annotatebyinterval_metrics", "txt")
+    val writer = IntervalListWriter(intervalPath, dict.fromSam)
+
+    writer += new Interval("chr1", 1, 150, false, "interval1")
+    writer.close()
+
+    builder.addPair("single", start1 = 50, start2 = 250)
+    new AnnotateByIntervalList(builder.toTempFile(), intervalPath, tmpOutput).execute()
+
+    val metrics = Metric.read[CoverageByIntervalMetrics](tmpOutput)
+    metrics.filter(_.name == "interval1").head.bases shouldBe 50
   }
 
+  "AnnotateByIntervalList" should "associate template bases with interval if read two overlaps a single interval" in {
+    val builder = new SamBuilder(readLength=50, sd=Some(dict.fromSam))
+    val intervalPath = makeTempFile("annotatebyinterval", "interval_list")
+    val tmpOutput = makeTempFile("annotatebyinterval_metrics", "txt")
+    val writer = IntervalListWriter(intervalPath, dict.fromSam)
+
+    writer += new Interval("chr1", 200, 350, false, "interval1")
+    writer.close()
+
+    builder.addPair("single", start1 = 50, start2 = 250)
+    new AnnotateByIntervalList(builder.toTempFile(), intervalPath, tmpOutput).execute()
+
+    val metrics = Metric.read[CoverageByIntervalMetrics](tmpOutput)
+    metrics.filter(_.name == "interval1").head.bases shouldBe 50
+  }
+
+  "AnnotateByIntervalList" should "associate template bases with interval if both reads overlap a single interval" in {
+    val builder = new SamBuilder(readLength=50, sd=Some(dict.fromSam))
+    val intervalPath = makeTempFile("annotatebyinterval", "interval_list")
+    val tmpOutput = makeTempFile("annotatebyinterval_metrics", "txt")
+    val writer = IntervalListWriter(intervalPath, dict.fromSam)
+
+    writer += new Interval("chr1", 1, 350, false, "interval1")
+    writer.close()
+
+    builder.addPair("single", start1 = 50, start2 = 250)
+    new AnnotateByIntervalList(builder.toTempFile(), intervalPath, tmpOutput).execute()
+
+    val metrics = Metric.read[CoverageByIntervalMetrics](tmpOutput)
+    metrics.filter(_.name == "interval1").head.bases shouldBe 100
+  }
+
+  "AnnotateByIntervalList" should "associate partial template bases with interval when part of a read overlaps" in {
+    val builder = new SamBuilder(readLength=50, sd=Some(dict.fromSam))
+    val intervalPath = makeTempFile("annotatebyinterval", "interval_list")
+    val tmpOutput = makeTempFile("annotatebyinterval_metrics", "txt")
+    val writer = IntervalListWriter(intervalPath, dict.fromSam)
+
+    writer += new Interval("chr1", 76, 275, false, "interval1")
+    writer.close()
+
+    builder.addPair("single", start1 = 50, start2 = 250)
+    new AnnotateByIntervalList(builder.toTempFile(), intervalPath, tmpOutput).execute()
+
+    val metrics = Metric.read[CoverageByIntervalMetrics](tmpOutput)
+    // 25 from read one 25 from read two
+    metrics.filter(_.name == "interval1").head.bases shouldBe 50
+  }
+
+  "AnnotateByIntervalList" should "associate bases with abutting intervals" in {
+    val builder = new SamBuilder(readLength=50, sd=Some(dict.fromSam))
+    val intervalPath = makeTempFile("annotatebyinterval", "interval_list")
+    val tmpOutput = makeTempFile("annotatebyinterval_metrics", "txt")
+    val writer = IntervalListWriter(intervalPath, dict.fromSam)
+
+    writer += new Interval("chr1", 1, 76, false, "interval1")
+    writer += new Interval("chr1", 77, 100, false, "interval2")
+    writer.close()
+
+    builder.addPair("single", start1 = 50, start2 = 250)
+    new AnnotateByIntervalList(builder.toTempFile(), intervalPath, tmpOutput).execute()
+
+    val metrics = Metric.read[CoverageByIntervalMetrics](tmpOutput)
+    // 25 from read one 25 from read two
+    metrics.filter(_.name == "interval1").head.bases shouldBe 50
+  }
 }

--- a/src/test/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalListTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/rnaseq/AnnotateByIntervalListTest.scala
@@ -9,23 +9,22 @@ import htsjdk.samtools.util.Interval
 import org.scalatest.OptionValues
 
 class AnnotateByIntervalListTest extends UnitSpec with ErrorLogLevel with OptionValues {
-  private val (ref, refPath) = {
+  private val ref = {
     val builder = new ReferenceSetBuilder
     builder.add("chr1").add("AAAAAAAAAA", 50) // 500 bases
     builder.add("chr2").add("CCCCCCCCCC", 50) // 500 bases
 
-    val refPath = builder.toTempFile()
-    val ref = ReferenceSequenceFileFactory.getReferenceSequenceFile(refPath)
-    (ref, refPath)
+    val ref     = ReferenceSequenceFileFactory.getReferenceSequenceFile(builder.toTempFile())
+    ref
   }
 
   val dict: SAMSequenceDictionary = ref.getSequenceDictionary
 
   "AnnotateByIntervalList" should "associate template bases if the template is enclosed in an interval" in {
-    val builder = new SamBuilder(readLength=50, sd=Some(dict.fromSam))
-    val intervalPath = makeTempFile("annotatebyinterval", "interval_list")
-    val tmpOutput = makeTempFile("annotatebyinterval_metrics", "txt")
-    val writer = IntervalListWriter(intervalPath, dict.fromSam)
+    val builder       = new SamBuilder(readLength=50, sd=Some(dict.fromSam))
+    val intervalPath  = makeTempFile("annotatebyinterval", "interval_list")
+    val tmpOutput     = makeTempFile("annotatebyinterval_metrics", "txt")
+    val writer        = IntervalListWriter(intervalPath, dict.fromSam)
 
     writer += new Interval("chr1", 1, 350, false, "interval1")
     writer.close()
@@ -38,10 +37,10 @@ class AnnotateByIntervalListTest extends UnitSpec with ErrorLogLevel with Option
   }
 
   "AnnotateByIntervalList" should "not associate template bases if the template is not fully enclosed in an interval" in {
-    val builder = new SamBuilder(readLength=50, sd=Some(dict.fromSam))
-    val intervalPath = makeTempFile("annotatebyinterval", "interval_list")
-    val tmpOutput = makeTempFile("annotatebyinterval_metrics", "txt")
-    val writer = IntervalListWriter(intervalPath, dict.fromSam)
+    val builder       = new SamBuilder(readLength=50, sd=Some(dict.fromSam))
+    val intervalPath  = makeTempFile("annotatebyinterval", "interval_list")
+    val tmpOutput     = makeTempFile("annotatebyinterval_metrics", "txt")
+    val writer        = IntervalListWriter(intervalPath, dict.fromSam)
 
     writer += new Interval("chr1", 1, 200, false, "interval1")
     writer.close()
@@ -54,10 +53,10 @@ class AnnotateByIntervalListTest extends UnitSpec with ErrorLogLevel with Option
   }
 
   "AnnotateByIntervalList" should "associate bases with only enclosing intervals" in {
-    val builder = new SamBuilder(readLength=50, sd=Some(dict.fromSam))
-    val intervalPath = makeTempFile("annotatebyinterval", "interval_list")
-    val tmpOutput = makeTempFile("annotatebyinterval_metrics", "txt")
-    val writer = IntervalListWriter(intervalPath, dict.fromSam)
+    val builder       = new SamBuilder(readLength=50, sd=Some(dict.fromSam))
+    val intervalPath  = makeTempFile("annotatebyinterval", "interval_list")
+    val tmpOutput     = makeTempFile("annotatebyinterval_metrics", "txt")
+    val writer        = IntervalListWriter(intervalPath, dict.fromSam)
 
     writer += new Interval("chr1", 1, 500, false, "interval1")
     writer += new Interval("chr1", 152, 300, false, "interval2")
@@ -72,10 +71,10 @@ class AnnotateByIntervalListTest extends UnitSpec with ErrorLogLevel with Option
   }
 
   "AnnotateByIntervalList" should "associate bases with all enclosing intervals (duplicate counts)" in {
-    val builder = new SamBuilder(readLength=50, sd=Some(dict.fromSam))
-    val intervalPath = makeTempFile("annotatebyinterval", "interval_list")
-    val tmpOutput = makeTempFile("annotatebyinterval_metrics", "txt")
-    val writer = IntervalListWriter(intervalPath, dict.fromSam)
+    val builder       = new SamBuilder(readLength=50, sd=Some(dict.fromSam))
+    val intervalPath  = makeTempFile("annotatebyinterval", "interval_list")
+    val tmpOutput     = makeTempFile("annotatebyinterval_metrics", "txt")
+    val writer        = IntervalListWriter(intervalPath, dict.fromSam)
 
     writer += new Interval("chr1", 1, 500, false, "interval1")
     writer += new Interval("chr1", 10, 490, false, "interval2")
@@ -92,10 +91,10 @@ class AnnotateByIntervalListTest extends UnitSpec with ErrorLogLevel with Option
   }
 
   "AnnotateByIntervalList" should "associate bases with the smallest interval (most specific counts)" in {
-    val builder = new SamBuilder(readLength=50, sd=Some(dict.fromSam))
-    val intervalPath = makeTempFile("annotatebyinterval", "interval_list")
-    val tmpOutput = makeTempFile("annotatebyinterval_metrics", "txt")
-    val writer = IntervalListWriter(intervalPath, dict.fromSam)
+    val builder       = new SamBuilder(readLength=50, sd=Some(dict.fromSam))
+    val intervalPath  = makeTempFile("annotatebyinterval", "interval_list")
+    val tmpOutput     = makeTempFile("annotatebyinterval_metrics", "txt")
+    val writer        = IntervalListWriter(intervalPath, dict.fromSam)
 
     writer += new Interval("chr1", 1, 500, false, "interval1")
     writer += new Interval("chr1", 10, 490, false, "interval2")
@@ -113,10 +112,10 @@ class AnnotateByIntervalListTest extends UnitSpec with ErrorLogLevel with Option
   }
 
   "AnnotateByIntervalList" should "associate bases with the largest interval (least specific counts)" in {
-    val builder = new SamBuilder(readLength=50, sd=Some(dict.fromSam))
-    val intervalPath = makeTempFile("annotatebyinterval", "interval_list")
-    val tmpOutput = makeTempFile("annotatebyinterval_metrics", "txt")
-    val writer = IntervalListWriter(intervalPath, dict.fromSam)
+    val builder       = new SamBuilder(readLength=50, sd=Some(dict.fromSam))
+    val intervalPath  = makeTempFile("annotatebyinterval", "interval_list")
+    val tmpOutput     = makeTempFile("annotatebyinterval_metrics", "txt")
+    val writer        = IntervalListWriter(intervalPath, dict.fromSam)
 
     writer += new Interval("chr1", 1, 500, false, "interval1")
     writer += new Interval("chr1", 10, 490, false, "interval2")


### PR DESCRIPTION
Currently this expects single ended reads or paired end template reads to be full enclosed within an interval by name in order for it to be counted for that interval.