### PR TITLE
Update EstimatePoolingFractions to be able to use GT.AF for per-sample allele frequencies

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/bam/EstimatePoolingFractions.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/EstimatePoolingFractions.scala
@@ -46,9 +46,9 @@ import org.apache.commons.math3.stat.regression.OLSMultipleLinearRegression
     |for the alternative allele fractions at each SNP locus, using as inputs the individual sample's genotypes.
     |Only SNPs that are bi-allelic within the pooled samples are used.
     |
-    |Each sample's contribution of REF vs. ALT alleles at each site is derived in one of two ways. If
-    |the sample's genotype in the VCF has the `AF` attribute then the value from that field will be used.  If the
-    |genotype has no AF attribute then the contribution is estimated based on the genotype (e.g. 0/0 will be 100%
+    |Each sample's contribution of REF vs. ALT alleles at each site is derived in one of two ways: (1) if
+    |the sample's genotype in the VCF has the `AF` attribute then the value from that field will be used, (2) if the
+    |genotype has no `AF` attribute then the contribution is estimated based on the genotype (e.g. 0/0 will be 100%
     |ref, 0/1 will be 50% ref and 50% alt, etc.).
     |
     |Various filtering parameters can be used to control which loci are used:

--- a/src/test/scala/com/fulcrumgenomics/bam/EstimatePoolingFractionsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/EstimatePoolingFractionsTest.scala
@@ -25,11 +25,12 @@
 package com.fulcrumgenomics.bam
 
 import java.nio.file.Paths
-
 import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.bam.api.{SamRecord, SamSource, SamWriter}
 import com.fulcrumgenomics.testing.UnitSpec
 import com.fulcrumgenomics.util.Metric
+import com.fulcrumgenomics.vcf.api
+import com.fulcrumgenomics.vcf.api.{Genotype, VcfCount, VcfFieldType, VcfFormatHeader, VcfSource, VcfWriter}
 import htsjdk.samtools.SAMFileHeader.SortOrder
 import htsjdk.samtools.{MergingSamRecordIterator, SamFileHeaderMerger}
 import org.scalatest.ParallelTestExecution
@@ -103,6 +104,65 @@ class EstimatePoolingFractionsTest extends UnitSpec with ParallelTestExecution {
     metrics should have size 2
     metrics.foreach {m =>
       val expected = if (m.sample == samples.head) 0.75 else 0.25
+      expected should (be >= m.ci99_low and be <= m.ci99_high)
+    }
+  }
+
+  it should "accurately estimate a three sample mixture using the AF genotype field" in {
+    val samples         = Samples.take(3)
+    val Seq(s1, s2, s3) = samples
+    val bams            = Bams.take(3)
+    val bam             = merge(bams)
+
+    val vcf = {
+      val vcf = makeTempFile("mixture.", ".vcf.gz")
+      val in  = api.VcfSource(Vcf)
+      val hd  = in.header.copy(
+        samples = IndexedSeq(s1, "two_sample_mixture"),
+        formats = VcfFormatHeader("AF", VcfCount.OnePerAltAllele, kind=VcfFieldType.Float, description="Allele Frequency") +: in.header.formats
+      )
+      val out = VcfWriter(vcf, hd)
+
+      in.filter(_.alleles.size == 2).foreach { v =>
+        val gts = samples.map(v.gt)
+
+        // Only bother with sites where all samples have called genotypes and there is variation
+        if (gts.forall((_.isFullyCalled)) && gts.flatMap(_.calls).toSet.size > 1) {
+          // Make a mixture of the 2nd and 3rd samples
+          val (mixCalls, mixAf) = {
+            val input = gts.drop(1)
+            if      (input.forall(_.isHomRef)) (IndexedSeq(v.alleles.ref, v.alleles.ref), 0.0)
+            else if (input.forall(_.isHomVar)) (IndexedSeq(v.alleles.alts.head, v.alleles.alts.head), 1.0)
+            else {
+              val calls = input.flatMap(_.calls)
+              (IndexedSeq(v.alleles.ref, v.alleles.alts.head), calls.count(_ != v.alleles.ref) / calls.size.toDouble)
+            }
+          }
+
+          val mixtureGt = Genotype(
+            alleles = v.alleles,
+            sample  = "two_sample_mixture",
+            calls   = mixCalls,
+            attrs   = Map("AF" -> IndexedSeq[Float](mixAf.toFloat))
+          )
+
+          out += v.copy(genotypes=Map(s1 -> gts.head, mixtureGt.sample -> mixtureGt))
+        }
+      }
+
+      in.safelyClose()
+      out.close()
+      vcf
+    }
+
+    // Run the estimator and test the outputs
+    val out = makeTempFile("pooling_metrics.", ".txt")
+    new EstimatePoolingFractions(vcf=vcf, bam=bam, output=out, minGenotypeQuality = -1).execute()
+    val metrics = Metric.read[PoolingFractionMetric](out)
+
+    metrics should have size 2
+    metrics.foreach {m =>
+      val expected = if (m.sample == samples.head) 1/3.0 else 2/3.0
       expected should (be >= m.ci99_low and be <= m.ci99_high)
     }
   }

--- a/src/test/scala/com/fulcrumgenomics/bam/EstimatePoolingFractionsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/EstimatePoolingFractionsTest.scala
@@ -34,8 +34,6 @@ import htsjdk.samtools.SAMFileHeader.SortOrder
 import htsjdk.samtools.{MergingSamRecordIterator, SamFileHeaderMerger}
 import org.scalatest.ParallelTestExecution
 
-import scala.collection.JavaConverters._
-
 class EstimatePoolingFractionsTest extends UnitSpec with ParallelTestExecution {
   private val Samples = Seq("HG01879", "HG01112", "HG01583", "HG01500", "HG03742", "HG03052")
   private val DataDir = Paths.get("src/test/resources/com/fulcrumgenomics/bam/estimate_pooling_fractions")


### PR DESCRIPTION
EstimatePoolingFractions is used when we do mixture experiments (i.e. mixing some number of samples), using known genotypes to accurately estimate the pooling of the samples (i.e. what fraction of the pool does each sample represent).  Up until this PR the assumption was that input samples were simple diploid germline samples, and so when performing the regression we estimate the fraction of each sample that is ALT at any SNP by a simple: homref -> 0, het -> 0.5, homvar -> 1.

What this change does is switches to use the per-sample `AF` field _if_ it is available.  If `AF` is not present for any given sample it will fall back to using the 0/0.5/1 system.  The motivation for this is to allow multi-level pooling using `EstimatePoolingFractions` and `MakeMixtureVcf`.  E.g. imagine a case where you mixed 10 samples equally into _Pool A_ and then 2 samples equally into _Pool B_, and then made a final pool of 95% _Pool B_ with only 5% _Pool A_.  In theory you could run `EstimatePoolingFractions` and feed it all twelve input samples and if you have deep enough coverage of enough SNPs it would do the right thing.  However given the very uneven target pooling, with less than ideal sequencing, it is very hard to accurately estimate the constituents of _Pool A_ in the final pool.  What this allows for is an experiment where you also sequence _Pool A_ and _Pool B_ in addition to the final pool, you can now:

1. EstimatePoolingFractions on _Pool A_ and _Pool B_
2. Use the resulting estimates to make mixture VCFs using `MakeMixtureVcf` which populates the `GT.AF` field
3. Run EstimatePoolingFractions on the final pool treating it as a mixture of the _Pool A_ and _Pool B_ mixtures.