### PR TITLE
Add support for read groups in EstimatePoolingFractions

### DIFF
--- a/src/test/scala/com/fulcrumgenomics/bam/EstimatePoolingFractionsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/EstimatePoolingFractionsTest.scala
@@ -103,7 +103,7 @@ class EstimatePoolingFractionsTest extends UnitSpec with ParallelTestExecution {
     val metrics = Metric.read[PoolingFractionMetric](out)
     metrics should have size 2
     metrics.foreach {m =>
-      val expected = if (m.sample == samples.head) 0.75 else 0.25
+      val expected = if (m.pool_sample == samples.head) 0.75 else 0.25
       expected should (be >= m.ci99_low and be <= m.ci99_high)
     }
   }
@@ -162,7 +162,7 @@ class EstimatePoolingFractionsTest extends UnitSpec with ParallelTestExecution {
 
     metrics should have size 2
     metrics.foreach {m =>
-      val expected = if (m.sample == samples.head) 1/3.0 else 2/3.0
+      val expected = if (m.pool_sample == samples.head) 1/3.0 else 2/3.0
       expected should (be >= m.ci99_low and be <= m.ci99_high)
     }
   }


### PR DESCRIPTION
The `--by-sample` argument will now group input reads by their sample
name specified in their corresponding read group.  In this case, reads
without a read group are ignored, and read groups with the same sample
are jointly estimated.