### PR TITLE
Document that sequence dictionary converts are computationally expensive, and add a cache

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/fasta/SequenceDictionary.scala
+++ b/src/main/scala/com/fulcrumgenomics/fasta/SequenceDictionary.scala
@@ -272,10 +272,16 @@ case class SequenceDictionary(infos: IndexedSeq[SequenceMetadata]) extends Itera
 }
 
 
-/** Contains useful converters to and from HTSJDK objects. */
+/** Contains useful converters to and from HTSJDK objects.
+  *
+  * These converters are computationally expensive, so it is best to only use them once when converting a sequence
+  * dictionary or sequence record.
+  *
+  *
+  * */
 object Converters {
 
-  /** Converter from a [[SequenceMetadata]] to a [[SAMSequenceRecord]] */
+  /** Converter from a [[SequenceMetadata]] to a [[SAMSequenceRecord]].  Warning: this is computationally expensive. */
   implicit class ToSAMSequenceRecord(info: SequenceMetadata) {
     def asSam: SAMSequenceRecord = {
       val rec = new SAMSequenceRecord(info.name, info.length)
@@ -285,7 +291,7 @@ object Converters {
     }
   }
 
-  /** Converter from a [[SAMSequenceRecord]] to a [[SequenceMetadata]] */
+  /** Converter from a [[SAMSequenceRecord]] to a [[SequenceMetadata]].  Warning: this is computationally expensive. */
   implicit class FromSAMSequenceRecord(rec: SAMSequenceRecord) {
     def fromSam: SequenceMetadata = {
       val attributes: Map[String, String] = rec.getAttributes.map { entry =>
@@ -300,7 +306,7 @@ object Converters {
     }
   }
 
-  /** Converter from a [[SequenceDictionary]] to a [[SAMSequenceDictionary]] */
+  /** Converter from a [[SequenceDictionary]] to a [[SAMSequenceDictionary]].  Warning: this is computationally expensive. */
   implicit class ToSAMSequenceDictionary(infos: SequenceDictionary) {
     def asSam: SAMSequenceDictionary = {
       val recs = infos.iterator.zipWithIndex.map { case (info, index) =>
@@ -310,7 +316,7 @@ object Converters {
     }
   }
 
-  /** Converter from a [[SAMSequenceDictionary]] to a [[SequenceDictionary]] */
+  /** Converter from a [[SAMSequenceDictionary]] to a [[SequenceDictionary]].  Warning: this is computationally expensive. */
   implicit class FromSAMSequenceDictionary(dict: SAMSequenceDictionary) {
     def fromSam: SequenceDictionary = SequenceDictionary(dict.getSequences.map(_.fromSam).toIndexedSeq)
   }


### PR DESCRIPTION
CC: @mjhipp https://github.com/fulcrumgenomics/fgbio/issues/579#issuecomment-754228920

This PR has two commits for consideration:
1. document that repeatedly converting sequence dictionaries using the provided implicits is expensive
2. add a cache so that "it just works" for anybody using the implicits.  This is so that anybody that converts over to the new `SequenceDictionary` class and friends don't experience the same pain as @mjhipp 

100 iterations on hs38DH

```
[2021/01/04 15:40:10 | FgBioMain | Info] Executing DictLoop from fgbio version 1.4.0-22b0efc-SNAPSHOT as nhomer@nils-fg.local on JRE 1.8.0_212-b10 with snappy, JdkInflater, and JdkDeflater
[2021/01/04 15:40:11 | DictLoop | Info] -----------------------------------------------------------------------------
[2021/01/04 15:40:11 | DictLoop | Info] Accessing SAMSequenceDictionary 100 times WITHOUT conversion step.
[2021/01/04 15:40:11 | DictLoop | Info] Elapsed time: 1.690521 ms.
[2021/01/04 15:40:11 | DictLoop | Info] -----------------------------------------------------------------------------
[2021/01/04 15:40:11 | DictLoop | Info] Accessing fasta.SequenceDictionary 100 times WITHOUT conversion step.
[2021/01/04 15:40:11 | DictLoop | Info] Elapsed time: 0.413097 ms.
[2021/01/04 15:40:11 | DictLoop | Info] -----------------------------------------------------------------------------
[2021/01/04 15:40:11 | DictLoop | Info] Accessing SAMSequenceDictionary 100 times with asSam conversion step.
[2021/01/04 15:40:11 | DictLoop | Info] Elapsed time: 39.607902 ms.
[2021/01/04 15:40:11 | DictLoop | Info] -----------------------------------------------------------------------------
[2021/01/04 15:40:11 | DictLoop | Info] Accessing fasta.SequenceDictionary 100 times with fromSam conversion step.
[2021/01/04 15:40:11 | DictLoop | Info] Elapsed time: 12.715213 ms.
[2021/01/04 15:40:11 | DictLoop | Info] -----------------------------------------------------------------------------
[2021/01/04 15:40:11 | FgBioMain | Info] DictLoop completed. Elapsed time: 0.03 minutes.
```

100,000 iterations on hs38DH:



```
[2021/01/04 15:37:14 | FgBioMain | Info] Executing DictLoop from fgbio version 1.4.0-22b0efc-SNAPSHOT as nhomer@nils-fg.local on JRE 1.8.0_212-b10 with snappy, JdkInflater, and JdkDeflater
[2021/01/04 15:37:14 | DictLoop | Info] -----------------------------------------------------------------------------
[2021/01/04 15:37:14 | DictLoop | Info] Accessing SAMSequenceDictionary 100000 times WITHOUT conversion step.
[2021/01/04 15:37:14 | DictLoop | Info] Elapsed time: 5.879807 ms.
[2021/01/04 15:37:14 | DictLoop | Info] -----------------------------------------------------------------------------
[2021/01/04 15:37:14 | DictLoop | Info] Accessing fasta.SequenceDictionary 100000 times WITHOUT conversion step.
[2021/01/04 15:37:14 | DictLoop | Info] Elapsed time: 3.194493 ms.
[2021/01/04 15:37:14 | DictLoop | Info] -----------------------------------------------------------------------------
[2021/01/04 15:37:14 | DictLoop | Info] Accessing SAMSequenceDictionary 100000 times with asSam conversion step.
[2021/01/04 15:37:14 | DictLoop | Info] Elapsed time: 44.157055 ms.
[2021/01/04 15:37:14 | DictLoop | Info] -----------------------------------------------------------------------------
[2021/01/04 15:37:14 | DictLoop | Info] Accessing fasta.SequenceDictionary 100000 times with fromSam conversion step.
[2021/01/04 15:37:16 | DictLoop | Info] Elapsed time: 1841.079818 ms.
[2021/01/04 15:37:16 | DictLoop | Info] -----------------------------------------------------------------------------
[2021/01/04 15:37:16 | FgBioMain | Info] DictLoop completed. Elapsed time: 0.06 minutes.
```