### PR TITLE
Update r-packages-source in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ cache:
 addons:
   apt:
     sources:
-      - r-packages-trusty
+      - r-packages-precise
     packages:
       - r-base
       - r-recommended


### PR DESCRIPTION
I noticed Travis builds were failing with a similar error that I have encountered in the past. This worked for me previously. 