### PR TITLE
Add source classes for BED and generic Interval types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ JeanLuc.iml
 target
 project/project
 .DS_Store
+out/
+*.iml

--- a/src/main/scala/com/fulcrumgenomics/util/BedSource.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/BedSource.scala
@@ -1,0 +1,116 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2021 Fulcrum Genomics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package com.fulcrumgenomics.util
+
+import com.fulcrumgenomics.commons.CommonsDef._
+import com.fulcrumgenomics.commons.collection.BetterBufferedIterator
+import com.fulcrumgenomics.fasta.SequenceDictionary
+import htsjdk.tribble.bed.BEDCodec.StartOffset
+import htsjdk.tribble.bed.{BEDCodec, BEDFeature}
+
+import java.io.{Closeable, File, InputStream}
+import scala.io.Source
+import scala.util.{Failure, Success, Try}
+
+/** A class for sourcing BED features from a stream of ASCII string data. */
+class BedSource private(
+  private val lines: Iterator[String],
+  private val sd: Option[SequenceDictionary] = None,
+  private val source: Option[{ def close(): Unit}] = None
+) extends Iterator[BEDFeature] with Closeable {
+
+  /** The underlying codec used to parse the lines of BED data. */
+  private val codec = new BEDCodec(StartOffset.ONE)
+
+  /** The current line count. */
+  private var lineNumber = 1L
+
+  /** The underlying buffered iterator of BED data. */
+  private val iter: BetterBufferedIterator[String] = lines match {
+    case iter: BetterBufferedIterator[String] => iter
+    case iter                                 => iter.bufferBetter
+  }
+
+  /** The header of this BED file. In most cases, the BED header is empty. */
+  val header: Seq[String] = {
+    val lines = iter.takeWhile(line => BedSource.HeaderPrefixes.exists(line.startsWith)).toIndexedSeq
+    lineNumber += lines.length
+    lines
+  }
+
+  /** The [[SequenceDictionary]] associated with the source. */
+  val dict: Option[SequenceDictionary] = sd
+
+  /** True if calling `next()` will yield another BED feature, false otherwise. */
+  override def hasNext: Boolean = iter.hasNext
+
+  /** Returns the next BED feature if available, or throws an exception if the feature is invalid or none is available. */
+  override def next(): BEDFeature = yieldAndThen(parse(iter.next()))(lineNumber += 1)
+
+  /** Parse a line of text and build a BED feature. */
+  private def parse(line: String): BEDFeature = {
+    val parsed  = codec.decode(line)
+    val feature = Option(parsed).getOrElse(throw new IllegalStateException(s"No BED feature could be built from line number: $lineNumber"))
+    Try(dict.foreach(_.validate(feature))) match {
+      case Success(())                          => feature
+      case Failure(e: NoSuchElementException)   => throw new NoSuchElementException(e.getMessage + s" Failed on line number: $lineNumber")
+      case Failure(e: IllegalArgumentException) => throw new IllegalArgumentException(e.getMessage + s" Failed on line number: $lineNumber")
+      case Failure(e: Throwable)                => throw new IllegalStateException(e.getMessage + s" Failed on line number: $lineNumber")
+    }
+  }
+
+  /** Closes the optional underlying handle. */
+  override def close(): Unit = this.source.foreach(_.close())
+}
+
+/** Companion object for [[BedSource]]. */
+object BedSource {
+
+  /** Common BED header line prefixes. */
+  val HeaderPrefixes: Seq[String] = Seq("#", "browser", "track")
+
+  /** Creates a new BED source from a sequence of lines. */
+  def apply(lines: Iterable[String], dict: Option[SequenceDictionary]): BedSource = new BedSource(lines.iterator, dict)
+
+  /** Creates a new BED source from an iterator of lines. */
+  def apply(lines: Iterator[String], dict: Option[SequenceDictionary]): BedSource = new BedSource(lines, dict)
+
+  /** Creates a new BED source from an input stream. */
+  def apply(stream: InputStream, dict: Option[SequenceDictionary]): BedSource = {
+    new BedSource(Source.fromInputStream(stream).getLines(), dict)
+  }
+
+  /** Creates a new BED source from a source. */
+  def apply(source: Source, dict: Option[SequenceDictionary]): BedSource = {
+    new BedSource(source.getLines(), dict, source = Some(source))
+  }
+
+  /** Creates a new BED source from a File. */
+  def apply(file: File, dict: Option[SequenceDictionary]): BedSource = apply(path=file.toPath, dict)
+
+  /** Creates a new BED source from a Path. */
+  def apply(path: PathToIntervals, dict: Option[SequenceDictionary]): BedSource = apply(Io.readLines(path), dict)
+}

--- a/src/main/scala/com/fulcrumgenomics/util/IntervalSource.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/IntervalSource.scala
@@ -1,0 +1,102 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2021 Fulcrum Genomics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package com.fulcrumgenomics.util
+
+import com.fulcrumgenomics.commons.CommonsDef._
+import com.fulcrumgenomics.commons.collection.BetterBufferedIterator
+import com.fulcrumgenomics.fasta.SequenceDictionary
+import com.fulcrumgenomics.util.IntervalListSource.{HeaderPrefix => IntervalListHeaderPrefix}
+import htsjdk.samtools.SAMFileHeader
+import htsjdk.samtools.util.Interval
+
+import java.io.{Closeable, File, InputStream}
+import scala.io.Source
+
+/** A class for sourcing intervals from a stream of data that could either be in BED or Interval List format. */
+class IntervalSource private(
+  private val lines: Iterator[String],
+  private val sd: Option[SequenceDictionary],
+  private val source: Option[{ def close(): Unit }] = None
+) extends Iterator[Interval] with Closeable {
+
+  /** The underlying buffered iterator of interval data. */
+  private val iter: BetterBufferedIterator[String] = lines match {
+    case iter: BetterBufferedIterator[String] => iter
+    case iter                                 => iter.bufferBetter
+  }
+
+  private val (underlying: Iterator[Interval], _dict, _header) = if (
+    iter.headOption.exists(_.startsWith(IntervalListHeaderPrefix))
+  ) {
+    val wrapped = IntervalListSource(iter)
+    require(sd.forall(wrapped.dict.sameAs), "Provided sequence dictionary does not match the input's dict header!")
+    (wrapped, Some(wrapped.dict), Some(wrapped.header))
+  } else {
+    val wrapped = BedSource(iter, sd)
+    (wrapped.map(feature => new Interval(feature)), sd, None)
+  }
+
+  /** The [[SAMFileHeader]] associated with the source, if it exists. */
+  val header: Option[SAMFileHeader] = _header
+
+  /** The [[SequenceDictionary]] associated with the source, if it exists. */
+  val dict: Option[SequenceDictionary] = _dict
+
+  /** True if calling `next()` will yield another interval, false otherwise. */
+  override def hasNext: Boolean = underlying.hasNext
+
+  /** Returns the next interval if available, or throws an exception if none is available. */
+  override def next(): Interval = underlying.next()
+
+  /** Closes the underlying reader. */
+  override def close(): Unit = this.source.foreach(_.close())
+}
+
+/** Companion object for [[IntervalSource]]. */
+object IntervalSource {
+
+  /** Creates a new interval source from a sequence of lines. */
+  def apply(lines: Iterable[String], dict: Option[SequenceDictionary]): IntervalSource = new IntervalSource(lines.iterator, dict)
+
+  /** Creates a new interval source from an iterator of lines. */
+  def apply(lines: Iterator[String], dict: Option[SequenceDictionary]): IntervalSource = new IntervalSource(lines, dict)
+
+  /** Creates a new interval source from an input stream. */
+  def apply(stream: InputStream, dict: Option[SequenceDictionary]): IntervalSource = {
+    new IntervalSource(Source.fromInputStream(stream).getLines(), dict)
+  }
+
+  /** Creates a new interval source from a source. */
+  def apply(source: Source, dict: Option[SequenceDictionary]): IntervalSource = {
+    new IntervalSource(source.getLines(), dict, source = Some(source))
+  }
+
+  /** Creates a new interval source from a File. */
+  def apply(file: File, dict: Option[SequenceDictionary]): IntervalSource = apply(path=file.toPath, dict)
+
+  /** Creates a new interval source from a Path. */
+  def apply(path: PathToIntervals, dict: Option[SequenceDictionary]): IntervalSource = apply(Io.readLines(path), dict)
+}

--- a/src/main/scala/com/fulcrumgenomics/util/Io.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/Io.scala
@@ -21,15 +21,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package com.fulcrumgenomics.util
 
-import java.io.{InputStream, OutputStream}
-import java.nio.file.{Files, Path, Paths}
-import java.util.zip.{GZIPInputStream, GZIPOutputStream}
-
-import com.fulcrumgenomics.commons.CommonsDef.DirPath
+import com.fulcrumgenomics.commons.CommonsDef._
 import com.fulcrumgenomics.commons.io.{IoUtil, PathUtil}
 import htsjdk.samtools.util.BlockCompressedOutputStream
+
+import java.io.OutputStream
+import java.nio.file.{Files, Path, Paths}
 
 /**
   * Provides common IO utility methods.  Can be instantiated to create a custom factory, or
@@ -51,7 +51,7 @@ class Io(var compressionLevel: Int = 5,
   override def makeTempDir(name: String): DirPath = Files.createTempDirectory(tmpDir, name)
 
   /** Overridden to ensure that tmp files are created within the correct tmpDir. */
-  override def makeTempFile(prefix: String, suffix: String, dir: Option[DirPath] = Some(tmpDir)): DirPath = super.makeTempFile(prefix, suffix, dir)
+  override def makeTempFile(prefix: String, suffix: String, dir: Option[DirPath] = Some(tmpDir)): FilePath = super.makeTempFile(prefix, suffix, dir)
 }
 
 /** Singleton object that can be used when the default buffer size and compression are desired. */

--- a/src/test/scala/com/fulcrumgenomics/util/BedSourceTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/util/BedSourceTest.scala
@@ -1,0 +1,266 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2021 Fulcrum Genomics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package com.fulcrumgenomics.util
+
+import com.fulcrumgenomics.fasta.{SequenceDictionary, SequenceMetadata}
+import com.fulcrumgenomics.testing.UnitSpec
+import htsjdk.tribble.bed.{BEDFeature, FullBEDFeature, SimpleBEDFeature}
+import org.scalactic.{Equality, Explicitly}
+import org.scalatest.OptionValues._
+
+import java.io.ByteArrayInputStream
+import scala.io.Source
+
+/** Unit tests for [[BedSource]]. */
+class BedSourceTest extends UnitSpec with Explicitly {
+
+  /** A sequence dictionary for unit testing. */
+  private val Dict: SequenceDictionary = SequenceDictionary(SequenceMetadata("chr1", length = 10000))
+
+  /** Convenience method for building a Full BED Feature from a contig, start, end, and name. */
+  private def bed(contig: String, start: Int, end: Int, name: String): FullBEDFeature = {
+    val feature = new FullBEDFeature(contig, start, end)
+    feature.setName(name)
+    feature
+  }
+
+  /** Equality helper for BED features that only compares contig, start, end, and name. */
+  private val equalityByLocatableAndName: Equality[BEDFeature] = (a: BEDFeature, b: Any) => b match {
+    case expected: BEDFeature => a.contigsMatch(expected) &&
+      a.getStart == expected.getStart &&
+      a.getEnd   == expected.getEnd &&
+      a.getName  == expected.getName
+    case _ => false
+  }
+
+  /** Contents of a BED file without a header for testing. */
+  private val BedWithoutHeader: String =
+    """chr19 49302000 49302300 -1.0
+      |chr19 49302300 49302600 -0.75
+      |chr19 49302600 49302900 -0.50
+      |chr19 49302900 49303200 -0.25
+      |chr19 49303200 49303500 0.0
+      |chr19 49303500 49303800 0.25
+      |chr19 49303800 49304100 0.50
+      |chr19 49304100 49304400 0.75
+      |chr20 10       100      1.00
+    """.stripMargin.trim
+
+  /** Deserialized version of [[BedWithoutHeader]] for testing. */
+  private val BedWithoutHeaderExpected: Seq[FullBEDFeature] = {
+    Seq(
+      bed("chr19", 49302001, 49302300, "-1.0"),
+      bed("chr19", 49302301, 49302600, "-0.75"),
+      bed("chr19", 49302601, 49302900, "-0.50"),
+      bed("chr19", 49302901, 49303200, "-0.25"),
+      bed("chr19", 49303201, 49303500, "0.0"),
+      bed("chr19", 49303501, 49303800, "0.25"),
+      bed("chr19", 49303801, 49304100, "0.50"),
+      bed("chr19", 49304101, 49304400, "0.75"),
+      bed("chr20", 11,       100,      "1.00"),
+    )
+  }
+
+  /** Contents of a BED file (actually a bedGraph) with a complex header for testing. */
+  private val BedWithHeader: String =
+    """browser position chr19:49302001-49304701
+      |browser hide all
+      |browser pack refGene encodeRegions
+      |browser full altGraph
+      |#	300 base wide bar graph, autoScale is on by default == graphing
+      |#	limits will dynamically change to always show full range of data
+      |#	in viewing window, priority = 20 positions this as the second graph
+      |#	Note, zero-relative, half-open coordinate system in use for bedGraph format
+      |track type=bedGraph name="BedGraph Format" description="BedGraph format" visibility=full color=200,100,0 altColor=0,100,200 priority=20
+      |chr19 49302000 49302300 -1.0
+      |chr19 49302300 49302600 -0.75
+      |chr19 49302600 49302900 -0.50
+      |chr19 49302900 49303200 -0.25
+      |chr19 49303200 49303500 0.0
+      |chr19 49303500 49303800 0.25
+      |chr19 49303800 49304100 0.50
+      |chr19 49304100 49304400 0.75
+      |chr19 49304400 49304700 1.00
+    """.stripMargin.trim
+
+  /** Deserialized version of [[BedWithHeader]] for testing. */
+  private val BedWithHeaderExpected: Seq[FullBEDFeature] = {
+    Seq(
+      bed("chr19", 49302001, 49302300, "-1.0"),
+      bed("chr19", 49302301, 49302600, "-0.75"),
+      bed("chr19", 49302601, 49302900, "-0.50"),
+      bed("chr19", 49302901, 49303200, "-0.25"),
+      bed("chr19", 49303201, 49303500, "0.0"),
+      bed("chr19", 49303501, 49303800, "0.25"),
+      bed("chr19", 49303801, 49304100, "0.50"),
+      bed("chr19", 49304101, 49304400, "0.75"),
+      bed("chr19", 49304401, 49304700, "1.00"),
+    )
+  }
+
+  "BedSource" should "read a single simple BED data record" in {
+    val actual   = BedSource("chr1 100\n".linesIterator, dict = None)
+    val expected = Seq(new SimpleBEDFeature(101, 101, "chr1"))
+    actual.dict shouldBe None
+    actual.header shouldBe empty
+    (actual.toList should contain theSameElementsInOrderAs expected) (decided by equalityByLocatableAndName)
+  }
+
+  it should "read no BED features from an empty iterator" in {
+    val actual   = BedSource(Iterator.empty, dict = None)
+    actual.dict shouldBe None
+    actual.header shouldBe empty
+    actual.toList shouldBe empty
+  }
+
+  it should "return BED features from a list of line records" in {
+    val actual = BedSource(BedWithoutHeader.linesIterator, dict = None)
+    actual.dict shouldBe None
+    actual.header shouldBe empty
+    (actual.toList should contain theSameElementsInOrderAs BedWithoutHeaderExpected) (decided by equalityByLocatableAndName)
+  }
+
+  it should "return BED features from a list of line records and keep a copy of the header" in {
+    val actual = BedSource(BedWithHeader.linesIterator, dict = None)
+    actual.dict shouldBe None
+    actual.header shouldBe Seq(
+      "browser position chr19:49302001-49304701",
+      "browser hide all",
+      "browser pack refGene encodeRegions",
+      "browser full altGraph",
+      "#\t300 base wide bar graph, autoScale is on by default == graphing",
+      "#\tlimits will dynamically change to always show full range of data",
+      "#\tin viewing window, priority = 20 positions this as the second graph",
+      "#\tNote, zero-relative, half-open coordinate system in use for bedGraph format",
+      "track type=bedGraph name=\"BedGraph Format\" description=\"BedGraph format\" visibility=full color=200,100,0 altColor=0,100,200 priority=20",
+    )
+    (actual.toList should contain theSameElementsInOrderAs BedWithHeaderExpected) (decided by equalityByLocatableAndName)
+  }
+
+  it should "raise an exception when the underlying BED codec cannot read the data line" in {
+    an[IllegalStateException] shouldBe thrownBy { BedSource("\n".linesIterator, dict = None).toList }
+    an[IllegalStateException] shouldBe thrownBy { BedSource("    \n".linesIterator, dict = None).toList }
+    an[IllegalStateException] shouldBe thrownBy { BedSource("chr1\n".linesIterator, dict = None).toList }
+  }
+
+  it should "have a sequence dictionary if one is passed to the constructor" in {
+    val source = BedSource(Iterator.empty, dict = Some(Dict))
+    source.dict.value shouldBe Dict
+    source.header shouldBe empty
+    source.toList shouldBe empty
+  }
+
+  it should "raise a NoSuchElementException if a BED record has a contig not in the optional sequence dictionary" in {
+    val source = BedSource("chr2 100\n".linesIterator, dict = Some(Dict))
+    source.dict.value shouldBe Dict
+    source.header shouldBe empty
+    val caught = intercept[NoSuchElementException] { source.toList }
+    caught.getMessage should include ("Contig does not exist within dictionary for locatable")
+    caught.getMessage should include ("Failed on line number: 1")
+  }
+
+  it should "raise a IllegalArgumentException if a BED record has a start value less than 1 (1-based)" in {
+    val source = BedSource("chr1 -1 50\n".linesIterator, dict = Some(Dict))
+    source.dict.value shouldBe Dict
+    source.header shouldBe empty
+    val caught = intercept[IllegalArgumentException] { source.toList }
+    caught.getMessage should include ("Start is less than 1 for locatable")
+    caught.getMessage should include ("Failed on line number: 1")
+  }
+
+  it should "raise a IllegalArgumentException if a BED record has an end value greater than the contig length" in {
+    val source = BedSource("chr1 0 10001\n".linesIterator, dict = Some(Dict))
+    source.dict.value shouldBe Dict
+    source.header shouldBe empty
+    val caught = intercept[IllegalArgumentException] { source.toList }
+    caught.getMessage should include ("End is beyond the reference contig length for locatable")
+    caught.getMessage should include ("Failed on line number: 1")
+  }
+
+  it should "raise a IllegalArgumentException if a BED record has a start value greater than an end value" in {
+    val source = BedSource("chr1 100 50\n".linesIterator, dict = Some(Dict))
+    source.dict.value shouldBe Dict
+    source.header shouldBe empty
+    val caught = intercept[IllegalArgumentException] { source.toList }
+    caught.getMessage should include ("Start is greater than end for locatable")
+    caught.getMessage should include ("Failed on line number: 1")
+  }
+
+  it should "know which line of input triggered a validation exception" in {
+    val source = BedSource("chr1 100\nchr2 100".linesIterator, dict = Some(Dict))
+    source.dict.value shouldBe Dict
+    source.header shouldBe empty
+    val caught = intercept[NoSuchElementException] { source.toList }
+    caught.getMessage should include ("Contig does not exist within dictionary for locatable")
+    caught.getMessage should include ("Failed on line number: 2")
+  }
+
+  "BedSource.apply" should "allow sourcing BED features from an iterable of string data" in {
+    val actual   = BedSource(Seq("chr1 100"), dict = Some(Dict))
+    val expected = Seq(new SimpleBEDFeature(101, 101, "chr1"))
+    actual.dict.value shouldBe Dict
+    actual.header shouldBe empty
+    (actual.toList should contain theSameElementsInOrderAs expected) (decided by equalityByLocatableAndName)
+  }
+
+  it should "allow sourcing BED features from an input stream of string data" in {
+    val stream   = new ByteArrayInputStream("chr1 100\n".getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
+    val actual   = BedSource(stream, dict = Some(Dict))
+    val expected = Seq(new SimpleBEDFeature(101, 101, "chr1"))
+    actual.dict.value shouldBe Dict
+    actual.header shouldBe empty
+    (actual.toList should contain theSameElementsInOrderAs expected) (decided by equalityByLocatableAndName)
+  }
+
+  it should "allow sourcing BED features from a source of string data" in {
+    val source   = Source.fromString("chr1 100\n")
+    val actual   = BedSource(source, dict = Some(Dict))
+    val expected = Seq(new SimpleBEDFeature(101, 101, "chr1"))
+    actual.dict.value shouldBe Dict
+    actual.header shouldBe empty
+    (actual.toList should contain theSameElementsInOrderAs expected) (decided by equalityByLocatableAndName)
+  }
+
+  it should "allow sourcing BED features from a file of string data" in {
+    val path = Io.makeTempFile(getClass.getSimpleName, ".bed")
+    Io.writeLines(path, Seq("chr1 100"))
+    val actual   = BedSource(path.toFile, dict = Some(Dict))
+    val expected = Seq(new SimpleBEDFeature(101, 101, "chr1"))
+    actual.dict.value shouldBe Dict
+    actual.header shouldBe empty
+    (actual.toList should contain theSameElementsInOrderAs expected) (decided by equalityByLocatableAndName)
+  }
+
+  it should "allow sourcing BED features from a path of string data" in {
+    val path = Io.makeTempFile(getClass.getSimpleName, ".bed")
+    Io.writeLines(path, Seq("chr1 100"))
+    val actual   = BedSource(path, dict = Some(Dict))
+    val expected = Seq(new SimpleBEDFeature(101, 101, "chr1"))
+    actual.dict.value shouldBe Dict
+    actual.header shouldBe empty
+    (actual.toList should contain theSameElementsInOrderAs expected) (decided by equalityByLocatableAndName)
+  }
+}

--- a/src/test/scala/com/fulcrumgenomics/util/IntervalListSourceTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/util/IntervalListSourceTest.scala
@@ -59,42 +59,42 @@ class IntervalListSourceTest extends UnitSpec {
   }
 
   it should "fail if no header is present" in {
-    val exception = intercept[Exception] { IntervalListSource(Seq("chr1\t1\t1\t+\tname")) }
+    val exception = intercept[IllegalArgumentException] { IntervalListSource(Seq("chr1\t1\t1\t+\tname")) }
     exception.getMessage should include("No header found")
   }
 
   it should "fail if no sequence dictionary is present" in {
-    val exception = intercept[Exception] { IntervalListSource(Seq("@HD\tVN:1.0", "chr1\t1\t1\t+\tname")) }
+    val exception = intercept[IllegalArgumentException] { IntervalListSource(Seq("@HD\tVN:1.0", "chr1\t1\t1\t+\tname")) }
     exception.getMessage should include("No reference sequences found")
   }
 
   it should "fail if a line does not have exactly five fields" in {
-    val exception = intercept[Exception] { IntervalListSource(Seq("@HD\tVN:1.0", "@SQ\tSN:chr1\tLN:10000", "chr1")).toSeq }
+    val exception = intercept[IllegalArgumentException] { IntervalListSource(Seq("@HD\tVN:1.0", "@SQ\tSN:chr1\tLN:10000", "chr1")).toSeq }
     exception.getMessage should include("Expected 5 fields on line 3")
   }
 
   it should "fail if an interval's contig is not found the in the sequence dictionary" in {
-    val exception = intercept[Exception] { IntervalListSource(Seq("@HD\tVN:1.0", "@SQ\tSN:chr1\tLN:10000", "chr2\t1\t1\t+\tname")).toSeq }
-    exception.getMessage should include("key not found: chr2")
+    val exception = intercept[NoSuchElementException] { IntervalListSource(Seq("@HD\tVN:1.0", "@SQ\tSN:chr1\tLN:10000", "chr2\t1\t1\t+\tname")).toSeq }
+    exception.getMessage should include("Contig does not exist within dictionary")
   }
 
   it should "fail if an interval's start is less than one" in {
-    val exception = intercept[Exception] { IntervalListSource(Seq("@HD\tVN:1.0", "@SQ\tSN:chr1\tLN:10000", "chr1\t0\t1\t+\tname")).toSeq }
+    val exception = intercept[IllegalArgumentException] { IntervalListSource(Seq("@HD\tVN:1.0", "@SQ\tSN:chr1\tLN:10000", "chr1\t0\t1\t+\tname")).toSeq }
     exception.getMessage should include("Start is less than 1")
   }
 
   it should "fail if an interval's end is beyond the contig's length in the sequence dictionary" in {
-    val exception = intercept[Exception] { IntervalListSource(Seq("@HD\tVN:1.0", "@SQ\tSN:chr1\tLN:10000", "chr1\t1\t10001\t+\tname")).toSeq }
+    val exception = intercept[IllegalArgumentException] { IntervalListSource(Seq("@HD\tVN:1.0", "@SQ\tSN:chr1\tLN:10000", "chr1\t1\t10001\t+\tname")).toSeq }
     exception.getMessage should include("End is beyond")
   }
 
   it should "fail if an interval's start is greater than its end" in {
-    val exception = intercept[Exception] { IntervalListSource(Seq("@HD\tVN:1.0", "@SQ\tSN:chr1\tLN:10000", "chr1\t2\t1\t+\tname")).toSeq }
+    val exception = intercept[IllegalArgumentException] { IntervalListSource(Seq("@HD\tVN:1.0", "@SQ\tSN:chr1\tLN:10000", "chr1\t2\t1\t+\tname")).toSeq }
     exception.getMessage should include("Start is greater than end")
   }
 
   it should "fail if the strand cannot be recognized" in {
-    val exception = intercept[Exception] { IntervalListSource(Seq("@HD\tVN:1.0", "@SQ\tSN:chr1\tLN:10000", "chr1\t1\t1\tN\tname")).toSeq }
+    val exception = intercept[IllegalArgumentException] { IntervalListSource(Seq("@HD\tVN:1.0", "@SQ\tSN:chr1\tLN:10000", "chr1\t1\t1\tN\tname")).toSeq }
     exception.getMessage should include("Unrecognized strand")
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/util/IntervalSourceTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/util/IntervalSourceTest.scala
@@ -1,0 +1,265 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2021 Fulcrum Genomics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package com.fulcrumgenomics.util
+
+import com.fulcrumgenomics.fasta.Converters.ToSAMSequenceDictionary
+import com.fulcrumgenomics.fasta.{SequenceDictionary, SequenceMetadata}
+import com.fulcrumgenomics.testing.UnitSpec
+import htsjdk.samtools.SAMFileHeader
+import htsjdk.samtools.util.Interval
+import org.scalatest.OptionValues._
+
+import java.io.ByteArrayInputStream
+import scala.io.Source
+
+/** Unit tests for [[IntervalSource]]. */
+class IntervalSourceTest extends UnitSpec {
+
+  /** A sequence dictionary for unit testing. */
+  private val Dict: SequenceDictionary = SequenceDictionary(
+    SequenceMetadata(name = "chr1", length = 50000000),
+    SequenceMetadata(name = "chr2", length = 50000)
+  )
+
+  /** Contents of a BED file without a header for testing. */
+  private val BedWithoutHeader: String =
+    """chr19 49302000 49302300 -1.0
+      |chr19 49302300 49302600 -0.75
+      |chr19 49302600 49302900 -0.50
+      |chr19 49302900 49303200 -0.25
+      |chr19 49303200 49303500 0.0
+      |chr19 49303500 49303800 0.25
+      |chr19 49303800 49304100 0.50
+      |chr19 49304100 49304400 0.75
+      |chr20 10       100      1.00
+    """.stripMargin.trim
+
+  /** Deserialized version of [[BedWithoutHeader]] for testing. */
+  private val BedWithoutHeaderExpected: Seq[Interval] = {
+    Seq(
+      new Interval("chr19", 49302001, 49302300, false, "-1.0"),
+      new Interval("chr19", 49302301, 49302600, false, "-0.75"),
+      new Interval("chr19", 49302601, 49302900, false, "-0.50"),
+      new Interval("chr19", 49302901, 49303200, false, "-0.25"),
+      new Interval("chr19", 49303201, 49303500, false, "0.0"),
+      new Interval("chr19", 49303501, 49303800, false, "0.25"),
+      new Interval("chr19", 49303801, 49304100, false, "0.50"),
+      new Interval("chr19", 49304101, 49304400, false, "0.75"),
+      new Interval("chr20", 11,       100,      false, "1.00"),
+    )
+  }
+
+  /** Contents of a BED file (actually a bedGraph) with a complex header for testing. */
+  private val BedWithHeader: String =
+    """browser position chr19:49302001-49304701
+      |browser hide all
+      |browser pack refGene encodeRegions
+      |browser full altGraph
+      |#	300 base wide bar graph, autoScale is on by default == graphing
+      |#	limits will dynamically change to always show full range of data
+      |#	in viewing window, priority = 20 positions this as the second graph
+      |#	Note, zero-relative, half-open coordinate system in use for bedGraph format
+      |track type=bedGraph name="BedGraph Format" description="BedGraph format" visibility=full color=200,100,0 altColor=0,100,200 priority=20
+      |chr19 49302000 49302300 -1.0
+      |chr19 49302300 49302600 -0.75
+      |chr19 49302600 49302900 -0.50
+      |chr19 49302900 49303200 -0.25
+      |chr19 49303200 49303500 0.0
+      |chr19 49303500 49303800 0.25
+      |chr19 49303800 49304100 0.50
+      |chr19 49304100 49304400 0.75
+      |chr19 49304400 49304700 1.00
+    """.stripMargin.trim
+
+  /** Deserialized version of [[BedWithHeader]] for testing. */
+  private val BedWithHeaderExpected: Seq[Interval] = {
+    Seq(
+      new Interval("chr19", 49302001, 49302300, false, "-1.0"),
+      new Interval("chr19", 49302301, 49302600, false, "-0.75"),
+      new Interval("chr19", 49302601, 49302900, false, "-0.50"),
+      new Interval("chr19", 49302901, 49303200, false, "-0.25"),
+      new Interval("chr19", 49303201, 49303500, false, "0.0"),
+      new Interval("chr19", 49303501, 49303800, false, "0.25"),
+      new Interval("chr19", 49303801, 49304100, false, "0.50"),
+      new Interval("chr19", 49304101, 49304400, false, "0.75"),
+      new Interval("chr19", 49304401, 49304700, false, "1.00"),
+    )
+  }
+
+  /** Contents of an Interval List header for testing. */
+  private val IntervalListData: String =
+    "@HD\tVN:1.0\n" + "@SQ\tSN:chr1\tLN:50000000\n" + "@SQ\tSN:chr2\tLN:50000\n" +
+      "chr1\t49302000\t49302300\t+\tname1\n" +
+      "chr1\t49302300\t49302600\t+\tname2\n" +
+      "chr1\t49302600\t49302900\t+\tname3\n" +
+      "chr1\t49302900\t49303200\t+\tname4\n" +
+      "chr1\t49303200\t49303500\t+\tname5\n" +
+      "chr1\t49303500\t49303800\t+\tname6\n" +
+      "chr1\t49303800\t49304100\t+\tname7\n" +
+      "chr1\t49304100\t49304400\t+\tname8\n" +
+      "chr2\t10\t100\t-\tname9\n"
+
+  /** Deserialized version of [[IntervalListData]] for testing. */
+  private val IntervalListExpected: Seq[Interval] = Seq(
+    new Interval("chr1", 49302000, 49302300, false, "name1"),
+    new Interval("chr1", 49302300, 49302600, false, "name2"),
+    new Interval("chr1", 49302600, 49302900, false, "name3"),
+    new Interval("chr1", 49302900, 49303200, false, "name4"),
+    new Interval("chr1", 49303200, 49303500, false, "name5"),
+    new Interval("chr1", 49303500, 49303800, false, "name6"),
+    new Interval("chr1", 49303800, 49304100, false, "name7"),
+    new Interval("chr1", 49304100, 49304400, false, "name8"),
+    new Interval("chr2", 10,       100,      true,  "name9"),
+  )
+
+  "IntervalSource" should "read a single simple BED data record into an interval" in {
+    val actual   = IntervalSource("chr1 100\n".linesIterator, dict = None)
+    val expected = Seq(new Interval("chr1", 101, 101))
+    actual.dict shouldBe None
+    actual.header shouldBe None
+    actual.toList should contain theSameElementsInOrderAs expected
+  }
+
+  it should "read no intervals at all from an empty iterator" in {
+    val actual   = IntervalSource(Iterator.empty, dict = None)
+    actual.dict shouldBe None
+    actual.header shouldBe None
+    actual.toList shouldBe empty
+  }
+
+  it should "return BED intervals from a list of line records" in {
+    val actual = IntervalSource(BedWithoutHeader.linesIterator, dict = None)
+    actual.dict shouldBe None
+    actual.header shouldBe None
+    actual.toList should contain theSameElementsInOrderAs BedWithoutHeaderExpected
+  }
+
+  it should "return BED intervals, skipping a header, from a list of line records" in {
+    val actual = IntervalSource(BedWithHeader.linesIterator, dict = None)
+    actual.dict shouldBe None
+    actual.header shouldBe None
+    actual.toList should contain theSameElementsInOrderAs BedWithHeaderExpected
+  }
+
+  it should "read a single simple Interval List data record into an interval" in {
+    val data   = "@HD\tVN:1.0\n" + "@SQ\tSN:chr1\tLN:50000000\n" + "chr1\t100\t100\t+\t.\n"
+    val dict   = SequenceDictionary(SequenceMetadata("chr1", length = 50000000))
+    val header = new SAMFileHeader()
+    header.setAttribute("VN", "1.0")
+    header.setSequenceDictionary(dict.asSam)
+
+    val source   = IntervalSource(data.linesIterator, dict = None)
+    val expected = Seq(new Interval("chr1", 100, 100, false, null))
+
+    source.dict.value shouldBe dict
+    source.header.value shouldBe header
+    source.toList should contain theSameElementsInOrderAs expected
+  }
+
+  it should "read multiple intervals from an interval list" in {
+    val source = IntervalSource(IntervalListData.linesIterator, dict = None)
+    val header = new SAMFileHeader()
+    header.setAttribute("VN", "1.0")
+    header.setSequenceDictionary(Dict.asSam)
+
+    source.dict.value shouldBe Dict
+    source.header.value shouldBe header
+    source.toList should contain theSameElementsInOrderAs IntervalListExpected
+  }
+
+  it should "assert the provided sequence dictionary matches the found sequence dictionary for interval list input" in {
+    val invalid = SequenceDictionary(SequenceMetadata("chrX", length =2))
+    val caught  = intercept[IllegalArgumentException] { IntervalSource(IntervalListData.linesIterator, dict = Some(invalid)) }
+    caught.getMessage should include ("Provided sequence dictionary does not match the input's dict header!")
+  }
+
+  it should "pass through the sequence dictionary when supplied for BED input" in {
+    val dict   = SequenceDictionary(
+      SequenceMetadata(name = "chr19", length = 50000000),
+      SequenceMetadata(name = "chr20", length = 50000)
+    )
+    val actual = IntervalSource(BedWithHeader.linesIterator, dict = Some(dict))
+    actual.dict.value shouldBe dict
+    actual.header shouldBe None
+    actual.toList should contain theSameElementsInOrderAs BedWithHeaderExpected
+  }
+
+  it should "assert the records match the provided sequence dictionary for BED input" in {
+    val dict   = SequenceDictionary(
+      SequenceMetadata(name = "chr19", length = 50000000),
+      SequenceMetadata(name = "chr20", length = 50000)
+    )
+    val caught = intercept[NoSuchElementException] { IntervalSource("chr1 100".linesIterator, dict = Some(dict)).toList }
+    caught.getMessage should include ("Contig does not exist within dictionary for locatable")
+    caught.getMessage should include ("Failed on line number: 1")
+  }
+
+  "IntervalSource.apply" should "allow sourcing intervals from an iterable of string data" in {
+    val actual   = IntervalSource(Seq("chr1 100"), dict = Some(Dict))
+    val expected = Seq(new Interval("chr1", 101, 101))
+    actual.dict.value shouldBe Dict
+    actual.header shouldBe None
+    actual.toList should contain theSameElementsInOrderAs expected
+  }
+
+  it should "allow sourcing interval from an input stream of string data" in {
+    val stream   = new ByteArrayInputStream("chr1 100\n".getBytes(java.nio.charset.StandardCharsets.UTF_8.name))
+    val actual   = IntervalSource(stream, dict = Some(Dict))
+    val expected = Seq(new Interval("chr1", 101, 101))
+    actual.dict.value shouldBe Dict
+    actual.header shouldBe None
+    actual.toList should contain theSameElementsInOrderAs expected
+  }
+
+  it should "allow sourcing intervals from a source of string data" in {
+    val source   = Source.fromString("chr1 100\n")
+    val actual   = IntervalSource(source, dict = Some(Dict))
+    val expected = Seq(new Interval("chr1", 101, 101))
+    actual.dict.value shouldBe Dict
+    actual.header shouldBe None
+    actual.toList should contain theSameElementsInOrderAs expected
+  }
+
+  it should "allow sourcing intervals from a file of string data" in {
+    val path = Io.makeTempFile(getClass.getSimpleName, ".bed")
+    Io.writeLines(path, Seq("chr1 100"))
+    val actual   = IntervalSource(path.toFile, dict = Some(Dict))
+    val expected = Seq(new Interval("chr1", 101, 101))
+    actual.dict.value shouldBe Dict
+    actual.header shouldBe None
+    actual.toList should contain theSameElementsInOrderAs expected
+  }
+
+  it should "allow sourcing intervals from a path of string data" in {
+    val path = Io.makeTempFile(getClass.getSimpleName, ".bed")
+    Io.writeLines(path, Seq("chr1 100"))
+    val actual   = IntervalSource(path, dict = Some(Dict))
+    val expected = Seq(new Interval("chr1", 101, 101))
+    actual.dict.value shouldBe Dict
+    actual.header shouldBe None
+    actual.toList should contain theSameElementsInOrderAs expected
+  }
+}


### PR DESCRIPTION
I need helpers for reading generic interval data, so I added these classes!

`BedSource`: A source for BED input (similar to `IntervalListSource`).
`IntervalSource`: A source for interval data that wraps either BED or Interval List input.

In both classes, you can optionally provide a sequence dictionary that will be used to validate the intervals. I did this because I find myself having a BED and reference FASTA, more often than I have an Interval List and reference FASTA, but I would still like the safety of knowing my intervals are well-formed.

I expect to use these classes like the following, (so even BED data is safe!):

```scala
@clp(description="Does the work for you")
class DoWork(
  @arg(flag='i', doc="The path to the input intervals.") val input: PathToIntervals,
  @arg(flag='r', doc="The reference FASTA.") val reference: PathToFasta,
) extends Tool {
  override def execute(): Unit = {
    val fasta     = ReferenceSequenceFileFactory.getReferenceSequenceFile(reference)
    val intervals = IntervalSource(input, Some(fasta.getSequenceDictionary.fromSam))

    intervals.foreach { interval => println(s"Found interval: $interval") }

    fasta.close()
    intervals.close()
  }
}
```

This should be OK from a type-alias perspective too, since `PathToIntervals` is defined as:

```scala
/** Represents a path to an intervals file (IntervalList or BED). */
type PathToIntervals = java.nio.file.Path
```