### PR TITLE
Add the --annotate-all option to AssignPrimers

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/util/AssignPrimers.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/AssignPrimers.scala
@@ -1,7 +1,8 @@
 package com.fulcrumgenomics.util
 
 import com.fulcrumgenomics.FgBioDef.{FilePath, PathToBam, SafelyClosable}
-import com.fulcrumgenomics.bam.api.{SamRecord, SamSource, SamWriter}
+import com.fulcrumgenomics.bam.Bams
+import com.fulcrumgenomics.bam.api.{SamOrder, SamRecord, SamSource, SamWriter}
 import com.fulcrumgenomics.cmdline.{ClpGroups, FgBioTool}
 import com.fulcrumgenomics.commons.util.LazyLogging
 import com.fulcrumgenomics.sopt.{arg, clp}
@@ -49,6 +50,11 @@ import com.fulcrumgenomics.sopt.{arg, clp}
     |or choose the primary alignment that has the closest aligned read base to the 5' end of the read in sequencing order.
     |For example, from `bwa` version `0.7.16` onwards, the `-5` option may be used.  Consider also using the `-q` option 
     |for `bwa` `0.7.16` as well, which is standard in `0.7.17` onwards when the `-5` option is used.
+    |
+    |The `--annotate-all` option may be used to annotate all alignments for a given read end (eg. R1) with
+    |the same assignment.  If the assignment differs across alignments for the same read end, no assignment is given.
+    |Furthermore, if the input BAM is neither `queryname` sorted nor `query` grouped, it will be sorted into queryname
+    |order to assign all alignments cross a template simultaneously.  The output is written in coordinate order.
   """)
 class AssignPrimers
 (@arg(flag='i', doc="Input BAM file.")  val input: PathToBam,
@@ -61,6 +67,7 @@ class AssignPrimers
  @arg(doc="The SAM tag for the mate's assigned primer coordinate.") val matePrimerCoordinatesTag: String = AssignPrimers.MatePrimerCoordinateTag,
  @arg(doc="The SAM tag for the assigned amplicon identifier.") val ampliconIdentifierTag: String = AssignPrimers.AmpliconIdentifierTag,
  @arg(doc="The SAM tag for the mate's assigned amplicon identifier.") val mateAmpliconIdentifierTag: String = AssignPrimers.MateAmpliconIdentifierTag,
+ @arg(doc="Annotate all R1 (or R2) with same value.") val annotateAll: Boolean = false
 ) extends FgBioTool with LazyLogging {
 
   Io.assertReadable(input)
@@ -86,17 +93,46 @@ class AssignPrimers
       mateAmpliconIdentifierTag = mateAmpliconIdentifierTag
     )
 
-    reader.foreach { rec =>
-      val recAmplicon = detector.findPrimer(rec=rec)
-      labeller.label(
-        rec = rec,
-        recAmplicon = recAmplicon,
-        mateAmplicon = if (rec.unpaired) None else detector.findMatePrimer(rec=rec)
-      )
-      writer.write(rec)
-      progress.record(rec)
+    if (annotateAll) {
+      // All alignments will be assigned a primer independently, and then grouped by read end. An primer assignment will
+      // be made on a given read end only if there is one and only one unique primer assignment.
+      val sorter = Bams.sorter(SamOrder.Coordinate, reader.header)
+      Bams.templateIterator(reader).foreach { template =>
+        // split into R1s and R2s
+        val (r1s, r2s) = template.allReads.toSeq.partition(r => r.unpaired || r.firstOfPair)
+        // detect the primers for each of the R1s and R2s
+        val r1Amplicons = r1s.flatMap(detector.findPrimer).distinct
+        val r1Amplicon = if (r1Amplicons.length == 1) r1Amplicons.headOption else None
+        val r2Amplicons = r2s.flatMap(detector.findPrimer).distinct
+        val r2Amplicon = if (r2Amplicons.length == 1) r2Amplicons.headOption else None
+        // label the reads
+        r1s.foreach { rec => labeller.label(rec=rec, recAmplicon=r1Amplicon, mateAmplicon=r2Amplicon) }
+        r2s.foreach { rec => labeller.label(rec=rec, recAmplicon=r2Amplicon, mateAmplicon=r1Amplicon) }
+        // write them out
+        template.allReads.foreach { r =>
+          sorter += r
+          progress.record(r)
+        }
+      }
+      progress.logLast()
+      // Write them out after sorting
+      sorter.foreach { rec =>
+        writer += rec
+      }
     }
-    progress.logLast()
+    else {
+      reader.foreach { rec =>
+        val recAmplicon = detector.findPrimer(rec=rec)
+        labeller.label(
+          rec          = rec,
+          recAmplicon  = recAmplicon,
+          mateAmplicon = if (rec.unpaired) None else detector.findMatePrimer(rec=rec)
+        )
+        writer += rec
+        progress.record(rec)
+      }
+      progress.logLast()
+    }
 
     reader.safelyClose()
     writer.close()
@@ -181,9 +217,11 @@ class AmpliconLabeller(val amplicons: Iterator[Amplicon] = Iterator.empty,
     // Process the primer for the current read
     recAmplicon.foreach { amp =>
       // update metrics
-      metrics.get(amp).foreach { metric =>
-        if (rec.positiveStrand) metric.left += 1 else metric.right += 1
-        if (rec.unpaired || rec.firstOfPair) metric.r1s += 1 else metric.r2s += 1
+      if (rec.primary && !rec.supplementary) {
+        metrics.get(amp).foreach { metric =>
+          if (rec.positiveStrand) metric.left += 1 else metric.right += 1
+          if (rec.unpaired || rec.firstOfPair) metric.r1s += 1 else metric.r2s += 1
+        }
       }
       // assign ap/ip
       rec(primerCoordinatesTag)  = if (rec.positiveStrand) amp.leftPrimerLocation else amp.rightPrimerLocation

--- a/src/test/scala/com/fulcrumgenomics/util/AssignPrimersTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/util/AssignPrimersTest.scala
@@ -25,7 +25,7 @@
 
 package com.fulcrumgenomics.util
 
-import com.fulcrumgenomics.bam.api.SamRecord
+import com.fulcrumgenomics.bam.api.{SamOrder, SamRecord}
 import com.fulcrumgenomics.testing.SamBuilder.Minus
 import com.fulcrumgenomics.testing.{SamBuilder, UnitSpec}
 import htsjdk.samtools.SamPairUtil

--- a/src/test/scala/com/fulcrumgenomics/util/AssignPrimersTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/util/AssignPrimersTest.scala
@@ -26,7 +26,9 @@
 package com.fulcrumgenomics.util
 
 import com.fulcrumgenomics.bam.api.SamRecord
+import com.fulcrumgenomics.testing.SamBuilder.Minus
 import com.fulcrumgenomics.testing.{SamBuilder, UnitSpec}
+import htsjdk.samtools.SamPairUtil
 import org.scalatest.OptionValues
 
 class AssignPrimersTest extends UnitSpec with OptionValues {
@@ -70,7 +72,7 @@ class AssignPrimersTest extends UnitSpec with OptionValues {
     checkMatch(rec=rec, amplicon=Some(amplicon), mateAmplicon=Some(mateAmplicon))
   }
 
-  "AssignPrimers" should "assign primers to reads" in {
+  {
     val ampliconsPath = makeTempFile("amplicons.", ".txt")
     val outputBam     = makeTempFile("output.", ".bam")
     val metricsPath   = makeTempFile("metrics.", ".txt")
@@ -91,56 +93,89 @@ class AssignPrimersTest extends UnitSpec with OptionValues {
     builder.addPair(start1=100, start2=501) // match amplicon #1 and #2, R1->1F, R2->2R
     builder.addPair(start1=100, start2=10000) // match amplicon #1 for R1->1F, no match for R2
     builder.addPair(contig=4, start1=100, start2=101) // match amplicon #5 , R1->F, R2->R
+    // Reads to test --annotate-all, where we have a primary and supplementary read
+    // R1->1F, R2_primary->2R, R2_supplementary->NA.  If --annotate-all is used, then R2_supplementary should have 2R
+    val Seq(matePrimary, _) = builder.addPair(start1=100, start2=551, cigar1="100M", cigar2="50S50M")
+    builder.addFrag(name=matePrimary.name, contig=2, start=1, cigar="50M50S", strand=Minus).foreach { supplemental =>
+      supplemental.paired        = true
+      supplemental.firstOfPair   = false
+      supplemental.secondOfPair  = true
+      supplemental.supplementary = true
+      SamPairUtil.setMateInformationOnSupplementalAlignment(supplemental.asSam, matePrimary.asSam, true)
+    }
 
     Metric.write(ampliconsPath, amplicons)
 
-    val tool = new AssignPrimers(
-      input   = builder.toTempFile(),
-      primers = ampliconsPath,
-      output  = outputBam,
-      metrics = metricsPath
-    )
+    // Test with/without --annotate-all set
+    Seq(false, true).foreach { annotateAll =>
+      val label = if (annotateAll) " with --annotate-all" else ""
+      "AssignPrimers" should s"assign primers to reads$label" in {
+        val tool = new AssignPrimers(
+          input       = builder.toTempFile(),
+          primers     = ampliconsPath,
+          output      = outputBam,
+          metrics     = metricsPath,
+          annotateAll = annotateAll
+        )
 
-    tool.execute()
+        tool.execute()
 
-    // check the output BAM
-    val recs = readBamRecs(bam=outputBam)
-    // frag
-    checkMatch(rec=recs(0), amplicons(0))
-    // frag
-    checkMatch(rec=recs(1))
-    // pair #1
-    checkMatch(rec=recs(2), amplicons(1), amplicons(1))
-    checkMatch(rec=recs(3), amplicons(1), amplicons(1))
-    // pair #2
-    checkMatch(rec=recs(4), amplicons(1), amplicons(1))
-    checkMatch(rec=recs(5), amplicons(1), amplicons(1))
-    // pair #3
-    checkMatch(rec=recs(6), amplicons(0), amplicons(1))
-    checkMatch(rec=recs(7), amplicons(1), amplicons(0))
-    // pair #4
-    checkMatch(rec=recs(8), amplicons(0))
-    checkMatch(rec=recs(9), None, Some(amplicons(0)))
-    // pair #5
-    checkMatch(rec=recs(10), amplicons(2), amplicons(2))
-    checkMatch(rec=recs(11), amplicons(2), amplicons(2))
+        // check the output BAM
+        val outputRecs = readBamRecs(bam=outputBam)
+        // The output BAM may be resorted, so the following methods retrieve records by read name (since they're numerically indexed)
+        def recs(nameIndex: Int): Seq[SamRecord] = outputRecs.filter(_.name.toInt == nameIndex)
+        def rec(nameIndex: Int): SamRecord = recs(nameIndex) match {
+          case Seq(rec) => rec
+          case records  => throw new IllegalStateException(s"Found ${records.length}")
+        }
 
-    // check the metrics
-    val metrics       = Metric.read[AssignPrimersMetric](metricsPath)
-    val allIdentifier = AssignPrimersMetric.AllAmpliconsIdentifier
-    val expected      = IndexedSeq(
-      AssignPrimersMetric(identifier=amplicons(0).identifier, left=3, right=0, r1s=3, r2s=0, pairs=0),
-      AssignPrimersMetric(identifier=amplicons(1).identifier, left=2, right=3, r1s=2, r2s=3, pairs=2),
-      AssignPrimersMetric(identifier=amplicons(2).identifier, left=1, right=1, r1s=1, r2s=1, pairs=1),
-      AssignPrimersMetric(identifier=allIdentifier,           left=6, right=4, r1s=6, r2s=4, pairs=3)
-    ).map(_.finalize(total=recs.length))
+        // frag
+        checkMatch(rec=rec(0), amplicons(0))
+        // frag
+        checkMatch(rec=rec(1))
+        // pair #1
+        checkMatch(rec=recs(2).head, amplicons(1), amplicons(1))
+        checkMatch(rec=recs(2).last, amplicons(1), amplicons(1))
+        // pair #2
+        checkMatch(rec=recs(3).head, amplicons(1), amplicons(1))
+        checkMatch(rec=recs(3).last, amplicons(1), amplicons(1))
+        // pair #3
+        checkMatch(rec=recs(4).head, amplicons(0), amplicons(1))
+        checkMatch(rec=recs(4).last, amplicons(1), amplicons(0))
+        // pair #4
+        checkMatch(rec=recs(5).head, amplicons(0))
+        checkMatch(rec=recs(5).last, None, Some(amplicons(0)))
+        // pair #5
+        checkMatch(rec=recs(6).head, amplicons(2), amplicons(2))
+        checkMatch(rec=recs(6).last, amplicons(2), amplicons(2))
+        // pair #6
+        checkMatch(rec=recs(7).head, amplicons(0), amplicons(1))
+        checkMatch(rec=recs(7)(1), amplicons(1), amplicons(0))
+        if (annotateAll) { // the amplicon tag (ma) **is** set in this case
+          checkMatch(rec=recs(7)(2), amplicons(1), amplicons(0))
+        } else { // the amplicon tag (ma) **is not** set in this case
+          checkMatch(rec=recs(7)(2), None, Some(amplicons(0)))
+        }
 
-    metrics.length shouldBe amplicons.length + 1
-    metrics.zip(expected).foreach { case (act, exp) =>
-      // compare one-by-one to make it easier to debug
-      act.finalize(0) shouldBe exp.finalize(0)  // just the values
-      act shouldBe exp // now the fractions
+        // check the metrics
+        val metrics       = Metric.read[AssignPrimersMetric](metricsPath)
+        val allIdentifier = AssignPrimersMetric.AllAmpliconsIdentifier
+        val expected      = IndexedSeq(
+          AssignPrimersMetric(identifier=amplicons(0).identifier, left=4, right=0, r1s=4, r2s=0, pairs=0),
+          AssignPrimersMetric(identifier=amplicons(1).identifier, left=2, right=4, r1s=2, r2s=4, pairs=2),
+          AssignPrimersMetric(identifier=amplicons(2).identifier, left=1, right=1, r1s=1, r2s=1, pairs=1),
+          AssignPrimersMetric(identifier=allIdentifier,           left=7, right=5, r1s=7, r2s=5, pairs=3)
+        ).map(_.finalize(total=outputRecs.length))
+
+        metrics.length shouldBe amplicons.length + 1
+        metrics.zip(expected).foreach { case (act, exp) =>
+          // compare one-by-one to make it easier to debug
+          act.finalize(0) shouldBe exp.finalize(0)  // just the values
+          act shouldBe exp // now the fractions
+        }
+        metrics.length shouldBe expected.length
+
+      }
     }
-    metrics.length shouldBe expected.length
   }
 }


### PR DESCRIPTION
In cases where a given read end (eg. R2) has both a primary and
supplementary alignment, where only of the two is assigned a primer,
the current behavior is to annotate the mate primer/amplicon for both,
but the primer/amplicon just for the alignment for the read end that
is assigned a primer.

The --annotate-all optiona will annotate both alignments of the same end
with the primer.  This may be important for downstream translocation
detection.