### PR TITLE
SampleSheet checks ID unique between samples with/without Lane

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/illumina/SampleSheet.scala
+++ b/src/main/scala/com/fulcrumgenomics/illumina/SampleSheet.scala
@@ -183,7 +183,7 @@ class SampleSheet(samples: Seq[Sample]) extends Iterable[Sample] {
 
   // Validate samples
   samples.flatMap(_.lane).toSet[Int].toList.foreach { lane =>
-    SampleSheet.validateSamplesFromTheSameLane(samples.filter(_.lane.contains(lane)))
+    SampleSheet.validateSamplesFromTheSameLane(samples.filter(s => s.lane.contains(lane) || s.lane.isEmpty))
   }
   SampleSheet.validateSamplesFromTheSameLane(samples.filter(_.lane.isEmpty))
 

--- a/src/test/scala/com/fulcrumgenomics/illumina/SampleSheetTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/illumina/SampleSheetTest.scala
@@ -85,12 +85,18 @@ class SampleSheetTest extends FlatSpec with Matchers with OptionValues {
   }
 
   it should "throw an exception if sample ids are not unique " in {
+    // with no lane defined
     val sample = Sample(sampleOrdinal=0, sampleId="ID", sampleName="NAMEA", libraryId="LIBRARY")
     an[IllegalArgumentException] should be thrownBy new SampleSheet(Seq(sample, sample.copy(sampleName="NAMEB")))
 
     // within a lane
     val sampleForLane = Sample(sampleOrdinal=0, sampleId="ID", sampleName="NAMEA", libraryId="LIBRARY", lane=Some(1))
     an[IllegalArgumentException] should be thrownBy new SampleSheet(Seq(sampleForLane, sampleForLane.copy(sampleName="NAMEB")))
+
+    // where one sample defines lane, another does not
+    val sampleWithLane = Sample(sampleOrdinal=0, sampleId="ID", sampleName="NAMEA", libraryId="LIBRARY", lane=Some(1))
+    val sampleNoLane   = sampleWithLane.copy(sampleName="NAMEB", lane=None)
+    an[IllegalArgumentException] should be thrownBy new SampleSheet(Seq(sampleWithLane, sampleNoLane))
   }
 
   it should "throw an exception if the combination of sample name and library id are not unique" in {


### PR DESCRIPTION
My reasoning here is that in a sample sheet, if a lane is not defined, it means that sample is present in all lanes. So if we have the same sample ID in two samples, one in lane 2 and one in all lanes, that should be a clash.