### PR TITLE
Make Variant locatable by mixing in GenomicSpan

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
@@ -24,6 +24,8 @@
 
 package com.fulcrumgenomics.vcf.api
 
+import com.fulcrumgenomics.util.GenomicSpan
+
 import scala.collection.immutable.ListMap
 import scala.reflect.ClassTag
 
@@ -99,7 +101,13 @@ final case class Variant(chrom: String,
                          filters: Set[String] = Variant.EmptyFilters,
                          attrs: ListMap[String,Any] = Variant.EmptyInfo,
                          genotypes: Map[String, Genotype] = Variant.EmptyGenotypes
-                        ) {
+                        ) extends GenomicSpan {
+
+  /** The chromosome on which a variant resides. */
+  override val contig: String = chrom
+
+  /** The start position of the variant. */
+  override val start: Int = pos
 
   /** The end position of the variant based on either the `END` INFO field _or_ the length of the reference allele. */
   val end: Int = get[Int]("END").getOrElse(pos + alleles.ref.length - 1)

--- a/src/test/scala/com/fulcrumgenomics/vcf/api/VariantTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/vcf/api/VariantTest.scala
@@ -24,11 +24,15 @@
 
 package com.fulcrumgenomics.vcf.api
 
-import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.testing.UnitSpec
+import htsjdk.samtools.util.Locatable
 import org.scalatest.OptionValues
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+
+import scala.collection.immutable.ListMap
 
 class VariantTest extends UnitSpec with OptionValues {
+
   "Variant.isMissingValue" should "correctly handle missing and non-missing values" in {
     Variant.isMissingValue(".") shouldBe true
     Variant.isMissingValue('.') shouldBe true
@@ -38,5 +42,21 @@ class VariantTest extends UnitSpec with OptionValues {
     Variant.isMissingValue(".1")      shouldBe false
     Variant.isMissingValue(Float.NaN) shouldBe false
     Range(-500, 500).foreach { i => Variant.isMissingValue(i) shouldBe false}
+  }
+
+  "Variant" should "be locatable when it contains a simple allele" in {
+    val variant = Variant("chr1", 10, alleles = AlleleSet(Allele("A")))
+    variant mustBe a[Locatable]
+    variant.contig shouldBe "chr1"
+    variant.start shouldBe 10
+    variant.end shouldBe 10
+  }
+
+  it should "be locatable when it contains a symbolic allele that is a deletion" in {
+    val variant = Variant("chr1", 10, alleles = AlleleSet(Allele("A"), Allele("<DEL>")), attrs = ListMap("END" -> 200))
+    variant mustBe a[Locatable]
+    variant.contig shouldBe "chr1"
+    variant.start shouldBe 10
+    variant.end shouldBe 200
   }
 }


### PR DESCRIPTION
This will make it easy to perform coordinate math on variants.

Curious why `Variant` has the `chrom`/`pos` field by design instead of the more common `contig`/`start`?