### PR TITLE
Add methods to make a Variant locatable

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
@@ -24,6 +24,8 @@
 
 package com.fulcrumgenomics.vcf.api
 
+import com.fulcrumgenomics.vcf.api.VcfConversions.VariantLocatable
+
 import scala.collection.immutable.ListMap
 import scala.reflect.ClassTag
 
@@ -118,4 +120,7 @@ final case class Variant(chrom: String,
 
   /** Returns an iterator over the genotypes for this variant. */
   def gts: Iterator[Genotype] = this.genotypes.valuesIterator
+
+  /** Returns a [[VariantLocatable]] for this variant. */
+  def toLocatable: VariantLocatable = new VariantLocatable(this)
 }

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
@@ -74,7 +74,7 @@ object Variant {
   /**
     * Little container class for a [[Variant]] to make it locatable (see [[Locatable]]).
     */
-  implicit case class LocatableVariant(variant: Variant) extends Locatable {
+  implicit class LocatableVariant(variant: Variant) extends Locatable {
     override def getContig: String = variant.chrom
     override def getStart: Int     = variant.pos
     override def getEnd: Int       = variant.end

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
@@ -25,6 +25,7 @@
 package com.fulcrumgenomics.vcf.api
 
 import com.fulcrumgenomics.vcf.api.VcfConversions.VariantLocatable
+import htsjdk.samtools.util.Locatable
 
 import scala.collection.immutable.ListMap
 import scala.reflect.ClassTag
@@ -71,6 +72,15 @@ object Variant {
   private[api] val EmptyInfo:       ListMap[String, Any]  = ListMap.empty
   private[api] val EmptyGtAttrs:    Map[String, Any]      = Map.empty
   private[api] val EmptyGenotypes:  Map[String, Genotype] = Map.empty
+
+  /**
+    * Little container class for a [[Variant]] to make it locatable (see [[Locatable]]).
+    */
+  implicit case class LocatableVariant(variant: Variant) extends Locatable {
+    override def getContig: String = variant.chrom
+    override def getStart: Int     = variant.pos
+    override def getEnd: Int       = variant.end
+  }
 }
 
 
@@ -121,6 +131,6 @@ final case class Variant(chrom: String,
   /** Returns an iterator over the genotypes for this variant. */
   def gts: Iterator[Genotype] = this.genotypes.valuesIterator
 
-  /** Returns a [[VariantLocatable]] for this variant. */
-  def toLocatable: VariantLocatable = new VariantLocatable(this)
+  /** Returns a [[Variant.LocatableVariant]] for this variant. */
+  def toLocatable: Variant.LocatableVariant = new Variant.LocatableVariant(this)
 }

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
@@ -24,11 +24,9 @@
 
 package com.fulcrumgenomics.vcf.api
 
-import com.fulcrumgenomics.vcf.api.VcfConversions.VariantLocatable
 import htsjdk.samtools.util.Locatable
 
 import scala.collection.immutable.ListMap
-import scala.reflect.ClassTag
 
 object Variant {
   /** Value used in VCF for values that are missing. */

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/VcfConversions.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/VcfConversions.scala
@@ -30,7 +30,6 @@ import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.fasta.SequenceMetadata
 import com.fulcrumgenomics.vcf.api.Allele.NoCallAllele
 import com.fulcrumgenomics.vcf.api.VcfCount.Fixed
-import htsjdk.samtools.util.Locatable
 import htsjdk.variant.variantcontext.{GenotypeBuilder, VariantContext, VariantContextBuilder, Allele => JavaAllele}
 import htsjdk.variant.vcf._
 
@@ -359,14 +358,5 @@ private[api] object VcfConversions {
     }
 
     out
-  }
-
-  /**
-    * Little container class for a [[Variant]] to make it locatable (see [[Locatable]]).
-    */
-  implicit class VariantLocatable(variant: Variant) extends Locatable {
-    override def getContig: String = variant.chrom
-    override def getStart: Int     = variant.pos
-    override def getEnd: Int       = variant.end
   }
 }

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/VcfConversions.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/VcfConversions.scala
@@ -24,8 +24,6 @@
 
 package com.fulcrumgenomics.vcf.api
 
-import java.util
-import java.util.{List => JavaList}
 import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.fasta.SequenceMetadata
 import com.fulcrumgenomics.vcf.api.Allele.NoCallAllele
@@ -33,6 +31,8 @@ import com.fulcrumgenomics.vcf.api.VcfCount.Fixed
 import htsjdk.variant.variantcontext.{GenotypeBuilder, VariantContext, VariantContextBuilder, Allele => JavaAllele}
 import htsjdk.variant.vcf._
 
+import java.util
+import java.util.{List => JavaList}
 import scala.collection.JavaConverters.mapAsJavaMapConverter
 import scala.collection.immutable.ListMap
 

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/VcfConversions.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/VcfConversions.scala
@@ -364,7 +364,7 @@ private[api] object VcfConversions {
   /**
     * Little container class for a [[Variant]] to make it locatable (see [[Locatable]]).
     */
-  implicit case class VariantLocatable(variant: Variant) extends Locatable {
+  implicit class VariantLocatable(variant: Variant) extends Locatable {
     override def getContig: String = variant.chrom
     override def getStart: Int     = variant.pos
     override def getEnd: Int       = variant.end

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/VcfConversions.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/VcfConversions.scala
@@ -26,17 +26,16 @@ package com.fulcrumgenomics.vcf.api
 
 import java.util
 import java.util.{List => JavaList}
-
 import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.fasta.SequenceMetadata
 import com.fulcrumgenomics.vcf.api.Allele.NoCallAllele
 import com.fulcrumgenomics.vcf.api.VcfCount.Fixed
+import htsjdk.samtools.util.Locatable
 import htsjdk.variant.variantcontext.{GenotypeBuilder, VariantContext, VariantContextBuilder, Allele => JavaAllele}
 import htsjdk.variant.vcf._
 
 import scala.collection.JavaConverters.mapAsJavaMapConverter
 import scala.collection.immutable.ListMap
-import scala.collection.mutable
 
 /**
   * Object that provides methods for converting from fgbio's scala VCF classes to HTSJDK's
@@ -360,5 +359,14 @@ private[api] object VcfConversions {
     }
 
     out
+  }
+
+  /**
+    * Little container class for a [[Variant]] to make it locatable (see [[Locatable]]).
+    */
+  implicit case class VariantLocatable(variant: Variant) extends Locatable {
+    override def getContig: String = variant.chrom
+    override def getStart: Int     = variant.pos
+    override def getEnd: Int       = variant.end
   }
 }


### PR DESCRIPTION
Alternate implementation of https://github.com/fulcrumgenomics/fgbio/pull/696

This gives two ways:
- use `toLocatable` on `Variant` directly
- import the implicit class `VariantLocatable`

The `VariantLocatable` class is just a container class for `Variant`, implementing the required methods for `Locatable`.  So you can use `VariantLocatable` anywhere `Locatable` is required, and still return the variant. 