### PR TITLE
[feature] add a cache into CorrectUmis

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -128,7 +128,7 @@ lazy val root = Project(id="fgbio", base=file("."))
       "org.scala-lang"            %  "scala-compiler" % scalaVersion.value,
       "org.scala-lang.modules"    %% "scala-xml"      % "1.2.0",
       "org.scala-lang.modules"    %% "scala-collection-compat" % "2.1.1",
-      "com.fulcrumgenomics"       %% "commons"        % "1.1.0",
+      "com.fulcrumgenomics"       %% "commons"        % "1.2.0-2ebb019-SNAPSHOT",
       "com.fulcrumgenomics"       %% "sopt"           % "1.1.0",
       "com.github.samtools"       %  "htsjdk"         % "2.23.0" excludeAll(htsjdkExcludes: _*),
       "org.apache.commons"        %  "commons-math3"  % "3.6.1",

--- a/src/main/scala/com/fulcrumgenomics/FgBioDef.scala
+++ b/src/main/scala/com/fulcrumgenomics/FgBioDef.scala
@@ -36,10 +36,6 @@ import scala.math.Ordering
   */
 object FgBioDef extends CommonsDef {
 
-  // TODO: Remove this once it is merged in commons: https://github.com/fulcrumgenomics/commons/pull/63
-  /** Represents a path to a sequence dictionary (.dict). */
-  type PathToSequenceDictionary = java.nio.file.Path
-
   /** Extends this trait in your enumeration object to enable the case objects to be created on the command line.
     * You should implement the [[enumeratum.Enum#values]] method in your object, for example:
     * `def values: IndexedSeq[T] = findValues`.

--- a/src/test/scala/com/fulcrumgenomics/umi/CorrectUmisTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/CorrectUmisTest.scala
@@ -24,7 +24,6 @@
 
 package com.fulcrumgenomics.umi
 
-import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.testing.{SamBuilder, UnitSpec}
 import com.fulcrumgenomics.umi.CorrectUmis.{UmiCorrectionMetrics, UmiMatch}
 import com.fulcrumgenomics.util.{Io, Metric}


### PR DESCRIPTION
This is useful when we have a large set (>1K) of Umis