### PR TITLE
Validate that a Variant and its Genotypes have the same alleles

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
@@ -100,7 +100,7 @@ final case class Variant(chrom: String,
                          attrs: ListMap[String,Any] = Variant.EmptyInfo,
                          genotypes: Map[String, Genotype] = Variant.EmptyGenotypes
                         ) {
-  require(gts.forall(_.alleles == alleles), "Genotypes must have the same alleles as their Variant.")
+  require(gts.forall(gt => gt.alleles eq alleles || gt.alleles == alleles), "Genotypes must have the same alleles as their Variant.")
 
   /** The end position of the variant based on either the `END` INFO field _or_ the length of the reference allele. */
   val end: Int = get[Int]("END").getOrElse(pos + alleles.ref.length - 1)

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
@@ -100,7 +100,7 @@ final case class Variant(chrom: String,
                          attrs: ListMap[String,Any] = Variant.EmptyInfo,
                          genotypes: Map[String, Genotype] = Variant.EmptyGenotypes
                         ) {
-  require(genotypes.values.forall(_.alleles == alleles), "Genotypes must have the same alleles as their Variant.")
+  require(gts.forall(_.alleles == alleles), "Genotypes must have the same alleles as their Variant.")
 
   /** The end position of the variant based on either the `END` INFO field _or_ the length of the reference allele. */
   val end: Int = get[Int]("END").getOrElse(pos + alleles.ref.length - 1)

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
@@ -100,6 +100,7 @@ final case class Variant(chrom: String,
                          attrs: ListMap[String,Any] = Variant.EmptyInfo,
                          genotypes: Map[String, Genotype] = Variant.EmptyGenotypes
                         ) {
+  require(genotypes.values.forall(_.alleles == alleles), "Genotypes must have the same alleles as their Variant.")
 
   /** The end position of the variant based on either the `END` INFO field _or_ the length of the reference allele. */
   val end: Int = get[Int]("END").getOrElse(pos + alleles.ref.length - 1)

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/Variant.scala
@@ -100,7 +100,7 @@ final case class Variant(chrom: String,
                          attrs: ListMap[String,Any] = Variant.EmptyInfo,
                          genotypes: Map[String, Genotype] = Variant.EmptyGenotypes
                         ) {
-  require(gts.forall(gt => gt.alleles eq alleles || gt.alleles == alleles), "Genotypes must have the same alleles as their Variant.")
+  require(gts.forall(gt => gt.alleles.eq(alleles) || gt.alleles == alleles), "Genotypes must have the same alleles as their Variant.")
 
   /** The end position of the variant based on either the `END` INFO field _or_ the length of the reference allele. */
   val end: Int = get[Int]("END").getOrElse(pos + alleles.ref.length - 1)

--- a/src/test/scala/com/fulcrumgenomics/vcf/api/VariantTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/vcf/api/VariantTest.scala
@@ -24,11 +24,28 @@
 
 package com.fulcrumgenomics.vcf.api
 
-import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.testing.UnitSpec
 import org.scalatest.OptionValues
 
 class VariantTest extends UnitSpec with OptionValues {
+  "Variant" should "not allow you to add genotypes that have a different set of alleles" in {
+    val sample    = "sample"
+    val gtAlleles = AlleleSet(Allele("A"), Allele("T")) // Extra allele compared to its variant.
+    val genotype  = Genotype(alleles = gtAlleles, sample = sample, calls = gtAlleles.toIndexedSeq)
+    an[IllegalArgumentException] shouldBe thrownBy {
+      Variant("chr1", 1, alleles = AlleleSet(Allele("A")), genotypes = Map(sample -> genotype))
+    }
+  }
+
+  it should "allow you to add genotypes that have the same set of alleles" in {
+    val sample   = "sample"
+    val alleles  = AlleleSet(Allele("A"))
+    val genotype = Genotype(alleles = alleles, sample = sample, calls = alleles.toIndexedSeq)
+    noException shouldBe thrownBy {
+      Variant("chr1", 1, alleles = alleles, genotypes = Map(sample -> genotype))
+    }
+  }
+
   "Variant.isMissingValue" should "correctly handle missing and non-missing values" in {
     Variant.isMissingValue(".") shouldBe true
     Variant.isMissingValue('.') shouldBe true


### PR DESCRIPTION
It's my understanding that the `alleles` field of Genotype should be identical to the `alleles` field of its parent `Variant`. 

Would you be OK adding this as a construction-time validation?