### PR TITLE
Add an option to DemuxFastqs to insert sample barcodes in the FASTQ header

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/fastq/DemuxFastqs.scala
+++ b/src/main/scala/com/fulcrumgenomics/fastq/DemuxFastqs.scala
@@ -810,10 +810,10 @@ object ReadInfo {
   private def reject(name: String) = throw new IllegalArgumentException(s"Cannot extract ReadInfo due to missing comment: $recname")
 
   /** Builds the [[ReadInfo]] by parsing a [[FastqRecord]]. */
-  def apply(rec: FastqRecord): ReadInfo = this(rec.name, rec.comment.getOrElse(reject(rec.name))
+  def apply(rec: FastqRecord): ReadInfo = this(rec.name, rec.comment.getOrElse(reject(rec.name)))
 
   /** Builds the [[ReadInfo]] by parsing a [[DemuxRecord]]. */
-  def apply(rec: DemuxRecord): ReadInfo = this(rec.name, rec.comment.getOrElse(reject(rec.name))
+  def apply(rec: DemuxRecord): ReadInfo = this(rec.name, rec.comment.getOrElse(reject(rec.name)))
 
   /** Builds the [[ReadInfo]] by parsing a standard input FASTQ. */
   def apply(name: String, comment: String): ReadInfo = try { // <- comment is an Option[String] in FastqRecord and DemuxRecord

--- a/src/main/scala/com/fulcrumgenomics/fastq/DemuxFastqs.scala
+++ b/src/main/scala/com/fulcrumgenomics/fastq/DemuxFastqs.scala
@@ -807,7 +807,7 @@ case class ReadInfo(readNumber: Int, passQc: Boolean, internalControl: Boolean, 
 }
 
 object ReadInfo {
-  private def reject(name: String) = throw new IllegalArgumentException(s"Cannot extract ReadInfo due to missing comment: $recname")
+  private def reject(name: String) = throw new IllegalArgumentException(s"Cannot extract ReadInfo due to missing comment: $name")
 
   /** Builds the [[ReadInfo]] by parsing a [[FastqRecord]]. */
   def apply(rec: FastqRecord): ReadInfo = this(rec.name, rec.comment.getOrElse(reject(rec.name)))

--- a/src/main/scala/com/fulcrumgenomics/fastq/DemuxFastqs.scala
+++ b/src/main/scala/com/fulcrumgenomics/fastq/DemuxFastqs.scala
@@ -483,10 +483,8 @@ private class SamRecordWriter(prefix: PathPrefix,
       record.mateUnmapped = true
       if (rec.readNumber == 1) record.firstOfPair = true else record.secondOfPair = true
     }
-//    rec.sampleBarcode.foreach(bc => record("BC") = bc)
     if (rec.sampleBarcode.nonEmpty) record("BC") = rec.sampleBarcode.mkString("-")
     record(ReservedTagConstants.READ_GROUP_ID) =  rgId
-//    rec.molecularBarcode.foreach(mb => record(umiTag) = mb)
     if (rec.molecularBarcode.nonEmpty) record(umiTag) = rec.molecularBarcode.mkString("-")
     writer += record
   }
@@ -694,7 +692,6 @@ private class FastqDemultiplexer(val sampleInfos: Seq[SampleInfo],
     // Method to get all the bases of a given type
     def bases(segmentType: SegmentType): Seq[String] = {
       subReads.filter(_.kind == segmentType).map(_.bases)
-//       if (b.isEmpty) None else Some(b) // <-- ask about this part, not quite sure what Some does.
     }
 
     // Get the molecular and sample barcodes

--- a/src/test/scala/com/fulcrumgenomics/fastq/DemuxFastqsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/fastq/DemuxFastqsTest.scala
@@ -607,7 +607,7 @@ class DemuxFastqsTest extends UnitSpec with OptionValues with ErrorLogLevel {
    }
   }
 
-  it should "demultiplex with --fastqs-include-read-numbers=false --fastqs-includ-sample-barcodes=false" in {
+  it should "demultiplex with --fastqs-include-read-numbers=false --fastqs-include-sample-barcodes=false" in {
     testEndToEndWithFastqStandards(FastqStandards(includeReadNumbers=false, includeSampleBarcodes=false))
   }
 

--- a/src/test/scala/com/fulcrumgenomics/fastq/DemuxFastqsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/fastq/DemuxFastqsTest.scala
@@ -546,17 +546,17 @@ class DemuxFastqsTest extends UnitSpec with OptionValues with ErrorLogLevel {
     val output     = outputDir()
     val structures = Seq(ReadStructure("17B100T"), ReadStructure("117T"))
     new DemuxFastqs(
-      inputs                     = Seq(illuminaReadNamesFastqPath, illuminaReadNamesFastqPath),
-      output                     = output,
-      metadata                   = sampleSheetPath,
-      readStructures             = structures,
-      metrics                    = None,
-      maxMismatches              = 2,
-      minMismatchDelta           = 3,
-      outputType                 = Some(OutputType.Fastq),
-      fastqSkipReadNumbers       = !fastqStandards.includeReadNumbers,
-      fastqIncludeSampleBarcodes = fastqStandards.includeSampleBarcodes,
-      illuminaFileNames          = fastqStandards.illuminaFileNames
+      inputs                       = Seq(illuminaReadNamesFastqPath, illuminaReadNamesFastqPath),
+      output                       = output,
+      metadata                     = sampleSheetPath,
+      readStructures               = structures,
+      metrics                      = None,
+      maxMismatches                = 2,
+      minMismatchDelta             = 3,
+      outputType                   = Some(OutputType.Fastq),
+      omitFastqReadNumbers         = !fastqStandards.includeReadNumbers,
+      includeSampleBarcodesInFastq = fastqStandards.includeSampleBarcodes,
+      illuminaFileNames            = fastqStandards.illuminaFileNames
     ).execute()
 
 
@@ -607,19 +607,19 @@ class DemuxFastqsTest extends UnitSpec with OptionValues with ErrorLogLevel {
    }
   }
 
-  it should "demultiplex with --fastqs-include-read-numbers=false --fastqs-include-sample-barcodes=false" in {
+  it should "demultiplex with --omit-fastq-read-numbers=false --include-sample-barcodes-in-fastq=false" in {
     testEndToEndWithFastqStandards(FastqStandards(includeReadNumbers=false, includeSampleBarcodes=false))
   }
 
-  it should "demultiplex with --fastqs-include-read-numbers=true --fastqs-includ-sample-barcodes=false" in {
+  it should "demultiplex with --omit-fastq-read-numbers=true --include-sample-barcodes-in-fastq=false" in {
     testEndToEndWithFastqStandards(FastqStandards(includeReadNumbers=true, includeSampleBarcodes=false))
   }
 
-  it should "demultiplex with --fastqs-include-read-numbers=false --fastqs-includ-sample-barcodes=true" in {
+  it should "demultiplex with --omit-fastq-read-numbers=false --include-sample-barcodes-in-fastq=true" in {
     testEndToEndWithFastqStandards(FastqStandards(includeReadNumbers=false, includeSampleBarcodes=true))
   }
 
-  it should "demultiplex with --fastqs-include-read-numbers=true --fastqs-includ-sample-barcodes=true" in {
+  it should "demultiplex with --omit-fastq-read-numbers=true --include-sample-barcodes-in-fastq=true" in {
     testEndToEndWithFastqStandards(FastqStandards(includeReadNumbers=true, includeSampleBarcodes=true))
   }
 
@@ -812,7 +812,7 @@ class DemuxFastqsTest extends UnitSpec with OptionValues with ErrorLogLevel {
 
     new DemuxFastqs(inputs=Seq(fq1, fq2, fq3, fq4), output=output, metadata=sampleSheetPath,
       readStructures=structures, metrics=Some(metrics), maxMismatches=2, minMismatchDelta=3,
-      outputType=Some(OutputType.BamAndFastq), includeAllBasesInFastqs=true, fastqIncludeSampleBarcodes=true).execute()
+      outputType=Some(OutputType.BamAndFastq), includeAllBasesInFastqs=true, includeSampleBarcodesInFastq=true).execute()
 
     val sampleInfos         = toSampleInfos(structures)
     val matchedSampleInfo   = sampleInfos.find(!_.isUnmatched).get
@@ -904,18 +904,6 @@ class DemuxFastqsTest extends UnitSpec with OptionValues with ErrorLogLevel {
 
   it should "fail if the read name or comment does not follow Illumina standards" in {
     val baseRec   = DemuxRecord(name="name", bases="", quals="", molecularBarcode=Seq("MB"), sampleBarcode=Seq("SB"), readNumber=1, pairedEnd=false, comment=None)
-
-    // too few fields in the name
-    {
-      val rec    = baseRec.copy(pairedEnd=true, name="RunID:FlowCellID:Lane:Tile:X:Y", comment=Some("1:N:0:SampleNumber"))
-      an[Exception] should be thrownBy ReadInfo(rec)
-    }
-
-    // too many fields in the name
-    {
-      val rec    = baseRec.copy(pairedEnd=true, name="Instrument:RunID:FlowCellID:Lane:Tile:X:Y:Z", comment=Some("1:N:0:SampleNumber"))
-      an[Exception] should be thrownBy ReadInfo(rec)
-    }
 
     // too few fields in the comment
     {


### PR DESCRIPTION
1. Deprecates the `--illumina-standards` option in favor of more explicit fine-grained options
2. `--fastq-include-sample-barcodes` will insert the sample barcode(s) into the FASTQ comment in the FASTQ header
3. `--fastq-skip-read-numbers` will _not_ insert trailing `/1` or `/2/ into the read names in the FASTQs
4. `--illumina-file-names` will name the output files according to bcl2fastq output file names

The above (2-3) are named the way they are with defaults to not change the current default behavior.

Also added the `--platform` option as not all reads are Illumina these days.
