### PR TITLE
AnnotateBamWithUmis Bug Fix

### DIFF
--- a/src/test/scala/com/fulcrumgenomics/umi/AnnotateBamWithUmisTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/AnnotateBamWithUmisTest.scala
@@ -117,12 +117,24 @@ class AnnotateBamWithUmisTest extends UnitSpec {
     })
   }
 
-  it should "successfully add UMIs to a BAM with a given read structure in" in {
+  it should "successfully add UMIs to a BAM with a given read structure" in {
     val out       = makeTempFile("with_umis.", ".bam")
     val annotator = new AnnotateBamWithUmis(input=sam, fastq=fq, output=out, attribute=umiTag, readStructure=ReadStructure("2B4M+B"))
     annotator.execute()
     SamSource(out).foreach(rec => {
       rec[String](umiTag) shouldBe rec.basesString.substring(2,6)
+    })
+  }
+
+  it should "successfully add UMIs to a BAM with a given read structure with multiple molecular barcodes" in {
+    val out       = makeTempFile("with_umis.", ".bam")
+    val annotator = new AnnotateBamWithUmis(input=sam, fastq=fq, output=out, attribute=umiTag, qualAttribute=Some(qualTag), readStructure=ReadStructure("2M2B+M"))
+    annotator.execute()
+    SamSource(out).foreach(rec => {
+      val bases = rec.basesString
+      val quals = rec.qualsString
+      rec[String](umiTag) shouldBe bases.substring(0,2) + "-" + bases.substring(4, 8)
+      rec[String](qualTag) shouldBe quals.substring(0,2) + " " + quals.substring(4, 8)
     })
   }
 }


### PR DESCRIPTION
This [commit](https://github.com/Poshi/fgbio/commit/468a843d19da4f67106dc148a1dba1f2c3390eab#diff-6af11c9e15cd56e53dde749b569558bdbb3755c359842f43abef11c6ba04d07e) incorrectly joined the UMI bases with no separator when there were multiple segments.   Then #733 was introduced which only returned the first set of UMI bases ([commit](https://github.com/Poshi/fgbio/blob/daa0254beaab498f66de13bfb5c02f7e2e2b041c/src/main/scala/com/fulcrumgenomics/umi/AnnotateBamWithUmis.scala#L94)).  The latter would not properly annotate `5M3S5M` for example, as it would only take the first 5 bp.

- [x] needs tests