### PR TITLE
Forcing log4j transitive dependency (through GKL) to version that doesn't have zero day exploit.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ JeanLuc.iml
 target
 project/project
 .DS_Store
+.bsp

--- a/build.sbt
+++ b/build.sbt
@@ -137,7 +137,11 @@ lazy val root = Project(id="fgbio", base=file("."))
 
       //---------- Test libraries -------------------//
       "org.scalatest"             %% "scalatest"     % "3.1.3"  % "test->*" excludeAll ExclusionRule(organization="org.junit", name="junit")
-    ))
+  ))
+  .settings(dependencyOverrides ++= Seq(
+      "org.apache.logging.log4j" % "log4j-api"  % "[2.15.0,)",
+      "org.apache.logging.log4j" % "log4j-core" % "[2.15.0,)",
+  ))
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.4.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,6 @@
-resolvers += Resolver.url("fix-sbt-plugin-releases", url("http://dl.bintray.com/sbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
+resolvers += Resolver.url("fix-sbt-plugin-releases", url("https://dl.bintray.com/sbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
+
+addDependencyTreePlugin
 
 addSbtPlugin("com.typesafe.sbt"  % "sbt-git"       % "1.0.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release"   % "1.0.10")
@@ -6,6 +8,5 @@ addSbtPlugin("com.eed3si9n"      % "sbt-assembly"  % "0.15.0")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage" % "1.6.1")
 addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"  % "3.9.4")
 addSbtPlugin("com.jsuereth"      % "sbt-pgp"       % "2.0.1")
-addSbtPlugin("net.virtual-void"  % "sbt-dependency-graph" % "0.9.2")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.0")
 


### PR DESCRIPTION
The changes to the plugins and sbt version were just to get a working run of `dependencyTree` so I could track down _why_ we had a dependency on log4j in the first place.

We should probably do a release once this is merged.  Sigh.