### PR TITLE
Allow VcfWriter to write to file links, devices, and named pipes

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/vcf/api/VcfWriter.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/VcfWriter.scala
@@ -30,6 +30,9 @@ import com.fulcrumgenomics.util.Io
 import htsjdk.samtools.Defaults
 import htsjdk.variant.variantcontext.writer.{Options, VariantContextWriter, VariantContextWriterBuilder}
 
+import java.nio.file.Files
+import java.nio.file.LinkOption.NOFOLLOW_LINKS
+
 /**
   * Writes [[Variant]]s to a file or other storage mechanism.
   *
@@ -61,10 +64,16 @@ object VcfWriter {
 
     val builder = new VariantContextWriterBuilder()
       .setOutputPath(path)
-      .setOption(Options.INDEX_ON_THE_FLY)
       .setReferenceDictionary(header.dict.asSam)
       .setOption(Options.ALLOW_MISSING_FIELDS_IN_HEADER)
       .setBuffer(Io.bufferSize)
+
+    if (Files.isRegularFile(path, NOFOLLOW_LINKS)) {
+      builder.setOption(Options.INDEX_ON_THE_FLY)
+    } else {
+      builder.unsetOption(Options.INDEX_ON_THE_FLY)
+      builder.setIndexCreator(null)
+    }
 
     if (async) builder.setOption(Options.USE_ASYNC_IO) else builder.unsetOption(Options.USE_ASYNC_IO)
     val writer = builder.build()

--- a/src/test/scala/com/fulcrumgenomics/vcf/api/VcfIoTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/vcf/api/VcfIoTest.scala
@@ -24,6 +24,7 @@
 
 package com.fulcrumgenomics.vcf.api
 
+import com.fulcrumgenomics.commons.io.Io
 import com.fulcrumgenomics.testing.{UnitSpec, VcfBuilder}
 import com.fulcrumgenomics.testing.VcfBuilder.Gt
 import com.fulcrumgenomics.vcf.api.Allele.NoCallAllele
@@ -224,5 +225,14 @@ class VcfIoTest extends UnitSpec with OptionValues {
     v.gt("C").callIndices.mkString("/") shouldBe "0/0"
     v.gt("D").callIndices.mkString("/") shouldBe "1/3"
     v.gt("0").callIndices.mkString("/") shouldBe "2/3"
+  }
+
+  it should "not attempt to index a VCF when streaming to a file handle or other kind of non-regular file" in {
+    val samples = Seq("sample")
+    val builder = VcfBuilder(samples=samples)
+    val writer  = VcfWriter(Io.DevNull, header = builder.header)
+    builder.add(chrom = "chr1", pos = 100, alleles = Seq("A", "C"), gts = Seq(Gt(sample="sample", gt="0/1")))
+    noException shouldBe thrownBy { writer.write(builder.toSeq) }
+    writer.close()
   }
 }


### PR DESCRIPTION
You can get a null-pointer exception when closing a `VcfWriter` if you are writing to a named pipe or device like `/dev/stdout`:

```scala
Exception in thread "main" java.lang.NullPointerException
	at htsjdk.tribble.index.AbstractIndex.<init>(AbstractIndex.java:181)
	at htsjdk.tribble.index.linear.LinearIndex.<init>(LinearIndex.java:73)
	at htsjdk.tribble.index.linear.LinearIndexCreator.finalizeIndex(LinearIndexCreator.java:122)
	at htsjdk.tribble.index.DynamicIndexCreator.finalizeIndex(DynamicIndexCreator.java:92)
	at htsjdk.variant.variantcontext.writer.IndexingVariantContextWriter.close(IndexingVariantContextWriter.java:177)
	at htsjdk.variant.variantcontext.writer.VCFWriter.close(VCFWriter.java:233)
	at com.fulcrumgenomics.vcf.api.VcfWriter.close(VcfWriter.scala:41)
	at com.my.coordinate.MyTool.execute(MyTool.scala:197)
	at com.fulcrumgenomics.cmdline.FgBioMain.makeItSo(FgBioMain.scala:110)
	at com.fulcrumgenomics.cmdline.FgBioMain.makeItSoAndExit(FgBioMain.scala:86)
	at com.my.coordinate.cmdline.MyToolMain$.main(MyToolMain.scala:12)
	at com.my.coordinate.cmdline.MyToolMain.main(MyToolMain.scala)
```

HTSJDK should probably be patched so the NPE can't happen in the first place, but this PR gives some safety.