### PR TITLE
Add better error messages for malformed input to Metric classes

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/cmdline/FgBioMain.scala
+++ b/src/main/scala/com/fulcrumgenomics/cmdline/FgBioMain.scala
@@ -53,7 +53,7 @@ object FgBioMain {
     * Exception class intended to be used by [[FgBioMain]] and [[FgBioTool]] to communicate
     * non-exceptional(!) failures when running a tool.
     */
-  case class FailureException private[cmdline] (exit:Int = 1, message: Option[String] = None) extends RuntimeException
+  case class FailureException private[cmdline] (exit: Int = 1, message: Option[String] = None) extends RuntimeException
 }
 
 class FgBioCommonArgs

--- a/src/main/scala/com/fulcrumgenomics/cmdline/FgBioMain.scala
+++ b/src/main/scala/com/fulcrumgenomics/cmdline/FgBioMain.scala
@@ -53,7 +53,7 @@ object FgBioMain {
     * Exception class intended to be used by [[FgBioMain]] and [[FgBioTool]] to communicate
     * non-exceptional(!) failures when running a tool.
     */
-  case class FailureException private[cmdline] (exit:Int = 1, message:Option[String] = None) extends RuntimeException
+  case class FailureException private[cmdline] (exit:Int = 1, message: Option[String] = None) extends RuntimeException
 }
 
 class FgBioCommonArgs

--- a/src/main/scala/com/fulcrumgenomics/util/Metric.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/Metric.scala
@@ -25,23 +25,24 @@
 
 package com.fulcrumgenomics.util
 
-import java.io.{Closeable, Writer}
+import com.fulcrumgenomics.cmdline.FgBioMain.FailureException
+import com.fulcrumgenomics.commons.CommonsDef._
+import com.fulcrumgenomics.commons.io.{Writer => CommonsWriter}
+import com.fulcrumgenomics.commons.reflect.{ReflectionUtil, ReflectiveBuilder}
+import com.fulcrumgenomics.commons.util.{DelimitedDataParser, LazyLogging}
+import enumeratum.EnumEntry
+import htsjdk.samtools.util.Iso8601Date
+
+import java.io.{PrintWriter, StringWriter, Writer}
 import java.nio.file.Path
 import java.text.{DecimalFormat, NumberFormat, SimpleDateFormat}
 import java.util.Date
-import com.fulcrumgenomics.commons.CommonsDef._
-import com.fulcrumgenomics.commons.reflect.{ReflectionUtil, ReflectiveBuilder}
-import com.fulcrumgenomics.commons.util.DelimitedDataParser
-import htsjdk.samtools.util.{FormatUtil, Iso8601Date}
-import com.fulcrumgenomics.commons.io.{Writer => CommonsWriter}
-import enumeratum.EnumEntry
-
 import scala.collection.compat._
 import scala.collection.concurrent.TrieMap
 import scala.reflect.runtime.{universe => ru}
 import scala.util.{Failure, Success}
 
-object Metric {
+object Metric extends LazyLogging {
   val Delimiter: Char = '\t'
   val DelimiterAsString: String = s"$Delimiter"
 
@@ -101,14 +102,30 @@ object Metric {
   /** Reads metrics from a set of lines.  The first line should be the header with the field names.  Each subsequent
     * line should be a single metric. */
   def iterator[T <: Metric](lines: Iterator[String], source: Option[String] = None)(implicit tt: ru.TypeTag[T]): Iterator[T] = {
-    if (lines.isEmpty) throw new IllegalArgumentException(s"No header found in metrics" + source.map(" in source: " + _).getOrElse(""))
+    val clazz: Class[T]   = ReflectionUtil.typeTagToClass[T]
+
+    def fail(lineNumber: Int,
+             message: String,
+             throwable: Option[Throwable] = None): Unit = {
+      val sourceMessage = source.map("\nIn source: " + _).getOrElse("")
+      val fullMessage   = s"On line #$lineNumber for metric '${clazz.getSimpleName}'$sourceMessage\n$message"
+      throwable.foreach { thr =>
+        val stringWriter = new StringWriter
+        thr.printStackTrace(new PrintWriter(stringWriter))
+        val banner = "#" * 80
+        logger.debug(banner)
+        logger.debug(stringWriter.toString)
+        logger.debug(banner)
+      }
+      throw FailureException(message=Some(fullMessage))
+    }
+
+    if (lines.isEmpty) fail(lineNumber=1, message="No header found")
     val parser = new DelimitedDataParser(lines=lines, delimiter=Delimiter, ignoreBlankLines=false, trimFields=true)
     val names  = parser.headers.toIndexedSeq
-
-    val clazz             = ReflectionUtil.typeTagToClass[T]
     val reflectiveBuilder = new ReflectiveBuilder(clazz)
 
-    parser.map { row =>
+    parser.zipWithIndex.map { case (row, rowIndex) =>
       forloop(from = 0, until = names.length) { i =>
         reflectiveBuilder.argumentLookup.forField(names(i)) match {
           case Some(arg) =>
@@ -119,11 +136,12 @@ object Metric {
 
             val argumentValue = ReflectionUtil.constructFromString(arg.argumentType, arg.unitType, value) match {
               case Success(v) => v
-              case Failure(thr) => throw thr
+              case Failure(thr) =>
+                fail(lineNumber=rowIndex+2, message=s"Could not construct value for column '${arg.name}' of type '${arg.typeDescription}' from '$value'", Some(thr))
             }
             arg.value = argumentValue
           case None =>
-            throw new IllegalArgumentException(s"The class '${clazz.getSimpleName}' did not have a field with name '${names(i)}'.")
+            fail(lineNumber=rowIndex+2, message=s"Did not have a field with name '${names(i)}'.")
         }
       }
 


### PR DESCRIPTION
This improves the error message when running `fgbio` and toolkits that extend it to output a much easier to understand message about where and why it can't construct a `Metric` sub-class.  This includes line number, source file (if given), the metric class name, column name, and a better message about why.

How?
It changes the exceptions raised in `Metric.iterator` to `FailureException`, which causes `FgBioMain` and sub-classes to only print the message not the full stack trace.  This makes it A LOT easier to debug when the input metric is malformed.

I also logged the full stack trace of the cause (throwable) at the debug level.

See examples below:

<details>

<summary>Console log before this change</summary>

```console
[2022/01/08 19:17:02 | ClientToolMain | Info] ExampleTool failed. Elapsed time: 0.02 minutes.
Exception in thread "main" com.fulcrumgenomics.commons.reflect.ReflectionException: Could not build a 'double' from a string: :none:: null
sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
java.lang.reflect.Constructor.newInstance(Constructor.java:423)
com.fulcrumgenomics.commons.reflect.ReflectionUtil$.$anonfun$buildUnitFromString$5(ReflectionUtil.scala:398)
scala.util.Try$.apply(Try.scala:210)
com.fulcrumgenomics.commons.reflect.ReflectionUtil$.$anonfun$buildUnitFromString$1(ReflectionUtil.scala:394)
scala.util.Try$.apply(Try.scala:210)
com.fulcrumgenomics.commons.reflect.ReflectionUtil$.buildUnitFromString(ReflectionUtil.scala:370)
com.fulcrumgenomics.commons.reflect.ReflectionUtil$.$anonfun$buildUnitOrOptionFromString$1(ReflectionUtil.scala:364)
scala.util.Try$.apply(Try.scala:210)
com.fulcrumgenomics.commons.reflect.ReflectionUtil$.buildUnitOrOptionFromString(ReflectionUtil.scala:363)
com.fulcrumgenomics.commons.reflect.ReflectionUtil$.$anonfun$typedValueFromString$1(ReflectionUtil.scala:349)
scala.util.Try$.apply(Try.scala:210)
com.fulcrumgenomics.commons.reflect.ReflectionUtil$.typedValueFromString(ReflectionUtil.scala:315)
com.fulcrumgenomics.commons.reflect.ReflectionUtil$.$anonfun$constructFromString$1(ReflectionUtil.scala:293)
scala.util.Try$.apply(Try.scala:210)
com.fulcrumgenomics.commons.reflect.ReflectionUtil$.constructFromString(ReflectionUtil.scala:287)
com.fulcrumgenomics.util.Metric$.$anonfun$iterator$4(Metric.scala:107)
com.fulcrumgenomics.commons.CommonsDef.forloop(CommonsDef.scala:305)
com.fulcrumgenomics.commons.CommonsDef.forloop$(CommonsDef.scala:301)
com.fulcrumgenomics.commons.CommonsDef$.forloop(CommonsDef.scala:422)
com.fulcrumgenomics.util.Metric$.$anonfun$iterator$3(Metric.scala:99)
scala.collection.Iterator$$anon$9.next(Iterator.scala:575)
scala.collection.immutable.List.prependedAll(List.scala:153)
scala.collection.immutable.List$.from(List.scala:651)
scala.collection.immutable.List$.from(List.scala:648)
scala.collection.SeqFactory$Delegate.from(Factory.scala:306)
scala.collection.immutable.Seq$.from(Seq.scala:42)
scala.collection.IterableOnceOps.toSeq(IterableOnce.scala:1270)
scala.collection.IterableOnceOps.toSeq$(IterableOnce.scala:1270)
scala.collection.AbstractIterator.toSeq(Iterator.scala:1279)
com.fulcrumgenomics.util.Metric$.read(Metric.scala:131)
com.fulcrumgenomics.util.Metric$.read(Metric.scala:136)
com.client.tools.ExampleTool.execute(ExampleTool.scala:22)
com.fulcrumgenomics.cmdline.FgBioMain.makeItSo(FgBioMain.scala:110)
com.fulcrumgenomics.cmdline.FgBioMain.makeItSoAndExit(FgBioMain.scala:86)
com.client.cmdline.ClientToolMain$.main(ClientToolMain.scala:10)
com.client.cmdline.ClientToolMain.main(ClientToolMain.scala)
	at com.fulcrumgenomics.commons.reflect.ReflectionUtil$$anonfun$$nestedInanonfun$buildUnitFromString$1$2.applyOrElse(ReflectionUtil.scala:413)
	at com.fulcrumgenomics.commons.reflect.ReflectionUtil$$anonfun$$nestedInanonfun$buildUnitFromString$1$2.applyOrElse(ReflectionUtil.scala:411)
	at scala.util.Failure.recover(Try.scala:233)
	at com.fulcrumgenomics.commons.reflect.ReflectionUtil$.$anonfun$buildUnitFromString$1(ReflectionUtil.scala:411)
	at scala.util.Try$.apply(Try.scala:210)
	at com.fulcrumgenomics.commons.reflect.ReflectionUtil$.buildUnitFromString(ReflectionUtil.scala:370)
	at com.fulcrumgenomics.commons.reflect.ReflectionUtil$.$anonfun$buildUnitOrOptionFromString$1(ReflectionUtil.scala:364)
	at scala.util.Try$.apply(Try.scala:210)
	at com.fulcrumgenomics.commons.reflect.ReflectionUtil$.buildUnitOrOptionFromString(ReflectionUtil.scala:363)
	at com.fulcrumgenomics.commons.reflect.ReflectionUtil$.$anonfun$typedValueFromString$1(ReflectionUtil.scala:349)
	at scala.util.Try$.apply(Try.scala:210)
	at com.fulcrumgenomics.commons.reflect.ReflectionUtil$.typedValueFromString(ReflectionUtil.scala:315)
	at com.fulcrumgenomics.commons.reflect.ReflectionUtil$.$anonfun$constructFromString$1(ReflectionUtil.scala:293)
	at scala.util.Try$.apply(Try.scala:210)
	at com.fulcrumgenomics.commons.reflect.ReflectionUtil$.constructFromString(ReflectionUtil.scala:287)
	at com.fulcrumgenomics.util.Metric$.$anonfun$iterator$4(Metric.scala:107)
	at com.fulcrumgenomics.commons.CommonsDef.forloop(CommonsDef.scala:305)
	at com.fulcrumgenomics.commons.CommonsDef.forloop$(CommonsDef.scala:301)
	at com.fulcrumgenomics.commons.CommonsDef$.forloop(CommonsDef.scala:422)
	at com.fulcrumgenomics.util.Metric$.$anonfun$iterator$3(Metric.scala:99)
	at scala.collection.Iterator$$anon$9.next(Iterator.scala:575)
	at scala.collection.immutable.List.prependedAll(List.scala:153)
	at scala.collection.immutable.List$.from(List.scala:651)
	at scala.collection.immutable.List$.from(List.scala:648)
	at scala.collection.SeqFactory$Delegate.from(Factory.scala:306)
	at scala.collection.immutable.Seq$.from(Seq.scala:42)
	at scala.collection.IterableOnceOps.toSeq(IterableOnce.scala:1270)
	at scala.collection.IterableOnceOps.toSeq$(IterableOnce.scala:1270)
	at scala.collection.AbstractIterator.toSeq(Iterator.scala:1279)
	at com.fulcrumgenomics.util.Metric$.read(Metric.scala:131)
	at com.fulcrumgenomics.util.Metric$.read(Metric.scala:136)
	at com.client.tools.ExampleTool.execute(ExampleTool.scala:22)
	at com.fulcrumgenomics.cmdline.FgBioMain.makeItSo(FgBioMain.scala:110)
	at com.fulcrumgenomics.cmdline.FgBioMain.makeItSoAndExit(FgBioMain.scala:86)
	at com.client.cmdline.ClientToolMain$.main(ClientToolMain.scala:10)
	at com.client.cmdline.ClientToolMain.main(ClientToolMain.scala)
```

</details>

<details>

<summary>Console log after this change</summary>

```console
[2022/01/08 19:13:58 | ClientToolMain | Fatal] #########################################################################################################################################################################################################
[2022/01/08 19:13:58 | ClientToolMain | Fatal] Execution failed!
[2022/01/08 19:13:58 | ClientToolMain | Fatal] On line #2 for metric 'ExampleMetric'
[2022/01/08 19:13:58 | ClientToolMain | Fatal] In source: /path/to/metrics.txt
[2022/01/08 19:13:58 | ClientToolMain | Fatal] Could not construct value for column 'column_name' of type 'Double' from ''
[2022/01/08 19:13:58 | ClientToolMain | Fatal] #########################################################################################################################################################################################################
[2022/01/08 19:13:58 | ClientToolMain | Info] ExampleTool failed. Elapsed time: 0.02 minutes.
```

</details>