### PR TITLE
Support for clipping reads that extend past their mate

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/bam/ClipBam.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ClipBam.scala
@@ -79,7 +79,7 @@ class ClipBam
   @arg(          doc="Require at least this number of bases to be clipped on the 5' end of R2") val readTwoFivePrime: Int  = 0,
   @arg(          doc="Require at least this number of bases to be clipped on the 3' end of R2") val readTwoThreePrime: Int = 0,
   @arg(          doc="Clip overlapping reads.", mutex=Array("clipBasesPastMate")) val clipOverlappingReads: Boolean = false,
-  @arg(          doc="Clip reads who sequence past the start of their mate.", mutex=Array("clipOverlappingReads")) val clipBasesPastMate: Boolean = false
+  @arg(          doc="Clip reads in FR pairs that sequence past the far end of their mate.", mutex=Array("clipOverlappingReads")) val clipBasesPastMate: Boolean = false
 ) extends FgBioTool with LazyLogging {
   Io.assertReadable(input)
   Io.assertReadable(ref)

--- a/src/main/scala/com/fulcrumgenomics/bam/ClipBam.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ClipBam.scala
@@ -189,7 +189,11 @@ class ClipBam
     }
 
     val (numExtendingPastMateStartReadOne, numExtendingPastMateStartReadTwo) = {
-      if (clipBasesPastMate && r1.isFrPair) this.clipper.clipExtendingPastMateEnds(r1, r2)
+      if (clipBasesPastMate && r1.isFrPair) {
+        val clip1 = this.clipper.clipExtendingPastMateEnd(rec=r1, mateEnd=r2.end)
+        val clip2 = this.clipper.clipExtendingPastMateEnd(rec=r2, mateEnd=r1.end)
+        (clip1, clip2)
+      }
       else (0, 0)
     }
 

--- a/src/main/scala/com/fulcrumgenomics/bam/ClipBam.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ClipBam.scala
@@ -78,13 +78,14 @@ class ClipBam
   @arg(          doc="Require at least this number of bases to be clipped on the 3' end of R1") val readOneThreePrime: Int = 0,
   @arg(          doc="Require at least this number of bases to be clipped on the 5' end of R2") val readTwoFivePrime: Int  = 0,
   @arg(          doc="Require at least this number of bases to be clipped on the 3' end of R2") val readTwoThreePrime: Int = 0,
-  @arg(          doc="Clip overlapping reads.") val clipOverlappingReads: Boolean = false
+  @arg(          doc="Clip overlapping reads.", mutex=Array("clipBasesPastMate")) val clipOverlappingReads: Boolean = false,
+  @arg(          doc="Clip reads who sequence past the start of their mate.", mutex=Array("clipOverlappingReads")) val clipBasesPastMate: Boolean = false
 ) extends FgBioTool with LazyLogging {
   Io.assertReadable(input)
   Io.assertReadable(ref)
   Io.assertCanWriteFile(output)
 
-  validate(upgradeClipping || clipOverlappingReads || Seq(readOneFivePrime, readOneThreePrime, readTwoFivePrime, readTwoThreePrime).exists(_ != 0),
+  validate(upgradeClipping || clipOverlappingReads || clipBasesPastMate || Seq(readOneFivePrime, readOneThreePrime, readTwoFivePrime, readTwoThreePrime).exists(_ != 0),
     "At least one clipping option is required")
 
   private val clipper = new SamRecordClipper(mode=clippingMode, autoClipAttributes=autoClipAttributes)
@@ -164,7 +165,8 @@ class ClipBam
         priorBasesClipped   = priorBasesClipped,
         numFivePrime        = numFivePrime,
         numThreePrime       = numThreePrime,
-        numOverlappingBases = 0
+        numOverlappingBases = 0,
+        numExtendingBases   = 0
       )
     }
   }
@@ -182,9 +184,13 @@ class ClipBam
     val numReadTwoThreePrime = this.clipper.clip3PrimeEndOfRead(r2, readTwoThreePrime)
 
     val (numOverlappingBasesReadOne, numOverlappingBasesReadTwo) = {
-      if (clipOverlappingReads && r1.isFrPair) {
-        if (r1.positiveStrand) clipOverlappingReads(r1, r2) else clipOverlappingReads(r2, r1)
-      } else (0, 0)
+      if (clipOverlappingReads && r1.isFrPair) this.clipper.clipOverlappingReads(r1, r2)
+      else (0, 0)
+    }
+
+    val (numExtendingPastMateStartReadOne, numExtendingPastMateStartReadTwo) = {
+      if (clipBasesPastMate && r1.isFrPair) this.clipper.clipExtendingPastMateEnds(r1, r2)
+      else (0, 0)
     }
 
     r1Metric.foreach { m =>
@@ -193,7 +199,8 @@ class ClipBam
         priorBasesClipped   = priorBasesClippedReadOne,
         numFivePrime        = numReadOneFivePrime,
         numThreePrime       = numReadOneThreePrime,
-        numOverlappingBases = numOverlappingBasesReadOne
+        numOverlappingBases = numOverlappingBasesReadOne,
+        numExtendingBases   = numExtendingPastMateStartReadOne
       )
     }
 
@@ -203,26 +210,10 @@ class ClipBam
         priorBasesClipped   = priorBasesClippedReadTwo,
         numFivePrime        = numReadTwoFivePrime,
         numThreePrime       = numReadTwoThreePrime,
-        numOverlappingBases = numOverlappingBasesReadTwo
+        numOverlappingBases = numOverlappingBasesReadTwo,
+        numExtendingBases   = numExtendingPastMateStartReadTwo
       )
     }
-  }
-
-  /** Clips overlapping reads, where both ends of the read pair are mapped to the same chromosome, and in FR orientation. */
-  protected def clipOverlappingReads(f: SamRecord, r: SamRecord): (Int, Int) = {
-    var numOverlappingBasesReadOne: Int = 0
-    var numOverlappingBasesReadTwo: Int = 0
-    // What we really want is to trim by the number of _reference_ bases not read bases,
-    // in order to eliminate overlap.  We could do something very complicated here, or
-    // we could just trim read bases in a loop until the overlap is eliminated!
-    while (f.end >= r.start && f.mapped && r.mapped) {
-      val lengthToClip = f.end - r.start + 1
-      val firstHalf    = lengthToClip / 2
-      val secondHalf   = lengthToClip - firstHalf // safe guard against rounding on odd lengths
-      numOverlappingBasesReadOne += this.clipper.clip3PrimeEndOfAlignment(f, firstHalf)
-      numOverlappingBasesReadTwo += this.clipper.clip3PrimeEndOfAlignment(r, secondHalf)
-    }
-    (numOverlappingBasesReadOne, numOverlappingBasesReadTwo)
   }
 }
 
@@ -246,6 +237,7 @@ object ReadType extends FgBioEnum[ReadType] {
   * @param reads_clipped_five_prime The number of reads with the 5' end clipped.
   * @param reads_clipped_three_prime The number of reads with the 3' end clipped.
   * @param reads_clipped_overlapping The number of reads clipped due to overlapping reads.
+  * @param reads_clipped_extending The number of reads clipped due to a read extending past its mate.
   * @param reads_unmapped The number of reads that became unmapped due to clipping.
   * @param bases The number of aligned bases after clipping.
   * @param bases_clipped_pre The number of bases clipped prior to clipping with [[ClipBam]].
@@ -253,6 +245,7 @@ object ReadType extends FgBioEnum[ReadType] {
   * @param bases_clipped_five_prime The number of bases clipped on the 5' end of the read.
   * @param bases_clipped_three_prime The number of bases clipped on the 3 end of the read.
   * @param bases_clipped_overlapping The number of bases clipped due to overlapping reads.
+  * @param bases_clipped_extending The number of bases clipped due to a read extending past its mate.
   */
 case class ClippingMetrics
 (read_type: ReadType,
@@ -263,14 +256,16 @@ case class ClippingMetrics
  var reads_clipped_five_prime: Long = 0,
  var reads_clipped_three_prime: Long = 0,
  var reads_clipped_overlapping: Long = 0,
+ var reads_clipped_extending: Long = 0,
  var bases: Long = 0,
  var bases_clipped_pre: Long = 0,
  var bases_clipped_post: Long = 0,
  var bases_clipped_five_prime: Long = 0,
  var bases_clipped_three_prime: Long = 0,
- var bases_clipped_overlapping: Long = 0
+ var bases_clipped_overlapping: Long = 0,
+ var bases_clipped_extending: Long = 0,
 ) extends Metric {
-  def update(rec: SamRecord, priorBasesClipped: Int, numFivePrime: Int, numThreePrime: Int, numOverlappingBases: Int): Unit = {
+  def update(rec: SamRecord, priorBasesClipped: Int, numFivePrime: Int, numThreePrime: Int, numOverlappingBases: Int, numExtendingBases: Int): Unit = {
     this.reads                      += 1
     this.bases                      += rec.cigar.alignedBases
     if (priorBasesClipped > 0) {
@@ -289,11 +284,15 @@ case class ClippingMetrics
       this.reads_clipped_overlapping += 1
       this.bases_clipped_overlapping += numOverlappingBases
     }
-    val additionalClippedBases = numFivePrime + numThreePrime + numOverlappingBases
-    val totalClippedBasees = additionalClippedBases + priorBasesClipped
-    if (totalClippedBasees > 0) {
+    if (numExtendingBases > 0) {
+      this.reads_clipped_extending += 1
+      this.bases_clipped_extending += numExtendingBases
+    }
+    val additionalClippedBases = numFivePrime + numThreePrime + numOverlappingBases + numExtendingBases
+    val totalClippedBases = additionalClippedBases + priorBasesClipped
+    if (totalClippedBases > 0) {
       this.reads_clipped_post        += 1
-      this.bases_clipped_post        += totalClippedBasees
+      this.bases_clipped_post        += totalClippedBases
       if (rec.unmapped && additionalClippedBases > 0) this.reads_unmapped += 1
     }
   }
@@ -306,11 +305,13 @@ case class ClippingMetrics
     this.reads_clipped_five_prime  += metric.sumBy(_.reads_clipped_five_prime)
     this.reads_clipped_three_prime += metric.sumBy(_.reads_clipped_three_prime)
     this.reads_clipped_overlapping += metric.sumBy(_.reads_clipped_overlapping)
+    this.reads_clipped_extending   += metric.sumBy(_.reads_clipped_extending)
     this.bases                     += metric.sumBy(_.bases)
     this.bases_clipped_pre         += metric.sumBy(_.bases_clipped_pre)
     this.bases_clipped_post        += metric.sumBy(_.bases_clipped_post)
     this.bases_clipped_five_prime  += metric.sumBy(_.bases_clipped_five_prime)
     this.bases_clipped_three_prime += metric.sumBy(_.bases_clipped_three_prime)
     this.bases_clipped_overlapping += metric.sumBy(_.bases_clipped_overlapping)
+    this.bases_clipped_extending   += metric.sumBy(_.bases_clipped_extending)
   }
 }

--- a/src/main/scala/com/fulcrumgenomics/bam/SamRecordClipper.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/SamRecordClipper.scala
@@ -322,21 +322,22 @@ class SamRecordClipper(val mode: ClippingMode, val autoClipAttributes: Boolean) 
 
   /** Returns the number of bases extending past the mate end for FR pairs including any soft-clipped bases, zero otherwise.
     *
-    * The mate end is computed via the mate-cigar (MC) SAM tag if present, otherwise the reported insert size is used.
+    * The largest mapped genomic coordinate of the mate is computed via the mate-cigar (MC) SAM tag if present,
+    * otherwise the reported insert size is used.
     *
     * @param rec the record to clip
     */
-  def numBasesExtendingPastMateEnd(rec: SamRecord): Int = {
+  def numBasesExtendingPastMate(rec: SamRecord): Int = {
     val mateEnd = rec.mateEnd.getOrElse(rec.start + abs(rec.insertSize) - 1)
-    numBasesExtendingPastMateEnd(rec=rec, mateEnd=mateEnd)
+    numBasesExtendingPastMate(rec=rec, mateEnd=mateEnd)
   }
 
   /** Returns the number of bases extending past the mate end for FR pairs including any soft-clipped bases, zero otherwise.
     *
     * @param rec the record to examine
-    * @param mateEnd the end coordinate of the mate
+    * @param mateEnd the largest mapped genomic coordinate of the mate
     */
-  def numBasesExtendingPastMateEnd(rec: SamRecord, mateEnd: Int): Int = {
+  def numBasesExtendingPastMate(rec: SamRecord, mateEnd: Int): Int = {
     if (!rec.isFrPair) 0 // not an FR pair
     else {
       if (rec.positiveStrand && rec.end >= mateEnd) {
@@ -386,7 +387,7 @@ class SamRecordClipper(val mode: ClippingMode, val autoClipAttributes: Boolean) 
   def clipExtendingPastMateEnd(rec: SamRecord, mateEnd: Int): Int = {
     if (!rec.isFrPair) 0 // do not overlap, don't clip
     else {
-      val totalClippedBases = numBasesExtendingPastMateEnd(rec=rec, mateEnd=mateEnd)
+      val totalClippedBases = numBasesExtendingPastMate(rec=rec, mateEnd=mateEnd)
       if (totalClippedBases == 0) 0 else {
        if (rec.positiveStrand) this.clipEndOfRead(rec, totalClippedBases)
        else this.clipStartOfRead(rec, totalClippedBases)

--- a/src/main/scala/com/fulcrumgenomics/bam/SamRecordClipper.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/SamRecordClipper.scala
@@ -364,7 +364,7 @@ class SamRecordClipper(val mode: ClippingMode, val autoClipAttributes: Boolean) 
     }
   }
 
-  /** Clips a read that sequences past the start (in sequencing order) of the mate, and in FR orientation.
+  /** Clips mate pairs in FR read pairs whose alignments extend beyond the far end of their mate's alignment.
     *
     * @param rec the read
     * @param mate the mate

--- a/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
@@ -254,9 +254,9 @@ trait UmiConsensusCaller[ConsensusRead <: SimpleRead] {
               // the # of bases to keep is the last read base of where the mate ends
               rec.readPosAtRefPos(pos=mateEnd, returnLastBaseIfDeleted=false)
             } else {
-              // Find where the end of the read goes past the mate start, if at all
-              val refPosAtReadEnd  = min(mateEnd, rec.end) // last 3' base
-              rec.readPosAtRefPos(pos=refPosAtReadEnd, returnLastBaseIfDeleted=false)
+              // the read does not go past the end, so just return the `trimToLength` as we take the minimum relative
+              // to it later
+              trimToLength
             }
           } else {
             // Find where the start of the read that goes before the mate start, if at all
@@ -264,13 +264,9 @@ trait UmiConsensusCaller[ConsensusRead <: SimpleRead] {
               // the # of bases to keep is the last read base of where the mate ends
               rec.length - rec.readPosAtRefPos(pos=rec.mateStart, returnLastBaseIfDeleted=false) + 1
             } else {
-              // The # of bases soft-clipped on the 3' end of the read (3' end in sequencing order)
-              val threePrimeClipping = cigar.reverseIterator.takeWhile(_.operator.isClipping).filter(_.operator == CigarOperator.S).sumBy(_.length)
-              // get the maximum # of allowable clipped bases on the 3' end
-              val maxThreePrimeClipping = rec.start - rec.mateStart
-              // if we have more than allowed, trim the read
-              if (threePrimeClipping <= maxThreePrimeClipping) bases.length
-              else bases.length - threePrimeClipping + maxThreePrimeClipping
+              // the read does not go past the end, so just return the `trimToLength` as we take the minimum relative
+              // to it later
+              trimToLength
             }
           }
         }

--- a/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
@@ -252,7 +252,7 @@ trait UmiConsensusCaller[ConsensusRead <: SimpleRead] {
       var index = if (!rec.isFrPair) trimToLength - 1 else {
         // Get the number of mapped bases to clip that maps beyond the mate's end, including any soft-clipped bases. Use
         // that to compute where in the read to keep.
-        val clipPosition = rec.length - this.clipper.numBasesExtendingPastMateEnd(rec=rec)
+        val clipPosition = rec.length - this.clipper.numBasesExtendingPastMate(rec=rec)
         min(clipPosition, trimToLength) - 1
       }
       // Find the last non-N base of sufficient quality in the record, starting from either the

--- a/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
@@ -221,7 +221,7 @@ trait UmiConsensusCaller[ConsensusRead <: SimpleRead] {
   /**
     * Converts from a SamRecord into a SourceRead.  During conversion the record is end-trimmed
     * to remove Ns and bases below the `minBaseQuality`.  Remaining bases that are below
-    * `minBaseQuality` are then masked to Ns.
+    * `minBaseQuality` are then masked to Ns.  Also trims reads so that no mapped bases extend past their mate.
     *
     * @return Some(SourceRead) if there are any called bases with quality > minBaseQuality, else None
     */

--- a/src/test/scala/com/fulcrumgenomics/alignment/AlignmentTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/alignment/AlignmentTest.scala
@@ -281,3 +281,23 @@ class AlignmentTest extends UnitSpec {
     alignment.subByTarget(6, 11).cigar.toString() shouldBe "5D1="
   }
 }
+
+class CigarStatsTest extends UnitSpec {
+
+  "CigarStats" should "compute various stats about a cigar" in {
+    CigarStats("100M")             shouldBe CigarStats(100, 100, 100,  0,  0,  0)
+    CigarStats("50M10I50M")        shouldBe CigarStats(110, 100, 100,  0,  0,  0)
+    CigarStats("50M10D50M")        shouldBe CigarStats(100, 110, 100,  0,  0,  0)
+    CigarStats("10H100M")          shouldBe CigarStats(100, 100, 100, 10,  0,  0)
+    CigarStats("100M10H")          shouldBe CigarStats(100, 100, 100, 10,  0,  0)
+    CigarStats("10S100M")          shouldBe CigarStats(110, 100, 100, 10, 10,  0)
+    CigarStats("100M10S")          shouldBe CigarStats(110, 100, 100, 10,  0, 10)
+    CigarStats("10H10S100M")       shouldBe CigarStats(110, 100, 100, 20, 10,  0)
+    CigarStats("100M10S10H")       shouldBe CigarStats(110, 100, 100, 20,  0, 10)
+    CigarStats("1H2S3M4D5I6M7S8H") shouldBe CigarStats(23,   13,   9, 18,  2,  7)
+  }
+
+  it should "fail on an invalid cigar" in {
+    an[Exception] should be thrownBy CigarStats("100M10S100M")
+  }
+}

--- a/src/test/scala/com/fulcrumgenomics/bam/ClipBamTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/ClipBamTest.scala
@@ -220,6 +220,7 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
     val prior = StartsAndEnds(r1, r2)
     r1.end shouldBe (r2.start + 3) // four bases overlap!
     clipper.clipPair(r1, r2)
+    r1.end shouldBe (r2.start - 1)
     prior.checkClipping(r1, r2, 0, 2, 0, 2) // clipping due to overlapping reads
   }
 

--- a/src/test/scala/com/fulcrumgenomics/bam/ClipBamTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/ClipBamTest.scala
@@ -240,10 +240,10 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
   }
 
   "ClippingMetrics.add" should "add two metrics" in {
-    val fragment = ClippingMetrics(ReadType.Fragment, 1, 2,  3,  4,  5,  6, 7,  8,   9, 10, 11, 12, 13)
-    val readOne  = ClippingMetrics(ReadType.ReadTwo,  2, 3,  4,  5,  6,  7, 8,  9,  10, 11, 12, 13, 14)
-    val readTwo  = ClippingMetrics(ReadType.ReadTwo,  3, 4,  5,  6,  7,  8, 9,  10, 11, 12, 13, 14, 15)
-    val all      = ClippingMetrics(ReadType.All,      6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42)
+    val fragment = ClippingMetrics(ReadType.Fragment, 1, 2,  3,  4,  5,  6, 7,  8,   9, 10, 11, 12, 13, 14, 15)
+    val readOne  = ClippingMetrics(ReadType.ReadTwo,  2, 3,  4,  5,  6,  7, 8,  9,  10, 11, 12, 13, 14, 15, 16)
+    val readTwo  = ClippingMetrics(ReadType.ReadTwo,  3, 4,  5,  6,  7,  8, 9,  10, 11, 12, 13, 14, 15, 16, 17)
+    val all      = ClippingMetrics(ReadType.All,      6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45, 48)
 
     // Check that adding fragment, readOne, and readTwo is correct
     val added    = ClippingMetrics(ReadType.All)
@@ -523,5 +523,17 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
           clipped.last.qualsString shouldBe frag2.qualsString
       }
     }
+  }
+
+  it should "clip FR reads that extend past the mate" in {
+    val builder = new SamBuilder(readLength=50)
+    val clipper = new ClipBam(input=dummyBam, output=dummyBam, ref=ref, clipBasesPastMate=true)
+    val Seq(r1, r2) = builder.addPair(start1=100, start2=90)
+
+    r1.end shouldBe 149
+    r2.end shouldBe 139
+    clipper.clipPair(r1, r2)
+    r1.start shouldBe r2.start
+    r1.end shouldBe r2.end
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/umi/AnnotateBamWithUmisTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/AnnotateBamWithUmisTest.scala
@@ -211,7 +211,6 @@ class AnnotateBamWithUmisTest extends UnitSpec {
     Io.writeLines(reverseFq, Io.readLines(fq).grouped(4).toSeq.reverse.flatten)
     val annotator = new AnnotateBamWithUmis(input=sam, fastq=Seq(fq, reverseFq), readStructure=Seq(ReadStructure("2M4B+M"), ReadStructure("1B+M")), output=out, attribute=umiTag, sorted=true)
     val result = intercept[Exception] { annotator.execute() }
-    println(result)
     result.getMessage should include ("out of sync")
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCallerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCallerTest.scala
@@ -513,13 +513,13 @@ class VanillaUmiConsensusCallerTest extends UnitSpec with OptionValues {
     val s1          = cc().toSourceRead(r1, minBaseQuality=2.toByte, trim=false).value
     val s2          = cc().toSourceRead(r2, minBaseQuality=2.toByte, trim=false).value
 
-    s1.baseString shouldBe "A"*2 + "C"*38 // trimmed by ten bases at the 3' end
+    s1.baseString shouldBe "A"*2 + "C"*38 // trimmed by ten bases at the 3' end, 5 due to soft-clipping and the other due to past mate start
     s1.cigar.toString shouldBe "10S30M"
     s2.baseString shouldBe "C"*2 + "G"*36 // trimmed by twelve bases at the 3' end
     s2.cigar.toString shouldBe "8S30M" // NB: cigar is reversed in toSourceRead
   }
 
-  it should "not to trim based on insert size in the presence of soft-clipping" in {
+  it should "not to trim based on insert size in the presence of soft-clipping (-/+)" in {
     val builder     = new SamBuilder(readLength=142)
     val Seq(r1, r2) = builder.addPair(start1=545, start2=493, strand1=Minus, strand2=Plus, cigar1="47S72M23S", cigar2="46S96M")
       .map { r => r.bases = "A"*142; r }
@@ -530,6 +530,20 @@ class VanillaUmiConsensusCallerTest extends UnitSpec with OptionValues {
     s1.cigar.toString shouldBe "23S72M47S"  // NB: cigar is reversed in toSourceRead
     s2.baseString shouldBe "A"*142
     s2.cigar.toString shouldBe "46S96M"
+  }
+
+  it should "not to trim based on insert size in the presence of soft-clipping (+/-)" in {
+    val builder     = new SamBuilder(readLength=142)
+    val Seq(r1, r2) = builder.addPair(start2=545, start1=493, strand2=Minus, strand1=Plus, cigar2="47S72M23S", cigar1="46S96M")
+      .map { r => r.bases = "A"*142; r }
+    val s1          = cc().toSourceRead(r1, minBaseQuality=2.toByte, trim=false).value
+    val s2          = cc().toSourceRead(r2, minBaseQuality=2.toByte, trim=false).value
+
+    // for R2, the leading 47S in the alignment is trimmed because
+    s1.baseString shouldBe "A"*142
+    s1.cigar.toString shouldBe "46S96M"
+    s2.baseString shouldBe "T"*142
+    s2.cigar.toString shouldBe "23S72M47S"  // NB: cigar is reversed in toSourceRead
   }
 
   it should "not trim the source read based on insert size if the read is not an FR pair" in {
@@ -559,5 +573,19 @@ class VanillaUmiConsensusCallerTest extends UnitSpec with OptionValues {
     source.quals should have length 3
     source.cigar.toString() shouldBe "3M"
     source.sam shouldBe Some(rec)
+  }
+
+  it should "not trim reads with an insert size shorter than the read length when there's an insertion in the middle" in {
+    val builder = new SamBuilder(readLength=100)
+    val Seq(r1, r2) = builder.addPair(
+      start1=1, start2=1, strand1=Plus, strand2=Minus, cigar1="40M20I40M", cigar2="40M20I40M"
+    ).map { r => r.bases = "A"*100; r }
+    val s1          = cc().toSourceRead(r1, minBaseQuality=2.toByte, trim=false).value
+    val s2          = cc().toSourceRead(r2, minBaseQuality=2.toByte, trim=false).value
+
+    s1.baseString shouldBe "A"*100
+    s1.cigar.toString shouldBe "40M20I40M"
+    s2.baseString shouldBe "T"*100
+    s2.cigar.toString shouldBe "40M20I40M"
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCallerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCallerTest.scala
@@ -515,8 +515,8 @@ class VanillaUmiConsensusCallerTest extends UnitSpec with OptionValues {
 
     s1.baseString shouldBe "A"*2 + "C"*38 // trimmed by ten bases at the 3' end, five due to existing soft-clipping and the other due to past mate start
     s1.cigar.toString shouldBe "10S30M"
-    s2.baseString shouldBe "C"*2 + "G"*46 + "T"*2 // leading soft-clipping is not trimmed, since there are no mapped bases prior to it's mate's start
-    s2.cigar.toString shouldBe "8S30M12S" // NB: cigar is reversed in toSourceRead
+    s2.baseString shouldBe "C"*2 + "G"*36 // trimmed by twelve bases at the 3' end (the "12S" in the cigar)
+    s2.cigar.toString shouldBe "8S30M" // NB: cigar is reversed in toSourceRead
   }
 
   it should "not trim based on insert size in the presence of soft-clipping (-/+)" in {

--- a/src/test/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCallerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCallerTest.scala
@@ -513,26 +513,26 @@ class VanillaUmiConsensusCallerTest extends UnitSpec with OptionValues {
     val s1          = cc().toSourceRead(r1, minBaseQuality=2.toByte, trim=false).value
     val s2          = cc().toSourceRead(r2, minBaseQuality=2.toByte, trim=false).value
 
-    s1.baseString shouldBe "A"*2 + "C"*38 // trimmed by ten bases at the 3' end, 5 due to soft-clipping and the other due to past mate start
+    s1.baseString shouldBe "A"*2 + "C"*38 // trimmed by ten bases at the 3' end, five due to existing soft-clipping and the other due to past mate start
     s1.cigar.toString shouldBe "10S30M"
-    s2.baseString shouldBe "C"*2 + "G"*36 // trimmed by twelve bases at the 3' end
-    s2.cigar.toString shouldBe "8S30M" // NB: cigar is reversed in toSourceRead
+    s2.baseString shouldBe "C"*2 + "G"*46 + "T"*2 // leading soft-clipping is not trimmed, since there are no mapped bases prior to it's mate's start
+    s2.cigar.toString shouldBe "8S30M12S" // NB: cigar is reversed in toSourceRead
   }
 
-  it should "not to trim based on insert size in the presence of soft-clipping (-/+)" in {
+  it should "not trim based on insert size in the presence of soft-clipping (-/+)" in {
     val builder     = new SamBuilder(readLength=142)
     val Seq(r1, r2) = builder.addPair(start1=545, start2=493, strand1=Minus, strand2=Plus, cigar1="47S72M23S", cigar2="46S96M")
       .map { r => r.bases = "A"*142; r }
     val s1          = cc().toSourceRead(r1, minBaseQuality=2.toByte, trim=false).value
     val s2          = cc().toSourceRead(r2, minBaseQuality=2.toByte, trim=false).value
 
-    s1.baseString shouldBe "T"*142
+    s1.baseString shouldBe "T"*142 // all the bases remain, no clipping
     s1.cigar.toString shouldBe "23S72M47S"  // NB: cigar is reversed in toSourceRead
-    s2.baseString shouldBe "A"*142
+    s2.baseString shouldBe "A"*142 // all the bases remain, no clipping
     s2.cigar.toString shouldBe "46S96M"
   }
 
-  it should "not to trim based on insert size in the presence of soft-clipping (+/-)" in {
+  it should "not trim based on insert size in the presence of soft-clipping (+/-)" in {
     val builder     = new SamBuilder(readLength=142)
     val Seq(r1, r2) = builder.addPair(start2=545, start1=493, strand2=Minus, strand1=Plus, cigar2="47S72M23S", cigar1="46S96M")
       .map { r => r.bases = "A"*142; r }


### PR DESCRIPTION
### Summary 

This adds:

1.  methods in `SamRecordClipper` to clip bases that map beyond the end of the mate for FR pairs.
2. Use these methods in `ClipBam` to implement the option `--clip-bases-past-mate`.
3.   Use these method in consensus calling to properly decide the number of bases to clip based on insert size for FR pairs.  This fixes a bug in the consensus caller that could improperly trim small inserts. 

### More details on the  bug in the consensus caller that could improperly trim small inserts

If the reads are longer than the insert size, but aligned with
insertions, the consensus read may have the insertion trimmed.

See issue #759.  Corrected output to include the full length read:

```
@HD	VN:1.6	SO:queryname	GO:none
@RG	ID:A	LB:lib1	SM:A	PL:ILLUMINA	PU:unit1
@CO	Read group A contains consensus reads generated from 1 input read groups.
lib1:8193187/A	77	*	0	0	*	*	0	0	ACCATTCTAATTACAGTGGGGGAAGTGTGCGCGCAAGTGTGTGCGTGTGTGCGCACGCGCAGGTGTGTGCGTGAGTGAAGGGATGTAGACAGAGGCTGCTGGCCGGG	CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC	cD:i:1	cE:f:0.0	RG:Z:A	MI:Z:8193187/A	cM:i:1	RX:Z:TTA-TCT	cd:B:s,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1	ce:B:s,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
lib1:8193187/A	141	*	0	0	*	*	0	0	CCCGGCCAGCAGCCTCTGTCTACATCCCTTCACTCACGCACACACCTGCGCGTGCGCACACACGCACACACTTGCGCGCACACTTCCCCCACTGTAATTAGAATGGT	CCCCCCCCCCCCCCCCCCCCC9CCC9CCC9CCCCCCCCC9CCCCCCCCCCCCCCCCCCCCCCCCCCCCC99CCCCCCC9CCCCCCCCCCCCCCCC9CCCCCCCCCCC	cD:i:1	cE:f:0.0	RG:Z:A	MI:Z:8193187/A	cM:i:1	RX:Z:TTA-TCT	cd:B:s,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1	ce:B:s,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
```