### PR TITLE
Make GroupReadsByUmi more permissive in the alignments it accepts.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/bam/api/SamRecord.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/api/SamRecord.scala
@@ -65,6 +65,13 @@ class TransientAttrs(private val rec: SamRecord) {
     case null => default
     case value => value.asInstanceOf[A]
   }
+  def getOrElseUpdate[A](key: Any, default: => A): A = rec.asSam.getTransientAttribute(key) match {
+    case null  =>
+      val value: A = default
+      update(key, value)
+      value
+    case value => value.asInstanceOf[A]
+  }
 }
 
 /**

--- a/src/main/scala/com/fulcrumgenomics/bam/api/SamRecord.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/api/SamRecord.scala
@@ -227,7 +227,7 @@ trait SamRecord {
   @inline final def remove(name: String): Unit                   = setAttribute(name, null)
 
   // transient attributes
-  @inline final def transientAttrs: TransientAttrs = new TransientAttrs(this)
+  @inline final val transientAttrs: TransientAttrs = new TransientAttrs(this)
 
   // TODO long-term: replace these two methods with methods on [[Cigar]] to save creating alignment blocks in memory
   @inline final def refPosAtReadPos(pos: Int) = getReferencePositionAtReadPosition(pos)

--- a/src/main/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReads.scala
@@ -27,7 +27,7 @@ package com.fulcrumgenomics.umi
 
 import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.bam.api.{SamOrder, SamSource, SamWriter}
-import com.fulcrumgenomics.cmdline.{ClpGroups, FgBioTool}
+import com.fulcrumgenomics.cmdline.{ClpGroups, FgBioMain, FgBioTool}
 import com.fulcrumgenomics.commons.io.Io
 import com.fulcrumgenomics.commons.util.{LazyLogging, LogLevel, Logger}
 import com.fulcrumgenomics.sopt._

--- a/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
@@ -334,7 +334,7 @@ trait UmiConsensusCaller[ConsensusRead <: SimpleRead] {
     *
     * NOTE: filtered out reads are sent to the [[rejectRecords]] method and do not need further handling
     */
-  protected[umi] def filterToMostCommonAlignment(recs: Seq[SourceRead]): Seq[SourceRead] = {
+  protected[umi] def filterToMostCommonAlignment(recs: Seq[SourceRead]): Seq[SourceRead] = if (recs.size < 2) recs else {
     val groups = new ArrayBuffer[AlignmentGroup]
     val sorted = recs.sortBy(r => -r.length).toIndexedSeq
 


### PR DESCRIPTION
@nh13 I think this does what we want.  I fixed up one test that was failing as a result, but have not added more tests.  I'd like to verify it works as intended on real data before writing the unit tests, otherwise the implementation might change before then.

I think this change might be enough to warrant a 2.0 release as I would like the behavior to be default or even non-optionally on to pass through both inter-contig and half-mapped mate pairs.  I wonder too if we should also drop the default `minMapQ` to 1 from 30?

I also enabled (trivially) threading in `CallMolecularConsensusReads` while I was there as I was testing consensus calling and got tired of waiting.

@clintval I'd be very curious on your take on this PR.  Our goal is to enable SV calling off the consensus BAM by allowing through any reads that might usefully support an SV including cross-chromosomal mappings _and_ read pairs with only one of the two mates mapped.