### PR TITLE
ZippperBams: A replacement for picard's MergeBamAlignment

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/Writer.scala
+++ b/src/main/scala/com/fulcrumgenomics/Writer.scala
@@ -25,5 +25,5 @@
 package com.fulcrumgenomics
 
 /** Writer trait to standardize how to interact with classes that write out objects. */
-@deprecated("Use com.fulcrumgenomics.commons.io.Writer instead.", since="0.8.1")
+@deprecated(message="Use com.fulcrumgenomics.commons.io.Writer instead.", since="0.8.1")
 trait Writer[A] extends com.fulcrumgenomics.commons.io.Writer[A]

--- a/src/main/scala/com/fulcrumgenomics/bam/Bams.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/Bams.scala
@@ -73,6 +73,11 @@ case class Template(r1: Option[SamRecord],
   /** Returns an iterator of all reads for the template. */
   def allReads: Iterator[SamRecord] = r1.iterator ++ r2.iterator ++ allSupplementaryAndSecondary
 
+  /** Returns an iterator of all read 1s for the template. */
+  def allR1s: Iterator[SamRecord] = r1.iterator ++ r1Secondaries.iterator ++ r1Supplementals.iterator
+
+  /** Returns an iterator of all read 2s for the template. */
+  def allR2s: Iterator[SamRecord] = r2.iterator ++ r2Secondaries.iterator ++ r2Supplementals.iterator
   /**
     * Produces a copy of the template that has had mapping information removed.  Discards secondary and supplementary
     * records, and retains the primary records after un-mapping them.  Auxillary tags listed in [[Bams.AlignmentTags]]
@@ -96,6 +101,19 @@ case class Template(r1: Option[SamRecord],
     }
 
     Template(x1, x2)
+  }
+
+  /** Fixes mate information and sets mate cigar on all primary and supplementary (but not secondary) records. */
+  def fixMateInfo(): Unit = {
+    for (primary <- r1; supp <- r2Supplementals) {
+      SamPairUtil.setMateInformationOnSupplementalAlignment(supp.asSam, primary.asSam, true)
+    }
+    for (primary <- r2; supp <- r1Supplementals) {
+      SamPairUtil.setMateInformationOnSupplementalAlignment(supp.asSam, primary.asSam, true)
+    }
+    for (first <- r1; second <- r2) {
+      SamPairUtil.setMateInfo(first.asSam, second.asSam)
+    }
   }
 
   /** The total count of records for the template. */

--- a/src/main/scala/com/fulcrumgenomics/bam/Bams.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/Bams.scala
@@ -36,7 +36,6 @@ import htsjdk.samtools._
 import htsjdk.samtools.reference.ReferenceSequenceFileWalker
 import htsjdk.samtools.util.{CloserUtil, CoordMath, SequenceUtil}
 
-import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import scala.math.{max, min}
 
 /**
@@ -112,7 +111,7 @@ case class Template(r1: Option[SamRecord],
       SamPairUtil.setMateInformationOnSupplementalAlignment(supp.asSam, primary.asSam, true)
     }
     for (first <- r1; second <- r2) {
-      SamPairUtil.setMateInfo(first.asSam, second.asSam)
+      SamPairUtil.setMateInfo(first.asSam, second.asSam, true)
     }
   }
 

--- a/src/main/scala/com/fulcrumgenomics/bam/ZipperBams.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ZipperBams.scala
@@ -194,7 +194,7 @@ private[bam] object ZipperBams extends LazyLogging {
 class ZipperBams
 ( @arg(flag='i', doc="Mapped SAM or BAM.") val input: PathToBam = Io.StdIn,
   @arg(flag='u', doc="Unmapped SAM or BAM.") val unmapped: PathToBam,
-  @arg(flag='r', doc="Path to the reference used in alignment.") val ref: PathToFasta,
+  @arg(flag='r', doc="Path to the reference used in alignment. Must have accompanying .dict file.") val ref: PathToFasta,
   @arg(flag='o', doc="Output SAM or BAM file.") val output: PathToBam = Io.StdOut,
   @arg(doc="Tags to remove from the mapped BAM records.", minElements=0)
   val tagsToRemove: IndexedSeq[String] = IndexedSeq.empty,
@@ -206,6 +206,11 @@ class ZipperBams
   @arg(flag='b', doc="Buffer this many read-pairs while reading the input BAMs.") val buffer: Int = 5000
 ) extends FgBioTool {
   import ZipperBams._
+
+  Io.assertReadable(ref)
+  Io.assertReadable(input)
+  Io.assertReadable(unmapped)
+  Io.assertCanWriteFile(output)
 
   override def execute(): Unit = {
     val unmappedSource = SamSource(unmapped)

--- a/src/main/scala/com/fulcrumgenomics/bam/ZipperBams.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ZipperBams.scala
@@ -56,6 +56,7 @@ object ZipperBams extends LazyLogging {
   def checkSort(source: SamSource, path: FilePath, name: String): Unit = {
     if (source.header.getSortOrder != SortOrder.queryname && source.header.getGroupOrder != GroupOrder.query) {
       logger.warning(s"${name} file ${path} does not appear to be queryname sorted or grouped.")
+      logger.warning(s"Continuing, but your output may be incorrect.")
     }
   }
 

--- a/src/main/scala/com/fulcrumgenomics/bam/ZipperBams.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ZipperBams.scala
@@ -137,7 +137,7 @@ private[bam] object ZipperBams extends LazyLogging {
     // Copy tags over from the unmapped record
     for (u <- unmapped.primaryReads) {
       // Get all the mapped records for the unmapped record
-      val ms = if (u.unpaired || u.firstOfPair) mapped.allR1s.toSeq else mapped.allR1s.toSeq
+      val ms = if (u.unpaired || u.firstOfPair) mapped.allR1s.toSeq else mapped.allR2s.toSeq
 
       // Copy over pass/fail qc flag
       ms.foreach(_.pf = u.pf)

--- a/src/main/scala/com/fulcrumgenomics/bam/ZipperBams.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ZipperBams.scala
@@ -84,7 +84,7 @@ object ZipperBams extends LazyLogging {
 
   /** Constructs a template iterator that assumes the input is sorted or grouped, and turns it into an async iter. */
   def templateIterator(source: SamSource, bufferSize: Int): BetterBufferedIterator[Template] = {
-    val recs = source.iterator.bufferBetter
+    val recs      = source.iterator.bufferBetter
     val templates = new Iterator[Template] {
       override def hasNext: Boolean = recs.hasNext
       override def next(): Template = Template(recs)
@@ -139,14 +139,13 @@ object ZipperBams extends LazyLogging {
     |name are grouped together in the file), and b) have the same ordering of querynames.  If either of these are
     |violated the output is undefined!
     |
-    |By default the mapped BAM is read from stdin and the output BAM is written to stdout. This can be changed
+    |By default the mapped BAM is read from standard input (stdin) and the output BAM is written to standard output (stdout). This can be changed
     |using the `--input/-i` and `--output/-o` options.
     |
     |By default the output BAM file is emitted in the same order as the input BAMs.  This can be overridden
     |using the `--sort` option, though in practice it may be faster to do the following:
     |
-    |  `fgbio --compression 0 ZipperBams -i mapped.bam -u unmapped.bam -r ref.fa | samtools sort -@ 16`
-    |
+    |  `fgbio --compression 0 ZipperBams -i mapped.bam -u unmapped.bam -r ref.fa | samtools sort -@ $(nproc)`
     |
   """)
 class ZipperBams
@@ -181,6 +180,7 @@ class ZipperBams
         out ++= merge(unmapped=template, mapped=mappedIter.next(), tagInfo=tagInfo).allReads
       }
       else {
+        logger.debug("Found an unmapped read with no corresponding mapped read: ${template.name}")
         out ++= template.allReads
       }
     }

--- a/src/main/scala/com/fulcrumgenomics/bam/api/HeaderHelper.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/api/HeaderHelper.scala
@@ -26,7 +26,7 @@ package com.fulcrumgenomics.bam.api
 
 import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.fasta.SequenceDictionary
-import htsjdk.samtools.{SAMFileHeader, SAMProgramRecord, SAMReadGroupRecord}
+import htsjdk.samtools.{SAMFileHeader, SAMProgramRecord, SAMReadGroupRecord, SAMTextHeaderCodec}
 
 /**
   * Trait that can be mixed into any class that provides access to a SAMFileHeader in
@@ -47,4 +47,8 @@ private[api] trait HeaderHelper {
 
   /** The list of program groups from the associated header. */
   def programGroups: Seq[SAMProgramRecord] = header.getProgramRecords.toIndexedSeq
+
+  /** Gets the comments from the header, removing the stupid leading @CO that HTSJDK returns. */
+  def comments: Seq[String] =
+    header.getComments.iterator().map(_.replace(SAMTextHeaderCodec.COMMENT_PREFIX, "")).toIndexedSeq
 }

--- a/src/main/scala/com/fulcrumgenomics/cmdline/FgBioTool.scala
+++ b/src/main/scala/com/fulcrumgenomics/cmdline/FgBioTool.scala
@@ -24,11 +24,11 @@
 package com.fulcrumgenomics.cmdline
 
 import com.fulcrumgenomics.cmdline.FgBioMain.FailureException
+import com.fulcrumgenomics.commons.util.LazyLogging
 import com.fulcrumgenomics.sopt.cmdline.ValidationException
 
 /** All fgbio tools should extend this. */
-// Todo: extend Lazy Logging?
-trait FgBioTool {
+trait FgBioTool extends LazyLogging {
   def execute(): Unit
 
   /** Fail with just an exit code. */

--- a/src/main/scala/com/fulcrumgenomics/util/Metric.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/Metric.scala
@@ -235,7 +235,7 @@ trait Metric extends Product with Iterable[(String,String)] {
   override def iterator: Iterator[(String,String)] = this.names.zip(this.values).iterator
 
   /** @deprecated use [[formatValue]] instead. */
-  @deprecated("Use formatValue instead.", since="0.5.0")
+  @deprecated(message="Use formatValue instead.", since="0.5.0")
   protected def formatValues(value: Any): String = formatValue(value)
 
   /** Override this method to customize how values are formatted. */

--- a/src/test/scala/com/fulcrumgenomics/bam/ZipperBamsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/ZipperBamsTest.scala
@@ -305,4 +305,20 @@ class ZipperBamsTest extends UnitSpec {
       }
     }
   }
+
+  it should "push unmapped reads into the output BAM if there are no mapped reads for a template" in {
+    val unmapped = uBuilder()
+    unmapped.addFrag(name="q1", unmapped=true, attrs=Map("RX" -> "ACGT", "xy" -> 1234))
+    unmapped.addFrag(name="q2", unmapped=true, attrs=Map("RX" -> "GATA", "xy" -> 3456))
+    unmapped.addFrag(name="q3", unmapped=true, attrs=Map("RX" -> "GGCG", "xy" -> 5678))
+
+    val mapped   = mBuilder()
+    mapped.addFrag(name="q1", start=100, strand=Plus,  attrs=Map("PG" -> mappedPg.getId, "AS" -> 77))
+    mapped.addFrag(name="q3", start=200, strand=Minus, attrs=Map("PG" -> mappedPg.getId, "AS" -> 77))
+
+    val zippered = run(unmapped, mapped, reverse=Seq("Consensus"), revcomp=Seq("Consensus"))
+    val recs = zippered.toIndexedSeq
+    recs should have length 3
+    recs.map(_.name) should contain theSameElementsInOrderAs Seq("q1", "q2", "q3")
+  }
 }

--- a/src/test/scala/com/fulcrumgenomics/bam/ZipperBamsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/ZipperBamsTest.scala
@@ -69,10 +69,11 @@ class ZipperBamsTest extends UnitSpec {
   }
 
   /** Generate a builder that will mimic what an aligner might produce. */
-  private def mBuilder(grouped: Boolean = false): SamBuilder = {
+  private def mBuilder(grouped: Boolean = true): SamBuilder = {
     val builder = new SamBuilder(readGroupId=None)
     builder.header.setReadGroups(Iterator().toJavaList)
     builder.header.addProgramRecord(mappedPg)
+    if (grouped) builder.header.setGroupOrder(GroupOrder.query)
     builder
   }
 

--- a/src/test/scala/com/fulcrumgenomics/bam/ZipperBamsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/ZipperBamsTest.scala
@@ -1,0 +1,157 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2022 Fulcrum Genomics LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.fulcrumgenomics.bam
+
+import com.fulcrumgenomics.bam.api.{SamOrder, SamSource}
+import com.fulcrumgenomics.testing.{SamBuilder, UnitSpec}
+import com.fulcrumgenomics.util.Io
+import htsjdk.samtools.SAMFileHeader.GroupOrder
+import htsjdk.samtools.{SAMProgramRecord, SAMSequenceDictionary}
+import com.fulcrumgenomics.FgBioDef._
+
+class ZipperBamsTest extends UnitSpec {
+  private val dict = new SamBuilder().dict
+
+  // Read Group ID to be used in unmapped BAMs
+  private val rgId = "abc"
+
+  // Program group to be inserted into unmapped BAM
+  private val unmappedPg   = {
+    val tmp = new SAMProgramRecord("fqToBam")
+    tmp.setCommandLine("FastqToBam do-some-stuff")
+    tmp.setProgramName("FastqToBam")
+    tmp
+  }
+
+  // Program group to be inserted into mapped BAM
+  private val mappedPg   = {
+    val tmp = new SAMProgramRecord("aligner")
+    tmp.setCommandLine("aligner -t 8 -x 4 in.fastq ref.fa")
+    tmp.setProgramName("SomeAligner")
+    tmp
+  }
+
+  // Comments to be inserted into unmapped BAMs
+  private val comments = Seq("This is a SAM Header comment.", "This is too.")
+
+  /** Generate a new SamBuilder for unmapped BAMs */
+  private def uBuilder(grouped: Boolean = true): SamBuilder = {
+    val builder = new SamBuilder(readGroupId=Some(rgId))
+    builder.header.setSequenceDictionary(new SAMSequenceDictionary()) // wipe out the sequence dictionary
+    builder.header.addProgramRecord(unmappedPg)
+    comments.foreach(builder.header.addComment)
+    if (grouped) builder.header.setGroupOrder(GroupOrder.query)
+    builder
+  }
+
+  /** Generate a builder that will mimic what an aligner might produce. */
+  private def mBuilder(grouped: Boolean = false): SamBuilder = {
+    val builder = new SamBuilder(readGroupId=None)
+    builder.header.setReadGroups(Iterator().toJavaList)
+    builder.header.addProgramRecord(mappedPg)
+    builder
+  }
+
+  /** Run ZipperBams from two sam builders and return the output as a SamSource. */
+  private def run(unmapped: SamBuilder,
+                  mapped: SamBuilder,
+                  remove: Iterable[String] = Nil,
+                  reverse: Iterable[String] = Nil,
+                  revcomp: Iterable[String] = Nil,
+                  sort: Option[SamOrder] = None,
+                  buffer: Int = 5000
+                 ): SamSource = {
+    val dir      = Io.makeTempDir("zipper-bams-test")
+    val uBam     = dir.resolve("unmapped.bam")
+    val mBam     = dir.resolve("mapped.bam")
+    val zBam     = dir.resolve("zippered.bam")
+    val dictPath = dir.resolve("ref.dict")
+
+    Seq(uBam, mBam, zBam, dictPath, dir).foreach(_.toFile.deleteOnExit())
+
+    dict.write(dictPath)
+    unmapped.write(uBam)
+
+    // Clean out any RG tags before writing the mapped BAM
+    mapped.foreach(r => r.remove("RG"))
+    mapped.write(mBam)
+
+    val zipper = new ZipperBams(
+      input         = mBam,
+      unmapped      = uBam,
+      ref           = dictPath,
+      output        = zBam,
+      tagsToRemove  = remove.toIndexedSeq,
+      tagsToReverse = reverse.toIndexedSeq,
+      tagsToRevcomp = revcomp.toIndexedSeq,
+      sort          = sort,
+      buffer        = buffer
+    )
+
+    executeFgbioTool(zipper)
+    SamSource(zBam)
+  }
+
+  "ZipperBams" should "run on small BAM and copy over information from the unmapped BAM" in {
+    val unmapped = uBuilder()
+    val mapped   = mBuilder()
+
+    unmapped.addPair(name="q1", unmapped1=true, unmapped2=true, attrs=Map("RX" -> "ACGT", "xy" -> 1234))
+    unmapped.addPair(name="q2", unmapped1=true, unmapped2=true, attrs=Map("RX" -> "GGTA", "xy" -> 4567))
+
+    mapped.addPair(name="q1", start1=100, start2=200, attrs=Map("PG" -> mappedPg.getId, "AS" -> 77))
+    mapped.addPair(name="q2", start1=500, start2=700, attrs=Map("PG" -> mappedPg.getId, "AS" -> 16))
+
+    val zippered = run(unmapped, mapped)
+
+    // Check the header first
+    zippered.comments should contain theSameElementsInOrderAs this.comments
+    zippered.readGroups should contain theSameElementsAs  unmapped.header.getReadGroups.toSeq
+    zippered.programGroups should contain theSameElementsAs Seq(unmappedPg, mappedPg)
+
+    // Then check the records
+    zippered.foreach { z =>
+      // Find the matching input records
+      val u = unmapped.find(u => u.name == z.name && u.firstOfPair == z.firstOfPair).value
+      val m = mapped.find(m => m.name == z.name && m.flags == z.flags).value
+
+      // All the attributes from the unmapped BAM should be there
+      u.attributes.foreach { case (tag, value) => z(tag) == value shouldBe true }
+
+      // And all the attributes from the mapped BAM
+      m.attributes.foreach { case (tag, value) => z(tag) == value shouldBe true }
+
+      // And we shouldn't have broken any of the alignment info
+      z.basesString shouldBe m.basesString
+      z.qualsString shouldBe m.qualsString
+      z.refIndex shouldBe m.refIndex
+      z.start shouldBe m.start
+      z.cigar shouldBe m.cigar
+
+      // And mate cigar should be present
+      z.get("MQ").isDefined shouldBe true
+    }
+  }
+}


### PR DESCRIPTION
@nh13 not ready for a full on code review, but it would be helpful for you to take a look at this and see if you think there is any functionality we routinely use in MergeBamAlignment that is missing from this?  

The only thing I can think of so far is the clipping of read-pairs that extend past each other's starts.  I'm hesitate to do that here as it would then require fixing up tags like NM, MD, etc. that then also require either iterating reads in coordinate order to use the reference efficiently, or holding the entire genome in memory (the latter may not be so bad these days).