### PR TITLE
Specify an output sort order in FilterConsensusReads

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/bam/ClipBam.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ClipBam.scala
@@ -128,7 +128,7 @@ class ClipBam
     val out    = SamWriter(output, header, ref=Some(ref))
 
     sorter.foreach { rec =>
-      Bams.regenerateNmUqMdTags(rec, walker)
+      Bams.regenerateNmUqMdTags(rec, walker.get(rec.refIndex))
       out += rec
     }
 

--- a/src/main/scala/com/fulcrumgenomics/umi/FilterConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/FilterConsensusReads.scala
@@ -271,7 +271,8 @@ class FilterConsensusReads
         }.orElse {
           // this can only happen if the input order is unrecognized
           throw new IllegalArgumentException(
-            s"The input BAM had an unrecognized sort order (SO:$inSortOrder GO:$inGroupOrder SS: $inSubSort) in $input"
+            s"The input BAM had an unrecognized sort order (SO:$inSortOrder GO:$inGroupOrder SS: $inSubSort)" +
+            s"\nTry re-running with --sort-order for a supported output order." in $input
           )
         }
       }

--- a/src/main/scala/com/fulcrumgenomics/umi/FilterConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/FilterConsensusReads.scala
@@ -233,10 +233,10 @@ class FilterConsensusReads
   /** Builds the writer to which filtered records should be written.
     *
     *  If the input order is [[SamOrder.Queryname]] or query grouped, then the filtered records will also be in the same
-    *  order.  So if the output order specified AND does not match the the input order, sorting will occur.
+    *  order.  So if the output order is specified AND does not match the the input order, sorting will occur.
     *
     *  If the input order is not [[SamOrder.Queryname]] or query grouped, then the input records will be resorted into
-    *  [[SamOrder.Queryname]].  So if the output order specified AND is not [[SamOrder.Queryname]], sorting will occur.
+    *  [[SamOrder.Queryname]].  So if the output order is specified AND is not [[SamOrder.Queryname]], sorting will occur.
     *
     *  Otherwise, we can skip sorting!
     *

--- a/src/main/scala/com/fulcrumgenomics/umi/FilterConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/FilterConsensusReads.scala
@@ -91,8 +91,10 @@ private[umi] case class ConsensusReadFilter(minReads: Int, maxReadErrorRate: Dou
       |values two and three differ, the _more stringent value comes earlier_.
       |
       |In order to correctly filter reads in or out by template, if the input BAM is not `queryname` sorted or
-      |grouped it will be sorted into queryname order.  The resulting records are `coordinate` sorted to efficiently
-      |correct the `NM`, `UQ` and `MD` tags, and the output BAM is always written in coordinate order.
+      |query grouped it will be sorted into queryname order prior to filtering.
+      |
+      |The output sort order may be specified with `--sort-order`.  If not given, then the output will be in the same
+      |order as input if the input is queryname sorted or query grouped, otherwise queryname order.
       |
       |The `--reverse-tags-per-base` option controls whether per-base tags should be reversed before being used on reads
       |marked as being mapped to the negative strand.  This is necessary if the reads have been mapped and the
@@ -119,7 +121,7 @@ class FilterConsensusReads
   val minMeanBaseQuality: Option[PhredScore] = None,
   @arg(flag='s', doc="Mask (make `N`) consensus bases where the AB and BA consensus reads disagree (for duplex-sequencing only).")
   val requireSingleStrandAgreement: Boolean = false,
-  @arg(flag='S', doc="The sort order of the output. If not given, output will be in the same order as input if the input is query grouped, otherwise queryname order.")
+  @arg(flag='S', doc="The sort order of the output. If not given, output will be in the same order as input if the input is query name sorted or query grouped, otherwise queryname order.")
   val sortOrder: Option[SamOrder] = None
 ) extends FgBioTool with LazyLogging {
   // Baseline input validation

--- a/src/main/scala/com/fulcrumgenomics/umi/FilterConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/FilterConsensusReads.scala
@@ -36,7 +36,7 @@ import com.fulcrumgenomics.util.NumericTypes.PhredScore
 import com.fulcrumgenomics.util.{Io, ProgressLogger}
 import htsjdk.samtools.SAMFileHeader
 import htsjdk.samtools.SAMFileHeader.GroupOrder
-import htsjdk.samtools.reference.ReferenceSequenceFileWalker
+import htsjdk.samtools.reference.ReferenceSequence
 import htsjdk.samtools.util.SequenceUtil
 
 import java.io.Closeable
@@ -119,8 +119,8 @@ class FilterConsensusReads
   val minMeanBaseQuality: Option[PhredScore] = None,
   @arg(flag='s', doc="Mask (make `N`) consensus bases where the AB and BA consensus reads disagree (for duplex-sequencing only).")
   val requireSingleStrandAgreement: Boolean = false,
-  @arg(flag='S', doc="The sort order of the output, if `:none:` then the same as the input.") val sortOrder: Option[SamOrder] = Some(SamOrder.Coordinate),
-  @arg(flag='l', doc="Load the full reference sequence in memory") val loadFullReference: Boolean = false
+  @arg(flag='S', doc="The sort order of the output.  If not given, query grouped if the input is also query grouped, otherwise queryname.")
+  val sortOrder: Option[SamOrder] = None
 ) extends FgBioTool with LazyLogging {
   // Baseline input validation
   Io.assertReadable(input)
@@ -175,9 +175,13 @@ class FilterConsensusReads
   private val EmptyFilterResult = FilterResult(keepRead=true, maskedBases=0)
 
   override def execute(): Unit = {
+    logger.info("Reading the reference into memory")
+    val refMap = ReferenceSequenceIterator(ref, stripComments=true).map { ref => ref.getContigIndex -> ref}.toMap
+    logger.info(f"Read ${refMap.size}%,d contigs.")
+
     val progress = ProgressLogger(logger, verb="Filtered and masked")
     val in       = SamSource(input)
-    val out      = buildOutputWriter(in.header)
+    val out      = buildOutputWriter(in.header, refMap)
 
     // Go through the reads by template and do the filtering
     val templateIterator = Bams.templateIterator(in, maxInMemory=MaxRecordsInMemoryWhenSorting)
@@ -226,103 +230,40 @@ class FilterConsensusReads
     logger.info(f"Masked $maskedBases%,d of $totalBases%,d bases in retained primary consensus reads.")
   }
 
-   /** Builds a method to re-generate teh NM/UQ/MD tags based on if we are loading the full reference or not.  Also
-     * returns a method to close the underling reference  */
-   private def buildRegenerateNmUqMdTags(): (SamRecord => SamRecord, () => Unit) = {
-    if (loadFullReference) {
-      logger.info("Loading reference into memory")
-      val refMap = ReferenceSequenceIterator(ref, stripComments=true).map { ref => ref.getContigIndex -> ref}.toMap
-      val f      = (rec: SamRecord) => Bams.regenerateNmUqMdTags(rec, refMap)
-      (f, () => ())
-    }
-    else {
-      logger.warning("Will require coordinate sorting to update tags, try --load-full-reference instead")
-      val walker = new ReferenceSequenceFileWalker(ref)
-      val f = (rec: SamRecord) => Bams.regenerateNmUqMdTags(rec, walker)
-      (f, () => walker.safelyClose())
-    }
-  }
-
   /** Builds the writer to which filtered records should be written.
     *
-    * The filtered records may be sorted once, twice, or never depending on (a) if the full reference is loaded into
-    * memory, (b) the order after filtering, and (c) the output order.
+    *  If the input order is [[SamOrder.Queryname]] or query grouped, then the filtered records will also be in the same
+    *  order.  So if the output order specified AND does not match the the input order, sorting will occur.
     *
-    * The order after filtering is determined as follows:
-    * 1. If the input order is Queryname, or the input is query grouped, then use the input order.
-    * 2. Otherwise, Queryname.
+    *  If the input order is not [[SamOrder.Queryname]] or query grouped, then the input records will be resorted into
+    *  [[SamOrder.Queryname]].  So if the output order specified AND is not [[SamOrder.Queryname]], sorting will occur.
     *
-    * The output order is determined as follows:
-    * 1. The order from the `--sort-order` option.
-    * 2. Otherwise, the order from the input file, if an order is present.
-    * 3. Otherwise, the order after filtering.
+    *  Otherwise, we can skip sorting!
     *
-    * If the full reference has not been loaded then:
-    * 1. the filtered records are sorted by coordinate to reset the SAM tags.
-    * 2. if the output order is coordinate, the records are then written directly to the output, otherwise they are
-    * re-sorted (for a second time) to the desired output order, and written to the output.
-    *
-    * If the full reference has been loaded then:
-    * 1. if the output order is the same as the order after filtering, the filtered records are written to the output,
-    * otherwise they re-sorted to the desired output order and written to the output.
-
     * */
-  private def buildOutputWriter(header: SAMFileHeader): Closeable with Writer[SamRecord] = {
-    val (regenerateNmUqMdTags, refCloseMethod) = buildRegenerateNmUqMdTags()
-    val outHeader = header.clone()
+  private def buildOutputWriter(inHeader: SAMFileHeader, refMap: Map[Int, ReferenceSequence]): Closeable with Writer[SamRecord] = {
+    val outHeader = inHeader.clone()
 
     // Check if the input will be re-sorted into QueryName, or if the input sort order will be kept
-    val orderAfterFiltering = SamOrder(header) match {
+    val orderAfterFiltering = SamOrder(inHeader) match {
       case Some(order) if order == SamOrder.Queryname || order.groupOrder == GroupOrder.query => order
-      case None => SamOrder.Queryname
+      case _ => SamOrder.Queryname // input will we resorted to queryname
     }
 
     // Get the output order
     val outputOrder = this.sortOrder
-      .orElse(SamOrder(header)) // use the input sort order
       .getOrElse(orderAfterFiltering) // use the order after filtering, so no sort occurs
     outputOrder.applyTo(outHeader) // remember to apply it
 
     // Build the writer
-    val sort = {
-      if (loadFullReference) {
-        // If the full reference has been loaded, we need only sort the output if the order after filtering does not
-        // match the output order.
-        if (orderAfterFiltering == outputOrder) None else Some(outputOrder)
-      }
-      else {
-        //  If the full reference has not been loaded, we will need to coordinate sort to reset
-        //  the tags, then only re-sort in the output order if not in coordinate order.
-        if (outputOrder == SamOrder.Coordinate) None else Some(outputOrder)
-      }
-    }
-    sort.foreach(o => logger.info(f"Output will be sorted into $o order"))
+    val sort   = if (orderAfterFiltering == outputOrder) None else Some(outputOrder)
     val writer = SamWriter(output, outHeader, sort=sort, maxRecordsInRam=MaxRecordsInMemoryWhenSorting)
+    sort.foreach(o => logger.info(f"Output will be sorted into $o order"))
 
     // Create the final writer based on if the full reference has been loaded, or not
-    if (loadFullReference) {
-      new Writer[SamRecord] with Closeable {
-        override def write(rec: SamRecord): Unit = writer += regenerateNmUqMdTags(rec)
-        def close(): Unit = {
-          writer.close()
-          refCloseMethod()
-        }
-      }
-    }
-    else {
-      val progress = ProgressLogger(this.logger, "records", "sorted")
-      new Writer[SamRecord] with Closeable {
-        private val _sorter = Bams.sorter(order=SamOrder.Coordinate, header=header, maxRecordsInRam=MaxRecordsInMemoryWhenSorting)
-        override def write(rec: SamRecord): Unit = {
-          progress.record(rec)
-          this._sorter += rec
-        }
-        def close(): Unit = {
-          this._sorter.foreach { rec => writer += regenerateNmUqMdTags(rec) }
-          writer.close()
-          refCloseMethod()
-        }
-      }
+    new Writer[SamRecord] with Closeable {
+      override def write(rec: SamRecord): Unit = writer += Bams.regenerateNmUqMdTags(rec, refMap)
+      def close(): Unit = writer.close()
     }
   }
 

--- a/src/test/scala/com/fulcrumgenomics/bam/BamsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/BamsTest.scala
@@ -225,7 +225,7 @@ class BamsTest extends UnitSpec {
     rec("NM") = 7
     rec("MD") = "6A7C8T9G"
     rec("UQ") = 237
-    Bams.regenerateNmUqMdTags(rec, DummyRefWalker)
+    Bams.regenerateNmUqMdTags(rec, DummyRefWalker.get(rec.refIndex))
     rec.get[Int]("NM")    shouldBe None
     rec.get[String]("MD") shouldBe None
     rec.get[Int]("UQ")    shouldBe None
@@ -238,7 +238,7 @@ class BamsTest extends UnitSpec {
     rec("MD") = "6A7C8T9G"
     rec("UQ") = 237
     rec.bases = "AAACAAAATA"
-    Bams.regenerateNmUqMdTags(rec, DummyRefWalker)
+    Bams.regenerateNmUqMdTags(rec, DummyRefWalker.get(rec.refIndex))
     rec[Int]("NM")    shouldBe 2
     rec[String]("MD") shouldBe "3A4A1"
     rec[Int]("UQ")    shouldBe 40


### PR DESCRIPTION
Also ReferenceSequenceIterator closes the underlying reference file.

@tfenne not sure if all this work is worth it.  But if the input order is queryname and the output order is queryname, then this will skip sorting when `--load-full-reference=true`.  This could be nice if we want to rely on multi-threaded sort tools or don't care about the order after filtering. 