### PR TITLE
Try using Clint's iterato in consensus calling iterator.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -134,8 +134,9 @@ lazy val root = Project(id="fgbio", base=file("."))
       "org.apache.commons"        %  "commons-math3"  % "3.6.1",
       "com.beachape"              %% "enumeratum"     % "1.6.1",
       "com.intel.gkl"             %  "gkl"            % "0.8.8",
+      "io.cvbio.collection"       %% "iterato"        % "0.0.1",
 
-      //---------- Test libraries -------------------//
+//---------- Test libraries -------------------//
       "org.scalatest"             %% "scalatest"     % "3.1.3"  % "test->*" excludeAll ExclusionRule(organization="org.junit", name="junit")
   ))
   .settings(dependencyOverrides ++= Seq(


### PR DESCRIPTION
Tried using `iterato` to see if we'd get a performance boost in the consensus caller, and it didn't go as I'd hoped.

```
$ time java -Xmx8g -jar fgbio-old.jar --compression 1 CallMolecularConsensusReads -i grouped.bam -o cons.old.bam --min-reads 1 --sort-order :none: --threads 4
...
[2022/02/25 05:49:32 | CallMolecularConsensusReads | Info] Total Raw Reads Considered: 80,371,072.
[2022/02/25 05:49:32 | CallMolecularConsensusReads | Info] Raw Reads Filtered Due to Mismatching Cigars: 609,198 (0.0076).
[2022/02/25 05:49:32 | CallMolecularConsensusReads | Info] Raw Reads Filtered Due to Insufficient Support: 0 (0.0000).
[2022/02/25 05:49:32 | CallMolecularConsensusReads | Info] Consensus reads emitted: 10,459,616.
[2022/02/25 05:49:32 | FgBioMain | Info] CallMolecularConsensusReads completed. Elapsed time: 10.07 minutes.
java -Xmx8g -jar fgbio-old.jar --compression 1 CallMolecularConsensusReads -i  1426.42s user 4.87s system 236% cpu 10:04.29 total


$ time java -Xmx8g -jar fgbio-new.jar --compression 1 CallMolecularConsensusReads -i grouped.bam -o cons.old.bam --min-reads 1 --sort-order :none: --threads 4
...
[2022/02/25 06:00:59 | CallMolecularConsensusReads | Info] Total Raw Reads Considered: 80,371,072.
[2022/02/25 06:00:59 | CallMolecularConsensusReads | Info] Raw Reads Filtered Due to Mismatching Cigars: 609,198 (0.0076).
[2022/02/25 06:00:59 | CallMolecularConsensusReads | Info] Raw Reads Filtered Due to Insufficient Support: 0 (0.0000).
[2022/02/25 06:00:59 | CallMolecularConsensusReads | Info] Consensus reads emitted: 10,459,616.
[2022/02/25 06:00:59 | FgBioMain | Info] CallMolecularConsensusReads completed. Elapsed time: 10.79 minutes.
java -Xmx8g -jar fgbio-new.jar --compression 1 CallMolecularConsensusReads -i  4442.70s user 30.35s system 691% cpu 10:47.32 total
```

Runtime is actually _longer_ though broadly similar, but CPU usage skyrocketed.  @clintval any idea why I'm not seeing the kind of gains you're seeing elsewhere?