### PR TITLE
Use the ParIterator in GroupReadsByUmi

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -128,7 +128,7 @@ lazy val root = Project(id="fgbio", base=file("."))
       "org.scala-lang"            %  "scala-compiler" % scalaVersion.value,
       "org.scala-lang.modules"    %% "scala-xml"      % "1.2.0",
       "org.scala-lang.modules"    %% "scala-collection-compat" % "2.1.1",
-      "com.fulcrumgenomics"       %% "commons"        % "1.3.0",
+      "com.fulcrumgenomics"       %% "commons"        % "1.4.0-ffd57b8-SNAPSHOT",
       "com.fulcrumgenomics"       %% "sopt"           % "1.1.0",
       "com.github.samtools"       %  "htsjdk"         % "2.23.0" excludeAll(htsjdkExcludes: _*),
       "org.apache.commons"        %  "commons-math3"  % "3.6.1",


### PR DESCRIPTION
@tfenne I tried updating the code to use the new `ParIterator` (and it also now skips sorting if the input is template-coordinate), but it seems to be all IO bound, so not sure either are worth it.  Perhaps I change the PR to only keep the sorting skip.  Can you take a look/run on your end?