### PR TITLE
GroupReadsByUmi only sort input if it is not TemplateCoordinate sorted

### DIFF
--- a/src/test/scala/com/fulcrumgenomics/umi/GroupReadsByUmiTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/GroupReadsByUmiTest.scala
@@ -28,6 +28,7 @@ package com.fulcrumgenomics.umi
 
 import com.fulcrumgenomics.bam.Template
 import com.fulcrumgenomics.bam.api.SamOrder
+import com.fulcrumgenomics.bam.api.SamOrder.TemplateCoordinate
 import com.fulcrumgenomics.cmdline.FgBioMain.FailureException
 import com.fulcrumgenomics.testing.SamBuilder.{Minus, Plus}
 import com.fulcrumgenomics.testing.{SamBuilder, UnitSpec}
@@ -216,35 +217,42 @@ class GroupReadsByUmiTest extends UnitSpec with OptionValues with PrivateMethodT
 
   // Test for running the GroupReadsByUmi command line program with some sample input
   "GroupReadsByUmi" should "group reads correctly" in {
-    val builder = new SamBuilder(readLength=100, sort=Some(SamOrder.Coordinate))
-    builder.addPair(name="a01", start1=100, start2=300, attrs=Map("RX" -> "AAAAAAAA"))
-    builder.addPair(name="a02", start1=100, start2=300, attrs=Map("RX" -> "AAAAgAAA"))
-    builder.addPair(name="a03", start1=100, start2=300, attrs=Map("RX" -> "AAAAAAAA"))
-    builder.addPair(name="a04", start1=100, start2=300, attrs=Map("RX" -> "AAAAAAAt"))
-    builder.addPair(name="b01", start1=100, start2=100, unmapped2=true, attrs=Map("RX" -> "AAAAAAAt"))
-    builder.addPair(name="c01", start1=100, start2=300, mapq1=5)
+    Seq(SamOrder.Coordinate, SamOrder.Queryname, SamOrder.TemplateCoordinate).foreach { sortOrder =>
+      val builder = new SamBuilder(readLength=100, sort=Some(sortOrder))
+      builder.addPair(name="a01", start1=100, start2=300, attrs=Map("RX" -> "AAAAAAAA"))
+      builder.addPair(name="a02", start1=100, start2=300, attrs=Map("RX" -> "AAAAgAAA"))
+      builder.addPair(name="a03", start1=100, start2=300, attrs=Map("RX" -> "AAAAAAAA"))
+      builder.addPair(name="a04", start1=100, start2=300, attrs=Map("RX" -> "AAAAAAAt"))
+      builder.addPair(name="b01", start1=100, start2=100, unmapped2=true, attrs=Map("RX" -> "AAAAAAAt"))
+      builder.addPair(name="c01", start1=100, start2=300, mapq1=5)
 
-    val in  = builder.toTempFile()
-    val out = Files.createTempFile("umi_grouped.", ".sam")
-    val hist = Files.createTempFile("umi_grouped.", ".histogram.txt")
-    new GroupReadsByUmi(input=in, output=out, familySizeHistogram=Some(hist), rawTag="RX", assignTag="MI", strategy=Strategy.Edit, edits=1, minMapQ=30).execute()
+      val in  = builder.toTempFile()
+      val out = Files.createTempFile("umi_grouped.", ".sam")
+      val hist = Files.createTempFile("umi_grouped.", ".histogram.txt")
+      val tool = new GroupReadsByUmi(input=in, output=out, familySizeHistogram=Some(hist), rawTag="RX", assignTag="MI", strategy=Strategy.Edit, edits=1, minMapQ=30)
+      val logs = executeFgbioTool(tool)
 
-    val groups = readBamRecs(out).groupBy(_.name.charAt(0))
+      val groups = readBamRecs(out).groupBy(_.name.charAt(0))
 
-    // Group A: 1-4 all passed through into one umi group
-    groups('a') should have size 4*2
-    groups('a').map(_.name).toSet shouldEqual Set("a01", "a02", "a03", "a04")
-    groups('a').map(r => r[String]("MI")).toSet should have size 1
+      // Group A: 1-4 all passed through into one umi group
+      groups('a') should have size 4*2
+      groups('a').map(_.name).toSet shouldEqual Set("a01", "a02", "a03", "a04")
+      groups('a').map(r => r[String]("MI")).toSet should have size 1
 
-    // 5 separated out into another group due to unmapped mate
-    groups('b') should have size 2
-    groups('b').map(r => r[String]("MI")).toSet should have size 1
-    groups('b').map(r => r[String]("MI")).head should not be groups('a').map(r => r[String]("MI")).head
+      // 5 separated out into another group due to unmapped mate
+      groups('b') should have size 2
+      groups('b').map(r => r[String]("MI")).toSet should have size 1
+      groups('b').map(r => r[String]("MI")).head should not be groups('a').map(r => r[String]("MI")).head
 
-    // 6 out for low mapq,
-    groups.contains('c') shouldBe false
+      // 6 out for low mapq,
+      groups.contains('c') shouldBe false
 
-    hist.toFile.exists() shouldBe true
+      hist.toFile.exists() shouldBe true
+
+      // Make sure that we skip sorting for TemplateCoordinate
+      val sortMessage = "Sorting the input to TemplateCoordinate order"
+      logs.exists(_.contains(sortMessage)) shouldBe (sortOrder != TemplateCoordinate)
+    }
   }
 
   it should "correctly group reads with the paired assigner when the two UMIs are the same" in {


### PR DESCRIPTION
This extracts some functionality from #791, where we skip sorting the input if the input is already `TemplateCoordinate` sorted.  This allows other tools to perform the sort.