### PR TITLE
Added ability for FastqToBam to also extract UMIs from read names.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/fastq/FastqToBam.scala
+++ b/src/main/scala/com/fulcrumgenomics/fastq/FastqToBam.scala
@@ -25,14 +25,13 @@
 package com.fulcrumgenomics.fastq
 
 import java.util
-
 import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.bam.api.{SamOrder, SamRecord, SamWriter}
 import com.fulcrumgenomics.cmdline.{ClpGroups, FgBioTool}
 import com.fulcrumgenomics.commons.CommonsDef.PathToFastq
 import com.fulcrumgenomics.commons.util.LazyLogging
 import com.fulcrumgenomics.sopt.{arg, clp}
-import com.fulcrumgenomics.umi.ConsensusTags
+import com.fulcrumgenomics.umi.{ConsensusTags, Umis}
 import com.fulcrumgenomics.util.SegmentType._
 import com.fulcrumgenomics.util.{Io, ProgressLogger, ReadStructure}
 import htsjdk.samtools.SAMFileHeader.{GroupOrder, SortOrder}
@@ -72,6 +71,13 @@ import htsjdk.samtools.{ReservedTagConstants, SAMFileHeader, SAMReadGroupRecord}
     |For more information on read structures see the
     |[Read Structure Wiki Page](https://github.com/fulcrumgenomics/fgbio/wiki/Read-Structures)
     |
+    |UMIs may be extracted from the read sequences, the read names, or both.  If `--extract-umis-from-read-names` is
+    |specified, any UMIs present in the read names are extracted; read names are expected to be `:`-separated with
+    |any UMIs present in the 8th field.  If this option is specified, the `--umi-qual-tag` option may not be used as
+    |qualities are not available for UMIs in the read name. If UMI segments are present in the read structures those
+    |will also be extracted.  If UMIs are present in both, the final UMIs be constructed by first taking the UMIs
+    |from the read names, then adding a hyphen, then the UMIs extracted from the reads.
+    |
     |The same number of input files and read structures must be provided, with one exception: if supplying exactly
     |1 or 2 fastq files, both of which are solely template reads, no read structures need be provided.
     |
@@ -86,6 +92,7 @@ class FastqToBam
   @arg(flag='s', doc="If true, queryname sort the BAM file, otherwise preserve input order.")  val sort: Boolean = false,
   @arg(flag='u', doc="Tag in which to store molecular barcodes/UMIs.")                         val umiTag: String = ConsensusTags.UmiBases,
   @arg(flag='q', doc="Tag in which to store molecular barcode/UMI qualities.")                 val umiQualTag: Option[String] = None,
+  @arg(flag='n', doc="Extract UMI(s) from read names and prepend to UMIs from reads.")         val extractUmisFromReadNames: Boolean = false,
   @arg(          doc="Read group ID to use in the file header.")                               val readGroupId: String = "A",
   @arg(          doc="The name of the sequenced sample.")                                      val sample: String,
   @arg(          doc="The name/ID of the sequenced library.")                                  val library: String,
@@ -107,6 +114,7 @@ class FastqToBam
   Io.assertCanWriteFile(output)
   validate(input.length == actualReadStructures.length, "input and read-structure must be supplied the same number of times.")
   validate(1 to 2 contains actualReadStructures.flatMap(_.templateSegments).size, "read structures must contain 1-2 template reads total.")
+  validate(!extractUmisFromReadNames || umiQualTag.isEmpty, "Cannot extract UMI qualities when also extracting UMI from read names.")
 
   override def execute(): Unit = {
     val encoding = qualityEncoding
@@ -153,6 +161,9 @@ class FastqToBam
       val umiQual       = subs.iterator.filter(_.kind == MolecularBarcode).map(_.quals).mkString(" ")
       val templates     = subs.iterator.filter(_.kind == Template).toList
 
+      // If requested, pull out the UMI(s) from the read name
+      val umiFromReadName = if (extractUmisFromReadNames) Umis.extractUmisFromReadName(fqs.head.name, strict=true) else None
+
       templates.zipWithIndex.map { case (read, index) =>
         // If the template read had no bases, we'll substitute in a single N @ Q2 below to keep htsjdk happy
         val empty = read.bases.length == 0
@@ -170,9 +181,15 @@ class FastqToBam
         }
 
         if (sampleBarcode.nonEmpty) rec("BC") = sampleBarcode
-        if (umi.nonEmpty) {
-          rec(this.umiTag) = umi
-          this.umiQualTag.foreach(rec(_) = umiQual)
+
+        // Set the UMI on the read depending on whether we got UMIs from the read names, reads or both
+        (umi, umiFromReadName) match {
+          case ("",       Some(fromName)) => rec(this.umiTag) = fromName
+          case ("",       None          ) => ()
+          case (fromRead, Some(fromName)) => rec(this.umiTag) = s"${fromName}-${fromRead}"
+          case (fromRead, None          ) =>
+            rec(this.umiTag) = fromRead
+            this.umiQualTag.foreach(rec(_) = umiQual)
         }
 
         rec

--- a/src/main/scala/com/fulcrumgenomics/fastq/FastqToBam.scala
+++ b/src/main/scala/com/fulcrumgenomics/fastq/FastqToBam.scala
@@ -75,7 +75,7 @@ import htsjdk.samtools.{ReservedTagConstants, SAMFileHeader, SAMReadGroupRecord}
     |specified, any UMIs present in the read names are extracted; read names are expected to be `:`-separated with
     |any UMIs present in the 8th field.  If this option is specified, the `--umi-qual-tag` option may not be used as
     |qualities are not available for UMIs in the read name. If UMI segments are present in the read structures those
-    |will also be extracted.  If UMIs are present in both, the final UMIs be constructed by first taking the UMIs
+    |will also be extracted.  If UMIs are present in both, the final UMIs are constructed by first taking the UMIs
     |from the read names, then adding a hyphen, then the UMIs extracted from the reads.
     |
     |The same number of input files and read structures must be provided, with one exception: if supplying exactly

--- a/src/main/scala/com/fulcrumgenomics/umi/CopyUmiFromReadName.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CopyUmiFromReadName.scala
@@ -42,9 +42,7 @@ import com.fulcrumgenomics.util.{Io, ProgressLogger}
 class CopyUmiFromReadName
 ( @arg(flag='i', doc="The input BAM file") input: PathToBam,
   @arg(flag='o', doc="The output BAM file") output: PathToBam,
-  @arg(doc="Remove the UMI from the read name") removeUmi: Boolean = false,
-  @arg(doc="Replaces any occurrences of this delimiter found in the UMI with a dash ('-') as per the SAM specification")
-  umiDelimiter: Option[Char] = None
+  @arg(doc="Remove the UMI from the read name") removeUmi: Boolean = false
 ) extends FgBioTool with LazyLogging {
 
   Io.assertReadable(input)
@@ -56,7 +54,7 @@ class CopyUmiFromReadName
     val progress = new ProgressLogger(logger)
     source.foreach { rec =>
       progress.record(rec)
-      writer += Umis.copyUmiFromReadName(rec=rec, removeUmi=removeUmi, umiDelimiter=umiDelimiter)
+      writer += Umis.copyUmiFromReadName(rec=rec, removeUmi=removeUmi)
     }
     progress.logLast()
     source.safelyClose()

--- a/src/main/scala/com/fulcrumgenomics/umi/CopyUmiFromReadName.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CopyUmiFromReadName.scala
@@ -36,8 +36,12 @@ import com.fulcrumgenomics.util.{Io, ProgressLogger}
   """
     |Copies the UMI at the end of the BAM's read name to the RX tag.
     |
-    |The read name is split by the given name delimiter, and the last field is assumed to be the UMI sequence.  The UMI
-    |will be copied to the `RX` tag as per the SAM specification.
+    |The read name is split on `:` characters with the last field is assumed to be the UMI sequence.  The UMI
+    |will be copied to the `RX` tag as per the SAM specification.  If any read does not have a UMI composed of
+    |valid bases (ACGTN), the program will report the error and fail.
+    |
+    |If a read name contains multiple UMIs they may be delimited by either hyphens (`-`) or pluses (`+`). The
+    |resulting UMI in the `RX` tag will always be hyphen delimited.
   """)
 class CopyUmiFromReadName
 ( @arg(flag='i', doc="The input BAM file") input: PathToBam,

--- a/src/main/scala/com/fulcrumgenomics/umi/Umis.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/Umis.scala
@@ -26,7 +26,6 @@
 package com.fulcrumgenomics.umi
 
 import com.fulcrumgenomics.bam.api.SamRecord
-import htsjdk.samtools.util.SequenceUtil
 
 object Umis {
 
@@ -61,7 +60,7 @@ object Umis {
     *  See https://support.illumina.com/help/BaseSpace_OLH_009008/Content/Source/Informatics/BS/FileFormat_FASTQ-files_swBS.htm
     *  The UMI field is optional, so read names may or may not contain it.  Illumina also specifies that the UMI
     *  field may contain multiple UMIs, in which case they will delimit them with `+` characters.  Pluses will be
-    *  translated to hyphens before returning.  
+    *  translated to hyphens before returning.
     *
     *  If `strict` is true the name _must_ contain either 7 or 8 colon-separated segments, 
     with the UMI being the last in the case of 8 and `None` in the case of 7.

--- a/src/main/scala/com/fulcrumgenomics/umi/Umis.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/Umis.scala
@@ -39,7 +39,7 @@ object Umis {
     *
     * @param rec the record to modify
     * @param removeUmi true to remove the UMI from the read name, otherwise only copy the UMI to the tag
-    * @param delimiter the delimiter of fields within the readname
+    * @param delimiter the delimiter of fields within the read name
     * @return the modified record
     */
   def copyUmiFromReadName(rec: SamRecord, removeUmi: Boolean = false, delimiter: Char = ':'): SamRecord = {

--- a/src/main/scala/com/fulcrumgenomics/umi/Umis.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/Umis.scala
@@ -59,19 +59,16 @@ object Umis {
     *   @<instrument>:<run number>:<flowcell ID>:<lane>:<tile>:<x-pos>:<y-pos>:<UMI> <read>:<is filtered>:<control number>:<index>
     *
     *  See https://support.illumina.com/help/BaseSpace_OLH_009008/Content/Source/Informatics/BS/FileFormat_FASTQ-files_swBS.htm
+    *  The UMI field is optional, so read names may or may not contain it.  Illumina also specifies that the UMI
+    *  field may contain multiple UMIs, in which case they will delimit them with `+` characters.  Pluses will be
+    *  translated to hyphens before returning.  
     *
     *  If `strict` is true the name _must_ contain either 7 or 8 colon-separated segments, 
     with the UMI being the last in the case of 8 and `None` in the case of 7.
     * 
     * If `strict` is false the last segment is returned so long as it appears to be a valid UMI.
     */
-  def extractUmisFromReadName(header: String, delimiter: Char = ':', strict: Boolean): Option[String] = {
-    // Support full FASTQ headers by first removing any spaces and trailing text
-    val name = {
-      val idx = header.indexOf(' ')
-      if (idx >= 0) header.substring(0, idx) else header
-    }
-
+  def extractUmisFromReadName(name: String, delimiter: Char = ':', strict: Boolean): Option[String] = {
     // If strict, check that the read name actually has eight parts, which is expected
     val rawUmi = if (strict) {
       val colons = name.count(_ == delimiter)

--- a/src/main/scala/com/fulcrumgenomics/umi/Umis.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/Umis.scala
@@ -60,8 +60,10 @@ object Umis {
     *
     *  See https://support.illumina.com/help/BaseSpace_OLH_009008/Content/Source/Informatics/BS/FileFormat_FASTQ-files_swBS.htm
     *
-    *  If `strict` is true the name _must_ contain 8 colon-separated segments, with the UMI being the last.  If
-    *  `strict` is false the last segment is returned so long as it appears to be a valid UMI.
+    *  If `strict` is true the name _must_ contain either 7 or 8 colon-separated segments, 
+    with the UMI being the last in the case of 8 and `None` in the case of 7.
+    * 
+    * If `strict` is false the last segment is returned so long as it appears to be a valid UMI.
     */
   def extractUmisFromReadName(header: String, delimiter: Char = ':', strict: Boolean): Option[String] = {
     // Support full FASTQ headers by first removing any spaces and trailing text


### PR DESCRIPTION
This ended up being more complicated than I thought, but I think it's still worthwhile.  I refactored `Umis.copyUmiFromReadName()` to enable me to apply it just to read names, and also to add a strict mode.  I got rid of the parameter for setting the conversion of `+` to `-` and just made that happen all the time, since I hope we really only see `+` or `-` in the wild.