### PR TITLE
Fix most scala 2.13 deprecation warnings.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/alignment/Aligner.scala
+++ b/src/main/scala/com/fulcrumgenomics/alignment/Aligner.scala
@@ -453,7 +453,7 @@ class Aligner(val scorer: AlignmentScorer,
       if (nextD == Done) elems += CigarElem(currOperator, currLength)
     }
 
-    Alignment(query=query, target=target, queryStart=curI+1, targetStart=curJ+1, cigar=Cigar(elems.result.reverse), score=score)
+    Alignment(query=query, target=target, queryStart=curI+1, targetStart=curJ+1, cigar=Cigar(elems.result().reverse), score=score)
   }
 
   /**
@@ -532,7 +532,7 @@ class Aligner(val scorer: AlignmentScorer,
         }
     }
 
-    hits.result
+    hits.result()
   }
 
   /** Returns true if the two bases should be considered a match when generating the alignment from the matrix

--- a/src/main/scala/com/fulcrumgenomics/alignment/Alignment.scala
+++ b/src/main/scala/com/fulcrumgenomics/alignment/Alignment.scala
@@ -240,7 +240,7 @@ case class Cigar(elems: IndexedSeq[CigarElem]) extends Iterable[CigarElem] {
       }
     }
 
-    Cigar(builder.result)
+    Cigar(builder.result())
   }
 
   /**
@@ -288,7 +288,7 @@ case class Cigar(elems: IndexedSeq[CigarElem]) extends Iterable[CigarElem] {
         builder += same
       }
 
-      Cigar(builder.result)
+      Cigar(builder.result())
     }
   }
 
@@ -482,6 +482,6 @@ case class Alignment(query: Array[Byte],
       }
     }
 
-    copy(queryStart=qStart, targetStart=tStart, cigar=Cigar(elems.result), score=0)
+    copy(queryStart=qStart, targetStart=tStart, cigar=Cigar(elems.result()), score=0)
   }
 }

--- a/src/main/scala/com/fulcrumgenomics/bam/Bams.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/Bams.scala
@@ -354,7 +354,7 @@ object Bams extends LazyLogging {
 
     val _iterator = new Iterator[Template] {
       override def hasNext: Boolean = queryIterator.hasNext
-      override def next: Template   = {
+      override def next(): Template   = {
         require(hasNext, "next() called on empty iterator")
         Template(queryIterator)
       }
@@ -443,7 +443,6 @@ object Bams extends LazyLogging {
         rec(SAMTag.UQ.name) = SequenceUtil.sumQualitiesOfMismatches(rec.asSam, refBases, 0)
       }
     }
-    rec
   }
 
   /**

--- a/src/main/scala/com/fulcrumgenomics/bam/BaseCounts.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/BaseCounts.scala
@@ -26,7 +26,7 @@ package com.fulcrumgenomics.bam
 
 import htsjdk.samtools.util.SamLocusIterator
 import htsjdk.samtools.util.SamLocusIterator.LocusInfo
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 object BaseCounts {
   /**

--- a/src/main/scala/com/fulcrumgenomics/bam/EstimatePoolingFractions.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/EstimatePoolingFractions.scala
@@ -25,7 +25,6 @@
 package com.fulcrumgenomics.bam
 
 import java.lang.Math.{max, min}
-
 import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.bam.api.SamSource
 import com.fulcrumgenomics.cmdline.{ClpGroups, FgBioTool}
@@ -37,6 +36,8 @@ import com.fulcrumgenomics.vcf.api.{Variant, VcfSource}
 import htsjdk.samtools.util.SamLocusIterator.LocusInfo
 import htsjdk.samtools.util._
 import org.apache.commons.math3.stat.regression.OLSMultipleLinearRegression
+
+import scala.collection.immutable.ArraySeq
 
 @clp(group=ClpGroups.SamOrBam, description=
   """
@@ -84,7 +85,7 @@ class EstimatePoolingFractions
     val intervals   = loadIntervals
 
     // Get the expected fractions from the VCF
-    val vcfIterator = constructVcfIterator(vcfReader, intervals, sampleNames)
+    val vcfIterator = constructVcfIterator(vcfReader, intervals, ArraySeq.unsafeWrapArray(sampleNames))
     val loci = vcfIterator.filterNot(v => this.nonAutosomes.contains(v.chrom)).map { v => Locus(
       chrom = v.chrom,
       pos   = v.pos,

--- a/src/main/scala/com/fulcrumgenomics/bam/UpdateReadGroups.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/UpdateReadGroups.scala
@@ -32,7 +32,7 @@ import com.fulcrumgenomics.commons.util.LazyLogging
 import com.fulcrumgenomics.sopt._
 import htsjdk.samtools._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /**
   * Updates one or more read groups.

--- a/src/main/scala/com/fulcrumgenomics/bam/api/SamWriter.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/api/SamWriter.scala
@@ -126,12 +126,12 @@ final class SamWriter private (private val writer: SAMFileWriter,
   /** Closes the writer. */
   override def close(): Unit = {
     this.sorter.foreach { s =>
-      sortProgress.foreach(_.logLast)
+      sortProgress.foreach(_.logLast())
       s.iterator.foreach { rec =>
         this.writer.addAlignment(rec.asSam)
         writeProgress.foreach(_.record(rec))
       }
-      writeProgress.foreach(_.logLast)
+      writeProgress.foreach(_.logLast())
 
       s.close()
     }

--- a/src/main/scala/com/fulcrumgenomics/fastq/FastqSource.scala
+++ b/src/main/scala/com/fulcrumgenomics/fastq/FastqSource.scala
@@ -62,12 +62,12 @@ object FastqSource {
   def zipped(sources: Seq[FastqSource]): Iterator[Seq[FastqRecord]] = new Iterator[Seq[FastqRecord]] {
     require(sources.nonEmpty, "No sources provided")
 
-    def hasNext(): Boolean = sources.exists(_.hasNext)
+    def hasNext: Boolean = sources.exists(_.hasNext)
 
     def next(): Seq[FastqRecord] = {
       if (!this.hasNext) throw new NoSuchElementException("Calling next() when hasNext() is false.")
       require(sources.forall(_.hasNext) == sources.head.hasNext, "Sources are out of sync.")
-      val records = sources.map(_.next)
+      val records = sources.map(_.next())
       // Check that the FASTQ records all have the same name
       require(records.forall(_.name == records.head.name), "Fastqs are out of sync, found read names: " + records.map(_.name).mkString(", "))
       records

--- a/src/main/scala/com/fulcrumgenomics/rnaseq/CollectErccMetrics.scala
+++ b/src/main/scala/com/fulcrumgenomics/rnaseq/CollectErccMetrics.scala
@@ -113,7 +113,7 @@ class CollectErccMetrics
       case Some(path) => DelimitedDataParser(path, '\t').map { row => row[String](0) -> row[Double](1) }.toMap
       case None       =>
         val stream    = getClass.getResourceAsStream(CollectErccMetrics.StandardMixtureMetadataPath)
-        val lines     = Source.fromInputStream(stream).withClose(() => stream.close()).getLines.filterNot(_.startsWith("#"))
+        val lines     = Source.fromInputStream(stream).withClose(() => stream.close()).getLines().filterNot(_.startsWith("#"))
         val mixColumn = if (mixtureName.get == ErccMixture.Mix1) 3 else 4
         new DelimitedDataParser(lines, '\t').map { row => row[String](1) -> row[Double](mixColumn) }.toMap
     }
@@ -162,7 +162,7 @@ class CollectErccMetrics
       val count = erccTemplatesCounter.countOf(name)
       if (minTranscriptCount <= count) {
         val erccLength = in.header.getSequence(name).getSequenceLength
-        counts += log2(count)
+        counts += log2(count.toDouble)
         normalizedCounts += log2(count * maximumErccLength / erccLength.toDouble) // normalize by the ERCC transcript length
         concentrations += log2(concentration)
       }

--- a/src/main/scala/com/fulcrumgenomics/rnaseq/EstimateRnaSeqInsertSize.scala
+++ b/src/main/scala/com/fulcrumgenomics/rnaseq/EstimateRnaSeqInsertSize.scala
@@ -40,7 +40,7 @@ import htsjdk.samtools._
 import htsjdk.samtools.filter._
 import htsjdk.samtools.util.{CoordMath, Interval, OverlapDetector}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 @clp(description =
   """Computes the insert size for RNA-Seq experiments.

--- a/src/main/scala/com/fulcrumgenomics/testing/VcfBuilder.scala
+++ b/src/main/scala/com/fulcrumgenomics/testing/VcfBuilder.scala
@@ -155,7 +155,7 @@ class VcfBuilder private (initialHeader: VcfHeader) extends Iterable[Variant] {
           alleles: Seq[String],
           qual: Int = -1,
           info: Map[String, Any] = Map.empty,
-          filters: IterableOnce[String] = Set.empty,
+          filters: Iterable[String] = Set.empty,
           gts: Seq[Gt] = Seq.empty
          ): this.type = {
 

--- a/src/main/scala/com/fulcrumgenomics/umi/CollectDuplexSeqMetrics.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CollectDuplexSeqMetrics.scala
@@ -392,7 +392,7 @@ class CollectDuplexSeqMetrics
     ab.iterator.map(r => r[String](this.umiTag).split('-')).foreach { case Array(u1, u2) => umi1s += u1; umi2s += u2 }
     ba.iterator.map(r => r[String](this.umiTag).split('-')).foreach { case Array(u1, u2) => umi1s += u2; umi2s += u1 }
 
-    val Seq(abConsensusUmi, baConsensusUmi) = Seq(umi1s, umi2s).map(_.result).map{ umis =>
+    val Seq(abConsensusUmi, baConsensusUmi) = Seq(umi1s, umi2s).map(_.result()).map{ umis =>
       val consensus = this.consensusBuilder.callConsensus(umis)
       val metric    = this.umiMetricsMap.getOrElseUpdate(consensus, UmiMetric(umi=consensus))
       metric.raw_observations    += umis.size

--- a/src/main/scala/com/fulcrumgenomics/umi/ConsensusCallingIterator.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/ConsensusCallingIterator.scala
@@ -86,7 +86,7 @@ class ConsensusCallingIterator[ConsensusRead <: SimpleRead](sourceIterator: Iter
     }
   }
 
-  override def next(): SamRecord = this.iter.next
+  override def next(): SamRecord = this.iter.next()
 }
 
 /** Groups consecutive records based on a method to group records. */
@@ -96,11 +96,11 @@ private class SamRecordGroupedIterator[Key](sourceIterator: Iterator[SamRecord],
   private var nextChunk = IndexedSeq.empty[SamRecord]
 
   /** True if there are more consensus reads, false otherwise. */
-  def hasNext(): Boolean = this.nextChunk.nonEmpty || (this.input.nonEmpty && advance())
+  def hasNext: Boolean = this.nextChunk.nonEmpty || (this.input.nonEmpty && advance())
 
   /** Returns the next consensus read. */
   def next(): Seq[SamRecord] = {
-    if (!this.hasNext()) throw new NoSuchElementException("Calling next() when hasNext() is false.")
+    if (!this.hasNext) throw new NoSuchElementException("Calling next() when hasNext() is false.")
     yieldAndThen { nextChunk } { nextChunk = IndexedSeq.empty }
   }
 

--- a/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
@@ -256,7 +256,7 @@ object GroupReadsByUmi {
         root.descendants.foreach(child => mappings += ((child.umi, id)))
       })
 
-      mappings.result
+      mappings.result()
     }
 
     override def assign(rawUmis: Seq[Umi]): Map[Umi, MoleculeId] = {
@@ -281,7 +281,7 @@ object GroupReadsByUmi {
         }
       }
 
-      assignIdsToNodes(roots.result)
+      assignIdsToNodes(roots.result())
     }
   }
 

--- a/src/main/scala/com/fulcrumgenomics/umi/ReviewConsensusVariants.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/ReviewConsensusVariants.scala
@@ -24,9 +24,6 @@
 
 package com.fulcrumgenomics.umi
 
-import java.nio.file.Path
-import java.util.Collections
-
 import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.bam.BaseCounts
 import com.fulcrumgenomics.bam.api.{SamRecord, SamSource, SamWriter}
@@ -37,16 +34,19 @@ import com.fulcrumgenomics.umi.ReviewConsensusVariants._
 import com.fulcrumgenomics.util.{Io, Metric}
 import htsjdk.samtools.SamPairUtil.PairOrientation
 import htsjdk.samtools.reference.{ReferenceSequenceFile, ReferenceSequenceFileFactory}
-import htsjdk.samtools.util.IOUtil.{VCF_EXTENSIONS => VcfExtensions}
-import htsjdk.samtools.util._
+import htsjdk.samtools.util.{FileExtensions, Interval, IntervalList, Locatable, SamLocusIterator, SequenceUtil}
 import htsjdk.variant.variantcontext.VariantContext
 import htsjdk.variant.vcf.VCFFileReader
 
-import scala.collection.JavaConverters._
+import java.nio.file.Path
+import java.util.Collections
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
+import scala.jdk.CollectionConverters._
 
 object ReviewConsensusVariants {
+  /** The set of file extensions for VCF-like files. */
+  val VcfExtensions: IndexedSeq[String] = FileExtensions.VCF_LIST.iterator().toIndexedSeq
 
   /**
     * Detailed information produced by `ReviewConsensusVariants` on variants called in consensus reads. Each

--- a/src/main/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCaller.scala
@@ -155,7 +155,7 @@ class VanillaUmiConsensusCaller(override val readNamePrefix: String,
         builder += createSamRecord(r2, SecondOfPair, secondOfPair.flatMap(_.get[String](ConsensusTags.UmiBases)))
     }
 
-    builder.result
+    builder.result()
   }
 
   /** Creates a consensus read from the given records.  If no consensus read was created, None is returned. */

--- a/src/main/scala/com/fulcrumgenomics/util/PickIlluminaIndices.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/PickIlluminaIndices.scala
@@ -2,7 +2,7 @@ package com.fulcrumgenomics.util
 
 import com.fulcrumgenomics.cmdline.{ClpGroups, FgBioTool}
 import com.fulcrumgenomics.FgBioDef._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import com.fulcrumgenomics.sopt.{arg, clp}
 
 /**

--- a/src/main/scala/com/fulcrumgenomics/util/ReadStructure.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/ReadStructure.scala
@@ -104,7 +104,7 @@ object ReadStructure {
       }
     }
 
-    segs.result
+    segs.result()
   }
 
   /**

--- a/src/main/scala/com/fulcrumgenomics/vcf/AssessPhasing.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/AssessPhasing.scala
@@ -42,7 +42,7 @@ import htsjdk.variant.variantcontext.{Genotype, GenotypeBuilder, VariantContext,
 import htsjdk.variant.vcf._
 
 import scala.annotation.tailrec
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable.ListBuffer
 
 @clp(
@@ -164,15 +164,15 @@ class AssessPhasing
     metric.mean_called_block_length   = calledBlockLengthCounter.mean()
     metric.median_called_block_length = calledBlockLengthCounter.median()
     metric.stddev_called_block_length = calledBlockLengthCounter.stddev(m=metric.mean_called_block_length)
-    metric.n50_called_block_length    = calledAssemblyStats.n50
-    metric.n90_called_block_length    = calledAssemblyStats.n90
-    metric.l50_called                 = calledAssemblyStats.l50
+    metric.n50_called_block_length    = calledAssemblyStats.n50.toDouble
+    metric.n90_called_block_length    = calledAssemblyStats.n90.toDouble
+    metric.l50_called                 = calledAssemblyStats.l50.toDouble
     metric.mean_truth_block_length    = truthBlockLengthCounter.mean()
     metric.median_truth_block_length  = truthBlockLengthCounter.median()
     metric.stddev_truth_block_length  = truthBlockLengthCounter.stddev(m=metric.mean_truth_block_length)
-    metric.n50_truth_block_length     = truthAssemblyStats.n50
-    metric.n90_truth_block_length     = truthAssemblyStats.n90
-    metric.l50_truth                  = truthAssemblyStats.l50
+    metric.n50_truth_block_length     = truthAssemblyStats.n50.toDouble
+    metric.n90_truth_block_length     = truthAssemblyStats.n90.toDouble
+    metric.l50_truth                  = truthAssemblyStats.l50.toDouble
 
     metric.finalizeMetric()
 
@@ -578,10 +578,10 @@ case class  AssessPhasingMetric
   var n90_truth_block_length: Double = 0,
   var l50_truth: Double = 0
 ) extends Metric {
-  private def divide(a: Double, b: Double): Double = {
-    if (b == 0) 0
-    else a / b
-  }
+
+  private def divide(a: Double, b: Double): Double = if (b == 0) 0 else a / b
+  private def divide(a: Long, b: Long): Double = divide(a.toDouble, b.toDouble)
+
   def finalizeMetric(): this.type = {
     this.frac_phased                                   = divide(this.num_phased, this.num_called)
     this.frac_phased_with_truth_phased                 = divide(this.num_phased_with_truth_phased, this.num_called_with_truth_phased)

--- a/src/main/scala/com/fulcrumgenomics/vcf/ByIntervalListVariantContextIterator.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/ByIntervalListVariantContextIterator.scala
@@ -73,7 +73,7 @@ private class OverlapDetectionVariantContextIterator(val iter: Iterator[VariantC
 
   this.advance()
 
-  def hasNext(): Boolean = this.nextVariantContext.isDefined
+  def hasNext: Boolean = this.nextVariantContext.isDefined
 
   def next(): VariantContext = {
     this.nextVariantContext match {
@@ -123,7 +123,7 @@ private class IndexQueryVariantContextIterator(private val reader: VCFFileReader
 
   this.advance()
 
-  def hasNext(): Boolean = {
+  def hasNext: Boolean = {
     this.iter.exists(_.hasNext)
   }
 

--- a/src/main/scala/com/fulcrumgenomics/vcf/HapCutToVcf.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/HapCutToVcf.scala
@@ -39,7 +39,7 @@ import htsjdk.variant.variantcontext._
 import htsjdk.variant.variantcontext.writer.{Options, VariantContextWriter, VariantContextWriterBuilder}
 import htsjdk.variant.vcf._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.io.Source
 
 @clp(
@@ -306,16 +306,16 @@ private class HapCutAndVcfMergingIterator(hapCutPath: FilePath,
   private val hapCutReader   = HapCutReader(path=hapCutPath)
   private val sampleName     = vcfReader.getFileHeader.getSampleNamesInOrder.iterator().next()
 
-  def hasNext(): Boolean = {
-    if (sourceIterator.isEmpty && hapCutReader.hasNext()) throw new IllegalStateException("HapCut has more phased variants but no more variants in the input")
+  def hasNext: Boolean = {
+    if (sourceIterator.isEmpty && hapCutReader.hasNext) throw new IllegalStateException("HapCut has more phased variants but no more variants in the input")
     sourceIterator.hasNext
   }
 
   /** Returns either the phased variant with added HapCut-specific genotype information (Left), or the original variant (Right). */
   def next(): VariantContext = {
-    if (!hasNext()) throw new NoSuchElementException("Calling next() when hasNext() is false")
+    if (!hasNext) throw new NoSuchElementException("Calling next() when hasNext() is false")
     val (sourceContext, sourceOffset) = sourceIterator.next()
-    if (!hapCutReader.hasNext()) formatSourceContext(sourceContext)
+    if (!hapCutReader.hasNext) formatSourceContext(sourceContext)
     else {
       val HapCutOffsetAndCall(offset, callOption) = hapCutReader.next()
       if (offset != sourceOffset+1) throw new IllegalStateException("BUG: calls are out of order")
@@ -720,13 +720,13 @@ private[vcf] class HapCutReader(iterator: Iterator[String],
     def nonEmpty: Boolean = this.callBuffer.nonEmpty
   }
 
-  def hasNext(): Boolean = {
+  def hasNext: Boolean = {
     if (calls.nonEmpty) true
     else this.advance()
   }
 
   def next(): HapCutOffsetAndCall = {
-    if (!hasNext()) throw new NoSuchElementException("Calling next() when hasNext() is false")
+    if (!hasNext) throw new NoSuchElementException("Calling next() when hasNext() is false")
     calls.removeFirst()
   }
 

--- a/src/main/scala/com/fulcrumgenomics/vcf/JointVariantContextIterator.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/JointVariantContextIterator.scala
@@ -65,7 +65,7 @@ extends Iterator[Seq[Option[VariantContext]]] {
     case Right(comp) => comp
   }
 
-  def hasNext(): Boolean = iterators.exists(_.nonEmpty)
+  def hasNext: Boolean = iterators.exists(_.nonEmpty)
 
   def next(): Seq[Option[VariantContext]] = {
     val minCtx = iterators.filter(_.nonEmpty).map(_.head).sortWith {

--- a/src/main/scala/com/fulcrumgenomics/vcf/MakeMixtureVcf.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/MakeMixtureVcf.scala
@@ -40,7 +40,7 @@ import htsjdk.variant.variantcontext.writer.{Options, VariantContextWriter, Vari
 import htsjdk.variant.vcf._
 
 import scala.collection.mutable
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 
 object MakeMixtureVcf {

--- a/src/main/scala/com/fulcrumgenomics/vcf/MakeTwoSampleMixtureVcf.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/MakeTwoSampleMixtureVcf.scala
@@ -35,7 +35,7 @@ import htsjdk.samtools.util.IntervalList
 import htsjdk.variant.variantcontext._
 import htsjdk.variant.vcf.{VCFFilterHeaderLine, _}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable.ListBuffer
 
 object MakeTwoSampleMixtureVcf {

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/ArrayAttr.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/ArrayAttr.scala
@@ -32,7 +32,7 @@ import scala.reflect.ClassTag
 object ArrayAttr {
   /** Constructs an instance with the values supplied. */
   def apply[A : ClassTag](values: IterableOnce[A]): ArrayAttr[A] = {
-    new ArrayAttr[A](values.toArray)
+    new ArrayAttr[A](values.iterator.toArray)
   }
 
   /** Apply method that re-uses the supplied array.  Should only be used from within the `api` package

--- a/src/main/scala/com/fulcrumgenomics/vcf/api/VcfConversions.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/api/VcfConversions.scala
@@ -33,7 +33,7 @@ import htsjdk.variant.vcf._
 
 import java.util
 import java.util.{List => JavaList}
-import scala.collection.JavaConverters.mapAsJavaMapConverter
+import scala.jdk.CollectionConverters.MapHasAsJava
 import scala.collection.immutable.ListMap
 
 /**
@@ -46,7 +46,7 @@ private[api] object VcfConversions {
   private class ArrayIndexedSeq[T](private val array: Array[T]) extends scala.collection.immutable.IndexedSeq[T] {
     override final def apply(i: Int): T = this.array(i)
     override final def length: Int = this.array.length
-    override final def nonEmpty: Boolean = this.array.length > 0
+    override final def isEmpty: Boolean = this.array.length == 0
   }
 
   /** Converts a String into Option[String]. Returns `None` if the input string is either

--- a/src/test/scala/com/fulcrumgenomics/fasta/SequenceDictionaryTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/fasta/SequenceDictionaryTest.scala
@@ -74,7 +74,7 @@ class SequenceDictionaryTest extends UnitSpec with OptionValues {
 
     // get
     validSequence.get("key1").value shouldBe "value1"
-    validSequence.get("key3") shouldBe 'empty
+    validSequence.get("key3") shouldBe empty
 
     // contains
     validSequence.contains("key1") shouldBe true
@@ -96,10 +96,10 @@ class SequenceDictionaryTest extends UnitSpec with OptionValues {
     val locusFull   = new SequenceMetadata(name="chr1", length=123, index=0, attributes=Map("AH" -> "chr4:2-3"))
 
     noAltLocus.isAlternate shouldBe false
-    noAltLocus.alternate shouldBe 'empty
+    noAltLocus.alternate shouldBe empty
 
     altStar.isAlternate shouldBe false
-    altStar.alternate shouldBe 'empty
+    altStar.alternate shouldBe empty
 
     locusEquals.isAlternate shouldBe true
     locusEquals.alternate.value shouldBe AlternateLocus(refName="chr1", start=1, end=2)
@@ -111,23 +111,23 @@ class SequenceDictionaryTest extends UnitSpec with OptionValues {
   "SequenceMetadata.md5" should "return the md5 checksum if present" in {
     validSequence.md5.value shouldBe "123"
     validSequence.md5Int.value shouldBe BigInt("123", 16)
-    emptySequence.md5 shouldBe 'empty
-    emptySequence.md5Int shouldBe 'empty
+    emptySequence.md5 shouldBe empty
+    emptySequence.md5Int shouldBe empty
   }
 
   "SequenceMetadata.assembly" should "return the assembly if present" in {
     validSequence.assembly.value shouldBe "assembly"
-    emptySequence.assembly shouldBe 'empty
+    emptySequence.assembly shouldBe empty
   }
 
   "SequenceMetadata.species" should "return the species if present" in {
     validSequence.species.value shouldBe "species"
-    emptySequence.species shouldBe 'empty
+    emptySequence.species shouldBe empty
   }
 
   "SequenceMetadata.description" should "return the description if present" in {
     validSequence.description.value shouldBe "description"
-    emptySequence.description shouldBe 'empty
+    emptySequence.description shouldBe empty
   }
 
   "SequenceMetadata.topology" should "return the topology if present" in {
@@ -136,7 +136,7 @@ class SequenceDictionaryTest extends UnitSpec with OptionValues {
 
     linear.topology.value shouldBe Linear
     circular.topology.value shouldBe Circular
-    emptySequence.topology shouldBe 'empty
+    emptySequence.topology shouldBe empty
   }
 
   "SequenceMetadata.sameAs" should "return false if not reference names are shared" in {
@@ -206,7 +206,7 @@ class SequenceDictionaryTest extends UnitSpec with OptionValues {
 
     an[IndexOutOfBoundsException] should be thrownBy dict.apply(3)
     an[Exception] should be thrownBy dict("4")
-    dict.get("4") shouldBe 'empty
+    dict.get("4") shouldBe empty
     dict.contains("4") shouldBe false
   }
 

--- a/src/test/scala/com/fulcrumgenomics/fastq/FastqIoTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/fastq/FastqIoTest.scala
@@ -60,11 +60,11 @@ class FastqIoTest extends UnitSpec {
 
     Seq(FastqSource(fq), FastqSource(fq.toFile), FastqSource(Io.toInputStream(fq)), FastqSource(FastqIoTest.someFastq)).foreach(source => {
       source.hasNext shouldBe true
-      source.next shouldBe FastqIoTest.someFastqRecords(0)
+      source.next() shouldBe FastqIoTest.someFastqRecords(0)
       source.hasNext shouldBe true
-      source.next shouldBe FastqIoTest.someFastqRecords(1)
+      source.next() shouldBe FastqIoTest.someFastqRecords(1)
       source.hasNext shouldBe true
-      source.next shouldBe FastqIoTest.someFastqRecords(2)
+      source.next() shouldBe FastqIoTest.someFastqRecords(2)
       source.hasNext shouldBe false
       an[NoSuchElementException] shouldBe thrownBy { source.next() }
     })

--- a/src/test/scala/com/fulcrumgenomics/illumina/SampleSheetTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/illumina/SampleSheetTest.scala
@@ -27,12 +27,12 @@
 
 package com.fulcrumgenomics.illumina
 
+import com.fulcrumgenomics.testing.UnitSpec
 import com.fulcrumgenomics.util.Io
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
 
 import java.nio.file.Paths
 
-class SampleSheetTest extends FlatSpec with Matchers with OptionValues {
+class SampleSheetTest extends UnitSpec {
   private val testDir = Paths.get("src/test/resources/com/fulcrumgenomics/util/miseq/")
 
   "SampleSheet" should "load a simple sample sheet" in {

--- a/src/test/scala/com/fulcrumgenomics/rnaseq/CollectErccMetricsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/rnaseq/CollectErccMetricsTest.scala
@@ -256,7 +256,7 @@ class CollectErccMetricsTest extends UnitSpec with OptionValues {
     val dict = {
       // Read in the standard file
       val stream = getClass.getResourceAsStream(s"${CollectErccMetrics.StandardMixtureMetadataPath}")
-      val lines  = Source.fromInputStream(stream).withClose(() => stream.close()).getLines.filterNot(_.startsWith("#")).toSeq
+      val lines  = Source.fromInputStream(stream).withClose(() => stream.close()).getLines().filterNot(_.startsWith("#")).toSeq
       val names  = new DelimitedDataParser(lines, '\t').map { row => row[String](1)  }.toSeq
 
       // Create a dummy dictionary

--- a/src/test/scala/com/fulcrumgenomics/testing/ReferenceSetBuilderTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/testing/ReferenceSetBuilderTest.scala
@@ -69,7 +69,7 @@ class ReferenceSetBuilderTest extends UnitSpec with OptionValues {
     }
 
     plus("chr1").assembly.value shouldBe "hg19"
-    minus("chr1").assembly shouldBe 'empty
+    minus("chr1").assembly shouldBe empty
   }
 
   it should "write species name into the dictionary if given one" in {
@@ -83,14 +83,14 @@ class ReferenceSetBuilderTest extends UnitSpec with OptionValues {
     }
 
     plus("chr1").species.value shouldBe "human"
-    minus("chr1").species shouldBe 'empty
+    minus("chr1").species shouldBe empty
   }
 
   it should "calculate MD5s for sequences only if asked" in {
     val builder = new ReferenceSetBuilder()
     builder.add("chr1").add("A", 100)
     val Seq(plus, minus) = Seq(true, false).map(md5 => builder.toTempFile(calculateMds5=md5)).map(SequenceDictionary.extract)
-    plus("chr1").md5 shouldBe 'nonEmpty
-    minus("chr1").md5 shouldBe 'empty
+    plus("chr1").md5 shouldBe defined
+    minus("chr1").md5 shouldBe empty
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/umi/ConsensusCallerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/ConsensusCallerTest.scala
@@ -95,12 +95,12 @@ class ConsensusCallerTest extends UnitSpec {
     val caller = new ConsensusCaller(errorRatePreLabeling=50.toByte, errorRatePostLabeling=50.toByte)
     val builder = caller.builder()
     builder.add('A'.toByte, 20.toByte)
-    builder.call shouldBe ('A'.toByte, 20.toByte)
+    builder.call() shouldBe ('A'.toByte, 20.toByte)
     builder.contributions shouldBe 1
 
     builder.reset()
     builder.add('C'.toByte, 20.toByte)
-    builder.call shouldBe ('C'.toByte, 20.toByte)
+    builder.call() shouldBe ('C'.toByte, 20.toByte)
     builder.contributions shouldBe 1
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCallerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCallerTest.scala
@@ -209,7 +209,7 @@ class VanillaUmiConsensusCallerTest extends UnitSpec with OptionValues {
     )
 
     cc(opts).consensusCall(Seq(source)) match {
-      case None => fail
+      case None => fail()
       case Some(consensus) =>
         consensus.baseString shouldBe "GATTACA"
         consensus.quals shouldBe inputQuals.map(_.toByte)
@@ -229,7 +229,7 @@ class VanillaUmiConsensusCallerTest extends UnitSpec with OptionValues {
     val outputQual  = PhredScore.fromLogProbability(LogProbability.probabilityOfErrorTwoTrials(lnProbError, lnProbError))
     val outputQuals = inputQuals.map(q => outputQual)
     caller.consensusCall(Seq(src("GATTACA", inputQuals))) match {
-      case None => fail
+      case None => fail()
       case Some(consensus) =>
         consensus.baseString shouldBe "GATTACA"
         consensus.quals      shouldBe outputQuals
@@ -250,7 +250,7 @@ class VanillaUmiConsensusCallerTest extends UnitSpec with OptionValues {
     val outputQuals = inputQuals.map(q => outputQual)
 
     caller.consensusCall(Seq(src("GATTACA", inputQuals))) match {
-      case None => fail
+      case None => fail()
       case Some(consensus) =>
         consensus.baseString shouldBe "GATTACA"
         consensus.quals      shouldBe outputQuals
@@ -270,7 +270,7 @@ class VanillaUmiConsensusCallerTest extends UnitSpec with OptionValues {
     )
 
     cc(opts).consensusFromSamRecords(builder.toSeq) match {
-      case None => fail
+      case None => fail()
       case Some(consensus) =>
         consensus.baseString shouldBe "GATTACA"
         consensus.quals.foreach(q => q shouldBe 30.toByte)
@@ -420,7 +420,7 @@ class VanillaUmiConsensusCallerTest extends UnitSpec with OptionValues {
     (1 to 10).foreach { i => buffer += src(cigar="50M") }
     (1 to  3).foreach { i => buffer += src(cigar="25M2I23M") }
 
-    val recs = cc().filterToMostCommonAlignment(buffer.result)
+    val recs = cc().filterToMostCommonAlignment(buffer.result())
     recs should have size 10
     recs.map(_.cigar.toString()).distinct shouldBe Seq("50M")
   }
@@ -438,9 +438,9 @@ class VanillaUmiConsensusCallerTest extends UnitSpec with OptionValues {
     (1 to  2).foreach { i => buffer += src(cigar="25M1I24M") }
     (1 to  2).foreach { i => buffer += src(cigar="20M1D5M1D25M") }
 
-    val recs = cc().filterToMostCommonAlignment(buffer.result)
+    val recs = cc().filterToMostCommonAlignment(buffer.result())
     recs should have size 11
-    recs.map(_.cigar.toString).distinct.sorted shouldBe Seq("25M1D25M", "5S20M1D25M", "5S20M1D20M5H", "25M1D20M5S").sorted
+    recs.map(_.cigar.toString()).distinct.sorted shouldBe Seq("25M1D25M", "5S20M1D25M", "5S20M1D20M5H", "25M1D20M5S").sorted
   }
 
   it should "return all the reads that are compatible with a 2 base deletion at base 25" in {

--- a/src/test/scala/com/fulcrumgenomics/vcf/JointVariantContextIteratorTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/vcf/JointVariantContextIteratorTest.scala
@@ -50,7 +50,7 @@ class JointVariantContextIteratorTest extends UnitSpec {
     val builder = new VariantContextSetBuilder()
     val iterator = JointVariantContextIterator(iters=Seq(builder.iterator, builder.iterator), dict=dict)
     iterator.hasNext shouldBe false
-    an[NoSuchElementException] should be thrownBy iterator.next
+    an[NoSuchElementException] should be thrownBy iterator.next()
   }
 
   it should "return a pair of variant contexts at the same position" in {


### PR DESCRIPTION
Mostly just adding and removing `()` in a bunch of places, plus a handful of other things.