### PR TITLE
Require template sort orders in ClipBam and FilterConsensusReads

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/bam/Bams.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/Bams.scala
@@ -26,16 +26,19 @@ package com.fulcrumgenomics.bam
 
 import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.bam.api.SamOrder.Queryname
-import com.fulcrumgenomics.bam.api.{SamOrder, SamRecord, SamRecordCodec, SamSource}
+import com.fulcrumgenomics.bam.api._
 import com.fulcrumgenomics.commons.collection.{BetterBufferedIterator, SelfClosingIterator}
+import com.fulcrumgenomics.commons.io.Writer
 import com.fulcrumgenomics.commons.util.LazyLogging
+import com.fulcrumgenomics.fasta.ReferenceSequenceIterator
 import com.fulcrumgenomics.util.{Io, ProgressLogger, Sorter}
 import htsjdk.samtools.SAMFileHeader.{GroupOrder, SortOrder}
 import htsjdk.samtools.SamPairUtil.PairOrientation
 import htsjdk.samtools._
-import htsjdk.samtools.reference.{ReferenceSequence, ReferenceSequenceFileWalker}
+import htsjdk.samtools.reference.ReferenceSequence
 import htsjdk.samtools.util.{CloserUtil, CoordMath, SequenceUtil}
 
+import java.io.Closeable
 import scala.math.{max, min}
 
 /**
@@ -467,7 +470,6 @@ object Bams extends LazyLogging {
     (min(firstEnd,secondEnd), max(firstEnd,secondEnd))
   }
 
-
   /** If the read is mapped in an FR pair, returns the distance of the position from the other end
     * of the template, other wise returns None.
     *
@@ -488,6 +490,37 @@ object Bams extends LazyLogging {
     }
     else {
       None
+    }
+  }
+
+  /** Requires that the header is queryname sorted or query grouped. */
+  def requireTemplateGrouped(header: SAMFileHeader, toolName: String): Unit = {
+    require(header.getSortOrder == SortOrder.queryname || header.getGroupOrder == GroupOrder.query,
+      "Input was not queryname sorted or query grouped, found: " +
+        s"SO:${header.getSortOrder} GO:${header.getGroupOrder}" +
+        Option(header.getAttribute("SS")).map(ss => f" SS:$ss").getOrElse("") +
+        f". Use `samtools sort -n -u in.bam | fgbio $toolName -i /dev/stdin`"
+    )
+  }
+
+  /** Builds a [[Writer]] of [[SamRecord]]s that regenerates the NM, UQ, and MD tags using the given map of reference
+    * sequences.
+    *
+    * @param writer the writer to write to
+    * @param ref the path to the reference FASTA
+    */
+  def regenerateNmUqMdTagsWriter(writer: SamWriter, ref: PathToFasta): Writer[SamRecord] with Closeable = {
+    logger.info("Reading the reference fasta into memory")
+    val refMap = ReferenceSequenceIterator(ref, stripComments=true).map { ref => ref.getContigIndex -> ref}.toMap
+    logger.info(f"Read ${refMap.size}%,d contigs.")
+
+    // Create the final writer based on if the full reference has been loaded, or not
+    new Writer[SamRecord] with Closeable {
+      override def write(rec: SamRecord): Unit = {
+        Bams.regenerateNmUqMdTags(rec, refMap(rec.refIndex))
+        writer += rec
+      }
+      def close(): Unit = writer.close()
     }
   }
 }

--- a/src/main/scala/com/fulcrumgenomics/bam/ClipBam.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ClipBam.scala
@@ -31,9 +31,8 @@ import com.fulcrumgenomics.commons.util.LazyLogging
 import com.fulcrumgenomics.sopt.{arg, clp}
 import com.fulcrumgenomics.util.{Io, Metric, ProgressLogger}
 import enumeratum.EnumEntry
-import htsjdk.samtools.SAMFileHeader.SortOrder
+import htsjdk.samtools.SAMFileHeader.{GroupOrder, SortOrder}
 import htsjdk.samtools.SamPairUtil
-import htsjdk.samtools.reference.ReferenceSequenceFileWalker
 
 import scala.collection.immutable.IndexedSeq
 
@@ -51,11 +50,17 @@ import scala.collection.immutable.IndexedSeq
     |Secondary alignments and supplemental alignments are not clipped, but are passed through into the
     |output.
     |
-    |If the input BAM is neither `queryname` sorted nor `query` grouped, it will be sorted into queryname
-    |order so that clipping can be performed on both ends of a pair simultaneously and so that mate
-    |pair information can be reset across all reads for the template.  Post-clipping the reads are
-    |resorted into coordinate order, any existing `NM`, `UQ` and `MD` tags are repaired, and the output is
-    |written in coordinate order.
+    |In order to correctly clip reads in or out by template, the input BAM must be either `queryname`  or `query`
+    |grouped.  The sort can be done in streaming fashion with:
+    |
+    |```
+    |samtools sort -n -u in.bam | fgbio ClipBam -i /dev/stdin ...
+    |```
+    |
+    |The output sort order may be specified with `--sort-order`.  If not given, then the output will be in the same
+    |order as input.
+    |
+    |Any existing `NM`, `UQ` and `MD` tags are repaired.
     |
     |Three clipping modes are supported:
     |1. `Soft` - soft-clip the bases and qualities.
@@ -79,7 +84,9 @@ class ClipBam
   @arg(          doc="Require at least this number of bases to be clipped on the 5' end of R2") val readTwoFivePrime: Int  = 0,
   @arg(          doc="Require at least this number of bases to be clipped on the 3' end of R2") val readTwoThreePrime: Int = 0,
   @arg(          doc="Clip overlapping reads.") val clipOverlappingReads: Boolean = false,
-  @arg(          doc="Clip reads in FR pairs that sequence past the far end of their mate.") val clipBasesPastMate: Boolean = false
+  @arg(          doc="Clip reads in FR pairs that sequence past the far end of their mate.") val clipBasesPastMate: Boolean = false,
+  @arg(flag='S', doc="The sort order of the output. If not given, output will be in the same order as input if the input.")
+  val sortOrder: Option[SamOrder] = None
 ) extends FgBioTool with LazyLogging {
   Io.assertReadable(input)
   Io.assertReadable(ref)
@@ -96,8 +103,12 @@ class ClipBam
 
   override def execute(): Unit = {
     val in         = SamSource(input)
+    val header     = in.header
     val progress   = ProgressLogger(logger)
-    val sorter     = Bams.sorter(SamOrder.Coordinate, in.header)
+    val out        = Bams.regenerateNmUqMdTagsWriter(writer=SamWriter(output, header.clone(), sort=sortOrder), ref=ref)
+
+    // Require queryname sorted or query grouped
+    Bams.requireTemplateGrouped(header=in.header, toolName="ClipBam")
 
     val metricsMap: Map[ReadType, ClippingMetrics] = this.metrics.map { _ =>
       ReadType.values.map { readType => readType -> ClippingMetrics(read_type=readType) }.toMap
@@ -119,24 +130,12 @@ class ClipBam
       }
 
       template.allReads.foreach { r =>
-        sorter += r
+        out += r
         progress.record(r)
       }
     }
-
-    // Then go through the coordinate sorted reads and fix up tags
-    logger.info("Re-sorting into coordinate order and writing output.")
-    val header = in.header.clone()
-    SamOrder.Coordinate.applyTo(header)
-    header.setSortOrder(SortOrder.coordinate)
-    val walker = new ReferenceSequenceFileWalker(ref.toFile)
-    val out    = SamWriter(output, header, ref=Some(ref))
-
-    sorter.foreach { rec =>
-      Bams.regenerateNmUqMdTags(rec, walker.get(rec.refIndex))
-      out += rec
-    }
-
+    progress.logLast()
+    out.close()
 
     this.metrics.foreach { path =>
       // Update the metrics for "All" and "Pair" read types
@@ -150,7 +149,6 @@ class ClipBam
       Metric.write(path, ReadType.values.map { readType => metricsMap(readType)})
     }
 
-    out.close()
   }
 
   /** Clips a fixed amount from the reads and then clips overlapping reads.

--- a/src/main/scala/com/fulcrumgenomics/bam/ClipBam.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ClipBam.scala
@@ -50,8 +50,8 @@ import scala.collection.immutable.IndexedSeq
     |Secondary alignments and supplemental alignments are not clipped, but are passed through into the
     |output.
     |
-    |In order to correctly clip reads in or out by template, the input BAM must be either `queryname`  or `query`
-    |grouped.  The sort can be done in streaming fashion with:
+    |In order to correctly clip reads by template, the input BAM must be either `queryname`  or `query` grouped.  The
+    |sort can be done in streaming fashion with:
     |
     |```
     |samtools sort -n -u in.bam | fgbio ClipBam -i /dev/stdin ...

--- a/src/main/scala/com/fulcrumgenomics/bam/ClipBam.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ClipBam.scala
@@ -50,8 +50,9 @@ import scala.collection.immutable.IndexedSeq
     |Secondary alignments and supplemental alignments are not clipped, but are passed through into the
     |output.
     |
-    |In order to correctly clip reads by template, the input BAM must be either `queryname`  or `query` grouped.  The
-    |sort can be done in streaming fashion with:
+    |In order to correctly clip reads by template and update mate information, the input BAM must be either
+    |`queryname` sorted or `query` grouped.  If your input BAM is not in an appropriate order the sort can be
+    |done in streaming fashion with, for example:
     |
     |```
     |samtools sort -n -u in.bam | fgbio ClipBam -i /dev/stdin ...
@@ -60,7 +61,7 @@ import scala.collection.immutable.IndexedSeq
     |The output sort order may be specified with `--sort-order`.  If not given, then the output will be in the same
     |order as input.
     |
-    |Any existing `NM`, `UQ` and `MD` tags are repaired.
+    |Any existing `NM`, `UQ` and `MD` tags are repaired, and mate-pair information updated.
     |
     |Three clipping modes are supported:
     |1. `Soft` - soft-clip the bases and qualities.

--- a/src/main/scala/com/fulcrumgenomics/umi/FilterConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/FilterConsensusReads.scala
@@ -88,7 +88,7 @@ private[umi] case class ConsensusReadFilter(minReads: Int, maxReadErrorRate: Dou
       |single-strand consensus, and the last value to the other single-strand consensus. It is required that if
       |values two and three differ, the _more stringent value comes earlier_.
       |
-      |In order to correctly filter reads in or out by template, if the input BAM must be either `queryname` sorted or
+      |In order to correctly filter reads in or out by template, the input BAM must be either `queryname` sorted or
       |`query` grouped.  The sort can be done in streaming fashion with:
       |
       |```

--- a/src/main/scala/com/fulcrumgenomics/umi/FilterConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/FilterConsensusReads.scala
@@ -30,13 +30,11 @@ import com.fulcrumgenomics.bam.api.{SamOrder, SamRecord, SamSource, SamWriter}
 import com.fulcrumgenomics.cmdline.{ClpGroups, FgBioTool}
 import com.fulcrumgenomics.commons.io.Writer
 import com.fulcrumgenomics.commons.util.LazyLogging
-import com.fulcrumgenomics.fasta.ReferenceSequenceIterator
 import com.fulcrumgenomics.sopt.{arg, clp}
-import com.fulcrumgenomics.util.NumericTypes.PhredScore
 import com.fulcrumgenomics.util.Io
+import com.fulcrumgenomics.util.NumericTypes.PhredScore
 import htsjdk.samtools.SAMFileHeader
 import htsjdk.samtools.SAMFileHeader.{GroupOrder, SortOrder}
-import htsjdk.samtools.reference.ReferenceSequence
 import htsjdk.samtools.util.SequenceUtil
 
 import java.io.Closeable
@@ -90,11 +88,15 @@ private[umi] case class ConsensusReadFilter(minReads: Int, maxReadErrorRate: Dou
       |single-strand consensus, and the last value to the other single-strand consensus. It is required that if
       |values two and three differ, the _more stringent value comes earlier_.
       |
-      |In order to correctly filter reads in or out by template, if the input BAM is not `queryname` sorted or
-      |query grouped it will be sorted into queryname order prior to filtering.
+      |In order to correctly filter reads in or out by template, if the input BAM must be either `queryname` sorted or
+      |`query` grouped.  The sort can be done in streaming fashion with:
+      |
+      |```
+      |samtools sort -n -u in.bam | fgbio FilterConsensusReads -i /dev/stdin ...
+      |```
       |
       |The output sort order may be specified with `--sort-order`.  If not given, then the output will be in the same
-      |order as input if the input is queryname sorted or query grouped, otherwise queryname order.
+      |order as input.
       |
       |The `--reverse-tags-per-base` option controls whether per-base tags should be reversed before being used on reads
       |marked as being mapped to the negative strand.  This is necessary if the reads have been mapped and the
@@ -177,12 +179,11 @@ class FilterConsensusReads
   private val EmptyFilterResult = FilterResult(keepRead=true, maskedBases=0)
 
   override def execute(): Unit = {
-    logger.info("Reading the reference fasta into memory")
-    val refMap = ReferenceSequenceIterator(ref, stripComments=true).map { ref => ref.getContigIndex -> ref}.toMap
-    logger.info(f"Read ${refMap.size}%,d contigs.")
-
     val in  = SamSource(input)
-    val out = buildOutputWriter(in.header, refMap)
+    val out = Bams.regenerateNmUqMdTagsWriter(writer=SamWriter(output, in.header.clone(), sort=sortOrder), ref=ref)
+
+    // Require queryname sorted or query grouped
+    Bams.requireTemplateGrouped(header=in.header, toolName="FilterConsensusReads")
 
     // Go through the reads by template and do the filtering
     val templateIterator = Bams.templateIterator(in, maxInMemory=MaxRecordsInMemoryWhenSorting)
@@ -226,65 +227,6 @@ class FilterConsensusReads
     out.close()
     logger.info(f"Output $keptReads%,d of $totalReads%,d primary consensus reads.")
     logger.info(f"Masked $maskedBases%,d of $totalBases%,d bases in retained primary consensus reads.")
-  }
-
-  /** Builds the writer to which filtered records should be written.
-    *
-    *  If the input order is [[SamOrder.Queryname]] or query grouped, then the filtered records will also be in the same
-    *  order.  So if the output order is specified AND does not match the the input order, sorting will occur.
-    *
-    *  If the input order is not [[SamOrder.Queryname]] or query grouped, then the input records will be resorted into
-    *  [[SamOrder.Queryname]].  So if the output order is specified AND is not [[SamOrder.Queryname]], sorting will occur.
-    *
-    *  Otherwise, we can skip sorting!
-    *
-    * */
-  private def buildOutputWriter(inHeader: SAMFileHeader, refMap: Map[Int, ReferenceSequence]): Writer[SamRecord] with Closeable = {
-    val outHeader    = inHeader.clone()
-
-    val inSortOrder  = inHeader.getSortOrder
-    val inGroupOrder = inHeader.getGroupOrder
-    val inSubSort    = Option(inHeader.getAttribute("SS"))
-
-    // Get the sort order, if any, to force the writer to resort.
-    val writerSortOrder = {
-      val canSkipSortingInput = inSortOrder == SortOrder.queryname || inGroupOrder == GroupOrder.query
-      (this.sortOrder, canSkipSortingInput) match {
-        case (None,        false) =>
-          // already sorted to Queryname after filtering, so the output will be Queryname, and so no need to re-sort the output
-          SamOrder.Queryname.applyTo(outHeader)
-          None
-        case (Some(order), false) =>
-          // already sorted to Queryname after filtering, so don't sort the output if the given output sort order matches Queryname
-          order.applyTo(outHeader)
-          if (order != SamOrder.Queryname) Some(order) else None
-        case (None,         true) =>
-          // input did not need to be re-sorted, so do not re-sort the output
-          None
-        case (Some(order), true)  =>
-          // If sorting prior to filtering was not required, then the input was queryname or query grouped.  So sort the
-          // output only if the specified output `sortOrder` does not match the input sort order.
-          if (order.sortOrder == inSortOrder && order.groupOrder == inGroupOrder && order.subSort == inSubSort) {
-            None // input matches the output order, no need to force sorting, keep the header
-          }
-          else { // mismatch in the input order and output order, force sorting the output
-            order.applyTo(outHeader)
-            Some(order)
-          }
-      }
-    }
-
-    val writer = SamWriter(output, outHeader, sort=writerSortOrder, maxRecordsInRam=MaxRecordsInMemoryWhenSorting)
-    writerSortOrder.foreach(o => logger.info(f"Output will be sorted into $o order"))
-
-    // Create the final writer based on if the full reference has been loaded, or not
-    new Writer[SamRecord] with Closeable {
-      override def write(rec: SamRecord): Unit = {
-        Bams.regenerateNmUqMdTags(rec, refMap(rec.refIndex))
-        writer += rec
-      }
-      def close(): Unit = writer.close()
-    }
   }
 
   /**

--- a/src/main/scala/com/fulcrumgenomics/umi/FilterConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/FilterConsensusReads.scala
@@ -180,10 +180,10 @@ class FilterConsensusReads
 
   override def execute(): Unit = {
     val in  = SamSource(input)
-    val out = Bams.regenerateNmUqMdTagsWriter(writer=SamWriter(output, in.header.clone(), sort=sortOrder), ref=ref)
+    val out = Bams.nmUqMdTagRegeneratingWriter(writer=SamWriter(output, in.header.clone(), sort=sortOrder), ref=ref)
 
     // Require queryname sorted or query grouped
-    Bams.requireTemplateGrouped(header=in.header, toolName="FilterConsensusReads")
+    Bams.requireQueryGrouped(header=in.header, toolName="FilterConsensusReads")
 
     // Go through the reads by template and do the filtering
     val templateIterator = Bams.templateIterator(in, maxInMemory=MaxRecordsInMemoryWhenSorting)

--- a/src/main/scala/com/fulcrumgenomics/umi/FilterConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/FilterConsensusReads.scala
@@ -89,7 +89,7 @@ private[umi] case class ConsensusReadFilter(minReads: Int, maxReadErrorRate: Dou
       |values two and three differ, the _more stringent value comes earlier_.
       |
       |In order to correctly filter reads in or out by template, the input BAM must be either `queryname` sorted or
-      |`query` grouped.  The sort can be done in streaming fashion with:
+      |`query` grouped.  If your BAM is not already in an appropriate order, this can be done in streaming fashion with:
       |
       |```
       |samtools sort -n -u in.bam | fgbio FilterConsensusReads -i /dev/stdin ...

--- a/src/test/scala/com/fulcrumgenomics/bam/BamsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/BamsTest.scala
@@ -25,7 +25,6 @@
 package com.fulcrumgenomics.bam
 
 import java.util
-
 import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.alignment.Cigar
 import com.fulcrumgenomics.bam.api.{SamOrder, SamRecord}
@@ -33,7 +32,7 @@ import com.fulcrumgenomics.testing.SamBuilder.{Minus, Plus}
 import com.fulcrumgenomics.testing.{SamBuilder, UnitSpec}
 import com.fulcrumgenomics.util.{Io, Sequences}
 import htsjdk.samtools.SAMFileHeader.GroupOrder
-import htsjdk.samtools.SamPairUtil
+import htsjdk.samtools.{SAMFileHeader, SamPairUtil}
 import htsjdk.samtools.SamPairUtil.PairOrientation
 import htsjdk.samtools.reference.{ReferenceSequence, ReferenceSequenceFile, ReferenceSequenceFileWalker}
 
@@ -329,6 +328,17 @@ class BamsTest extends UnitSpec {
 
     Bams.sortByTransformedTag[Int,Float](iterator=builder.iterator, header=builder.header, tag="ZZ", transform=f)
       .map(r => r[Int]("ZZ")).toSeq should contain theSameElementsInOrderAs Seq(4, 3, 2, 2, 1)
+  }
+
+  "Bams.requireTemplateGrouped" should "require the header to be queryname sorted or query grouped" in {
+    def header(order: SamOrder): SAMFileHeader = {
+      val h = new SAMFileHeader()
+      order.applyTo(h)
+      h
+    }
+    Bams.requireTemplateGrouped(header=header(SamOrder.Queryname), "test")
+    Bams.requireTemplateGrouped(header=header(SamOrder.RandomQuery), "test") // this is group ordered
+    an[Exception] should be thrownBy Bams.requireTemplateGrouped(header=header(SamOrder.Coordinate), "test")
   }
 
   "Template.primaryReads" should "return an iterator over just the primary reads" in {

--- a/src/test/scala/com/fulcrumgenomics/bam/BamsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/BamsTest.scala
@@ -336,9 +336,9 @@ class BamsTest extends UnitSpec {
       order.applyTo(h)
       h
     }
-    Bams.requireTemplateGrouped(header=header(SamOrder.Queryname), "test")
-    Bams.requireTemplateGrouped(header=header(SamOrder.RandomQuery), "test") // this is group ordered
-    an[Exception] should be thrownBy Bams.requireTemplateGrouped(header=header(SamOrder.Coordinate), "test")
+    Bams.requireQueryGrouped(header=header(SamOrder.Queryname), "test")
+    Bams.requireQueryGrouped(header=header(SamOrder.RandomQuery), "test") // this is group ordered
+    an[Exception] should be thrownBy Bams.requireQueryGrouped(header=header(SamOrder.Coordinate), "test")
   }
 
   "Template.primaryReads" should "return an iterator over just the primary reads" in {

--- a/src/test/scala/com/fulcrumgenomics/bam/ClipBamTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/ClipBamTest.scala
@@ -26,6 +26,7 @@ package com.fulcrumgenomics.bam
 
 import com.fulcrumgenomics.FgBioDef.unreachable
 import com.fulcrumgenomics.bam.ClippingMode.{Hard, Soft, SoftWithMask}
+import com.fulcrumgenomics.bam.api.SamOrder.Queryname
 import com.fulcrumgenomics.bam.api.{SamRecord, SamSource}
 import com.fulcrumgenomics.testing.SamBuilder._
 import com.fulcrumgenomics.testing.{ErrorLogLevel, ReferenceSetBuilder, SamBuilder, UnitSpec}
@@ -257,7 +258,7 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
 
   "ClipBam" should "clip overlapping reads, update mate info, and reset NM, UQ & MD" in {
     val random = new Random(1)
-    val builder = new SamBuilder(readLength=50)
+    val builder = new SamBuilder(readLength=50, sort=Some(Queryname))
     builder.addPair(name="q1", start1=100, start2=140) // overlaps by ten
     builder.addPair(name="q2", start1=200, start2=242) // overlaps by eight
     builder.addPair(name="q3", start1=300, start2=344) // overlaps by six
@@ -362,7 +363,7 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
 
   it should "clip fragment reads, and reset NM, UQ & MD" in {
     val random = new Random(1)
-    val builder = new SamBuilder(readLength=50)
+    val builder = new SamBuilder(readLength=50, sort=Some(Queryname))
     builder.addFrag(start=100)
     builder.addFrag(start=200, strand=Minus)
     builder.addFrag(start=300, cigar="40S10M") // should be fully clipped
@@ -437,7 +438,7 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
 
   Seq((Soft, SoftWithMask), (Soft, Hard), (SoftWithMask, Hard)).foreach { case (prior, mode) =>
     it should s"upgrade existing clipping from $prior to $mode with --upgrade-clipping" in {
-      val builder = new SamBuilder(readLength=50)
+      val builder = new SamBuilder(readLength=50, sort=Some(Queryname))
       val frag1 = builder.addFrag(name="q1", start=100).value
       val frag2 = builder.addFrag(name="q2", start=200, strand=Minus).value
 
@@ -482,7 +483,7 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
 
   Seq((Soft, Soft), (SoftWithMask, Soft), (SoftWithMask, SoftWithMask), (Hard, Hard), (Hard, SoftWithMask), (Hard, Soft)).foreach { case (prior, mode) =>
     it should s"not upgrade existing clipping from $prior to $mode with --upgrade-clipping" in {
-      val builder = new SamBuilder(readLength=50)
+      val builder = new SamBuilder(readLength=50, sort=Some(Queryname))
       val frag1 = builder.addFrag(name="q1", start=100).value
       val frag2 = builder.addFrag(name="q2", start=200, strand=Minus).value
 
@@ -527,7 +528,7 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
   }
 
   it should "clip FR reads that extend past the mate" in {
-    val builder = new SamBuilder(readLength=50)
+    val builder = new SamBuilder(readLength=50, sort=Some(Queryname))
     val clipper = new ClipBam(input=dummyBam, output=dummyBam, ref=ref, clipBasesPastMate=true)
     val Seq(r1, r2) = builder.addPair(start1=100, start2=90)
 

--- a/src/test/scala/com/fulcrumgenomics/umi/FilterConsensusReadsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/FilterConsensusReadsTest.scala
@@ -330,7 +330,7 @@ class FilterConsensusReadsTest extends UnitSpec {
     result.out should contain theSameElementsInOrderAs Seq("q2", "q2", "q1", "q1") // query grouped, but not query name
   }
 
-    it should "should output coordinate sorted if the output order is coordinate" in {
+  it should "should output coordinate sorted if the output order is coordinate" in {
     val result = sortOrderTest(
       name1="q1", start1R1=100, start1R2=200,
       name2="q2", start2R1=101, start2R2=201,

--- a/src/test/scala/com/fulcrumgenomics/umi/FilterConsensusReadsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/FilterConsensusReadsTest.scala
@@ -25,8 +25,8 @@
 package com.fulcrumgenomics.umi
 
 import java.nio.file.Files
-
 import com.fulcrumgenomics.FgBioDef._
+import com.fulcrumgenomics.bam.api.SamOrder.Queryname
 import com.fulcrumgenomics.bam.api.{SamOrder, SamRecord, SamSource, SamWriter}
 import com.fulcrumgenomics.testing.{ReferenceSetBuilder, SamBuilder, UnitSpec}
 import com.fulcrumgenomics.util.NumericTypes.PhredScore
@@ -330,17 +330,7 @@ class FilterConsensusReadsTest extends UnitSpec {
     result.out should contain theSameElementsInOrderAs Seq("q2", "q2", "q1", "q1") // query grouped, but not query name
   }
 
-  it should "should output queryname sorted if the input is neither queryname nor query grouped sorted" in {
-    val result = sortOrderTest(
-      name1="q2", start1R1=100, start1R2=200,
-      name2="q1", start2R1=101, start2R2=201,
-      inOrder=SamOrder.Unsorted
-    )
-    result.in should contain theSameElementsInOrderAs Seq("q2", "q2", "q1", "q1") // query grouped, but not query name
-    result.out should contain theSameElementsInOrderAs Seq("q1", "q1", "q2", "q2") // query name
-  }
-
-  it should "should output coordinate sorted if the output order is coordinate" in {
+    it should "should output coordinate sorted if the output order is coordinate" in {
     val result = sortOrderTest(
       name1="q1", start1R1=100, start1R2=200,
       name2="q2", start2R1=101, start2R2=201,
@@ -366,7 +356,7 @@ class FilterConsensusReadsTest extends UnitSpec {
   }
 
   /** An extension to SamBuilder to make building duplex pairs marginally less painful. */
-  object DuplexBuilder extends SamBuilder(readLength=10, baseQuality=90) {
+  object DuplexBuilder extends SamBuilder(readLength=10, baseQuality=90, sort=Some(Queryname)) {
     /** Method to create/add a single read with all the duplex tags on it. */
     def add(name:String=nextName,
             dp: Int=10, minDp:Int=10, abDp:Int=5, baDp:Int=5, abMinDp:Int=5, baMinDp:Int=5,


### PR DESCRIPTION
  This requires that the input BAM files are queryname sorted or query
    grouped in both tools.  Supporting the sorting of the input is now
    removed.  Use `samtools sort -n -u in.bam | fgbio <tool> -i /dev/stdin`
    instead.  The header of the input BAM must properly specify one of these
    two sort orders.
    
    Adds a method to Bams assert the header is queryname sorted or query
    grouped.