### PR TITLE
Make SamWriter stop checking sort order when emitting pre-sorted records.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -129,7 +129,7 @@ lazy val root = Project(id="fgbio", base=file("."))
       "org.scala-lang.modules"    %% "scala-collection-compat" % "2.1.1",
       "com.fulcrumgenomics"       %% "commons"        % "1.4.0",
       "com.fulcrumgenomics"       %% "sopt"           % "1.1.0",
-      "com.github.samtools"       %  "htsjdk"         % "2.24.1" excludeAll(htsjdkExcludes: _*),
+      "com.github.samtools"       %  "htsjdk"         % "2.24.1-26-ga38c78d-SNAPSHOT" excludeAll(htsjdkExcludes: _*),
       "org.apache.commons"        %  "commons-math3"  % "3.6.1",
       "com.beachape"              %% "enumeratum"     % "1.7.0",
       "com.intel.gkl"             %  "gkl"            % "0.8.8",

--- a/src/main/scala/com/fulcrumgenomics/bam/api/SamWriter.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/api/SamWriter.scala
@@ -98,8 +98,10 @@ object SamWriter extends LazyLogging {
     factory.setCreateMd5File(md5)
     tmp.foreach(dir => factory.setTempDirectory(dir.toFile))
 
-    new SamWriter(writer=factory.makeWriter(header, true, path.toFile, ref.map(_.toFile).orNull),
-      sorter=sorter, sortProgress=sortProgress, writeProgress=writeProgress)
+    val htsJdkWriter = factory.makeWriter(header, true, path.toFile, ref.map(_.toFile).orNull)
+    htsJdkWriter.setSortOrderChecking(false)
+
+    new SamWriter(writer=htsJdkWriter, sorter=sorter, sortProgress=sortProgress, writeProgress=writeProgress)
   }
 }
 


### PR DESCRIPTION
Build will probably fail for a while until the HTSJDK snapshot is published.