### PR TITLE
[bugfix] overlapping consensus caller should examine only

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/bam/OverlappingBasesConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/OverlappingBasesConsensusCaller.scala
@@ -72,57 +72,34 @@ class OverlappingBasesConsensusCaller(agreementStrategy: AgreementStrategy = Agr
     require(r1.mapped && r2.mapped && r1.paired && r2.paired && r1.name == r2.name && r1.matesOverlap.contains(true))
     require(r1.firstOfPair && r2.secondOfPair)
 
-    // Initialize the iters
-    val maxStartRefPos   = Math.max(r1.start, r2.start)
-    val minEndRefPos     = Math.min(r1.end, r2.end)
-    val r1Iter           = new ReadAndRefPosIterator(r1, minRefPos=maxStartRefPos, maxRefPos=minEndRefPos).buffered
-    val r2Iter           = new ReadAndRefPosIterator(r2, minRefPos=maxStartRefPos, maxRefPos=minEndRefPos).buffered
-    var r1LastReadPos    = r1Iter.head.readPos - 1
-    var r2LastReadPos    = r2Iter.head.readPos - 1
+    val iter             = new ReadMateAndRefPosIterator(rec=r1, mate=r2).buffered
     var overlappingBases = 0
     var r1Corrected      = 0
     var r2Corrected      = 0
 
     // Walk through the iterators by reference position
-    while (r1Iter.hasNext && r2Iter.hasNext) {
-      val r1Head = r1Iter.head
-      val r2Head = r2Iter.head
-      if (r1Head.refPos < r2Head.refPos) {
-        r1LastReadPos = r1Head.readPos
-        r1Iter.next()
-      }
-      else if (r2Head.refPos < r1Head.refPos) {
-        r2LastReadPos = r2Head.readPos
-        r2Iter.next()
-      }
-      else { // both reads are mapped to the same reference bases, so consensus call
+    iter.foreach { item =>
+
+      val base1 = r1.bases(item.readPos - 1)
+      val base2 = r2.bases(item.matePos - 1)
+      if (!SequenceUtil.isNoCall(base1) && !SequenceUtil.isNoCall(base2)) {
+        // consensus call
+        val (newBase1, newQual1, newBase2, newQual2) = consensusCall(
+          base1 = base1,
+          qual1 = r1.quals(item.readPos - 1),
+          base2 = base2,
+          qual2 = r2.quals(item.matePos - 1)
+        )
+
+        if (newBase1 != NoCall && newBase1 != base1) r1Corrected += 1
+        if (newBase2 != NoCall && newBase2 != base2) r2Corrected += 1
+
+        r1.bases(item.readPos - 1) = newBase1
+        r1.quals(item.readPos - 1) = newQual1
+        r2.bases(item.matePos - 1) = newBase2
+        r2.quals(item.matePos - 1) = newQual2
+
         overlappingBases += 1 // only one for the template
-
-        val base1 = r1.bases(r1Head.readPos - 1)
-        val base2 = r2.bases(r2Head.readPos - 1)
-        if (!SequenceUtil.isNoCall(base1) && !SequenceUtil.isNoCall(base2)) {
-          // consensus call
-          val (newBase1, newQual1, newBase2, newQual2) = consensusCall(
-            base1 = base1,
-            qual1 = r1.quals(r1Head.readPos - 1),
-            base2 = base2,
-            qual2 = r2.quals(r2Head.readPos - 1)
-          )
-
-          if (newBase1 != NoCall && newBase1 != base1) r1Corrected += 1
-          if (newBase2 != NoCall && newBase2 != base2) r2Corrected += 1
-
-          r1.bases(r1Head.readPos - 1) = newBase1
-          r1.quals(r1Head.readPos - 1) = newQual1
-          r2.bases(r2Head.readPos - 1) = newBase2
-          r2.quals(r2Head.readPos - 1) = newQual2
-        }
-
-        // consume the current
-        r1LastReadPos = r1Head.readPos
-        r2LastReadPos = r2Head.readPos
-        r1Iter.next()
-        r2Iter.next()
       }
     }
 

--- a/src/main/scala/com/fulcrumgenomics/bam/OverlappingBasesConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/OverlappingBasesConsensusCaller.scala
@@ -79,7 +79,6 @@ class OverlappingBasesConsensusCaller(agreementStrategy: AgreementStrategy = Agr
 
     // Walk through the iterators by reference position
     iter.foreach { item =>
-
       val base1 = r1.bases(item.readPos - 1)
       val base2 = r2.bases(item.matePos - 1)
       if (!SequenceUtil.isNoCall(base1) && !SequenceUtil.isNoCall(base2)) {

--- a/src/main/scala/com/fulcrumgenomics/bam/ReadAndRefPosIterator.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ReadAndRefPosIterator.scala
@@ -28,6 +28,7 @@ package com.fulcrumgenomics.bam
 import com.fulcrumgenomics.FgBioDef.yieldAndThen
 import com.fulcrumgenomics.alignment.CigarElem
 import com.fulcrumgenomics.bam.ReadAndRefPosIterator.ReadAndRefPos
+import com.fulcrumgenomics.bam.ReadMateAndRefPosIterator.ReadMateAndRefPos
 import com.fulcrumgenomics.bam.api.SamRecord
 import htsjdk.samtools.util.CoordMath
 
@@ -170,12 +171,75 @@ object ReadAndRefPosIterator {
             maxReadPos: Int = Int.MaxValue): ReadAndRefPosIterator = {
     require(rec.paired && rec.mapped && mate.paired && mate.mapped && rec.name == mate.name)
     require(rec.refIndex == mate.refIndex)
+
     new ReadAndRefPosIterator(
-      rec        = rec,
-      minReadPos = minReadPos,
-      maxReadPos = maxReadPos,
-      minRefPos  = Math.max(rec.start, mate.start),
-      maxRefPos  = Math.min(rec.end, mate.end)
+          rec        = rec,
+          minReadPos = minReadPos,
+          maxReadPos = maxReadPos,
+          minRefPos  = Math.max(rec.start, mate.start),
+          maxRefPos  = Math.min(rec.end, mate.end)
     )
   }
+
 }
+
+
+
+/** An iterator for each _mapped_ read base (i.e. has a corresponding reference base) that also has a _mapped_ base in
+  * its mate, with each value being the 1-based position in the read and reference respectively.
+  *
+  * Insertions and deletions will not be returned.  For example, an insertion consumes a read base, but has no
+  * corresponding reference base.  A deletion consumes a reference base, but has no corresponding read base.
+  *
+  * The _mapped_ read bases returned can be limited using the arguments for the minimum and maximum position in the read
+  * and reference respectively.
+  *
+  * @param rec the record over which read and reference positions should be returned
+  * @param mate the mate of the record
+  * @param minReadPos the minimum 1-based position in the read to return
+  * @param maxReadPos the maximum 1-based inclusive end position in the read to return
+  */
+class ReadMateAndRefPosIterator(rec: SamRecord,
+                                mate: SamRecord,
+                                minReadPos: Int = 1,
+                                maxReadPos: Int = Int.MaxValue) extends Iterator[ReadMateAndRefPos] {
+  private val recIter  = ReadAndRefPosIterator(rec=rec, mate=mate, minReadPos=minReadPos, maxReadPos=maxReadPos).buffered
+  private val mateIter = ReadAndRefPosIterator(rec=mate, mate=rec).buffered
+
+  private var nextItem: Option[ReadMateAndRefPos] = None
+
+  override def hasNext(): Boolean = {
+    while (nextItem.isEmpty && recIter.hasNext && mateIter.hasNext) {
+      val nextRec  = recIter.head
+      val nextMate = mateIter.head
+      if (nextRec.refPos < nextMate.refPos) recIter.next()
+      else if (nextMate.refPos < nextRec.refPos) mateIter.next()
+      else {
+        nextItem = Some(ReadMateAndRefPos(readPos=nextRec.readPos, matePos=nextMate.readPos, refPos=nextRec.refPos))
+        recIter.next()
+        mateIter.next()
+      }
+    }
+    nextItem.isDefined
+  }
+
+  def next(): ReadMateAndRefPos = this.nextItem match {
+    case None        => throw new NoSuchElementException()
+    case Some(value) =>
+      this.nextItem = None
+      value
+  }
+}
+
+object ReadMateAndRefPosIterator {
+  /** Stores a 1-based position in the read and reference
+    *
+    * @param readPos 1-based position in the read
+    * @param matePos 1-based position in the mate
+    * @param refPos 1-based position in the reference
+    */
+  case class ReadMateAndRefPos(readPos: Int, matePos: Int, refPos: Int)
+}
+
+
+

--- a/src/main/scala/com/fulcrumgenomics/bam/ReadAndRefPosIterator.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ReadAndRefPosIterator.scala
@@ -238,6 +238,3 @@ object ReadMateAndRefPosIterator {
     */
   case class ReadMateAndRefPos(readPos: Int, matePos: Int, refPos: Int)
 }
-
-
-

--- a/src/main/scala/com/fulcrumgenomics/bam/ReadAndRefPosIterator.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ReadAndRefPosIterator.scala
@@ -221,11 +221,11 @@ class ReadMateAndRefPosIterator(rec: SamRecord,
     nextItem.isDefined
   }
 
-  def next(): ReadMateAndRefPos = this.nextItem match {
-    case None        => throw new NoSuchElementException()
-    case Some(value) =>
-      this.nextItem = None
-      value
+  def next(): ReadMateAndRefPos = {
+   if (!hasNext()) throw new NoSuchElementException()
+   val retval = this.nextItem.get
+   this.nextItem = None
+   retval
   }
 }
 

--- a/src/main/scala/com/fulcrumgenomics/bam/ReadAndRefPosIterator.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ReadAndRefPosIterator.scala
@@ -157,8 +157,7 @@ object ReadAndRefPosIterator {
     * Insertions and deletions will not be returned.  For example, an insertion consumes a read base, but has no
     * corresponding reference base.  A deletion consumes a reference base, but has no corresponding read base.
     *
-    * The _mapped_ read bases returned can be limited using the arguments for the minimum and maximum position in the read
-    * and reference respectively.
+    * The _mapped_ read bases returned can be limited using the arguments for the minimum and maximum position in the read.
     *
     * @param rec the record over which read and reference positions should be returned
     * @param mate the mate of the record
@@ -173,16 +172,14 @@ object ReadAndRefPosIterator {
     require(rec.refIndex == mate.refIndex)
 
     new ReadAndRefPosIterator(
-          rec        = rec,
-          minReadPos = minReadPos,
-          maxReadPos = maxReadPos,
-          minRefPos  = Math.max(rec.start, mate.start),
-          maxRefPos  = Math.min(rec.end, mate.end)
+      rec        = rec,
+      minReadPos = minReadPos,
+      maxReadPos = maxReadPos,
+      minRefPos  = Math.max(rec.start, mate.start),
+      maxRefPos  = Math.min(rec.end, mate.end)
     )
   }
-
 }
-
 
 
 /** An iterator for each _mapped_ read base (i.e. has a corresponding reference base) that also has a _mapped_ base in
@@ -191,8 +188,7 @@ object ReadAndRefPosIterator {
   * Insertions and deletions will not be returned.  For example, an insertion consumes a read base, but has no
   * corresponding reference base.  A deletion consumes a reference base, but has no corresponding read base.
   *
-  * The _mapped_ read bases returned can be limited using the arguments for the minimum and maximum position in the read
-  * and reference respectively.
+  * The _mapped_ read bases returned can be limited using the arguments for the minimum and maximum position in the read.
   *
   * @param rec the record over which read and reference positions should be returned
   * @param mate the mate of the record
@@ -203,6 +199,8 @@ class ReadMateAndRefPosIterator(rec: SamRecord,
                                 mate: SamRecord,
                                 minReadPos: Int = 1,
                                 maxReadPos: Int = Int.MaxValue) extends Iterator[ReadMateAndRefPos] {
+  // Use an iterators that returns the position for the read and mate respectively, then just find the reference positions
+  // where both have a read position defined.
   private val recIter  = ReadAndRefPosIterator(rec=rec, mate=mate, minReadPos=minReadPos, maxReadPos=maxReadPos).buffered
   private val mateIter = ReadAndRefPosIterator(rec=mate, mate=rec).buffered
 
@@ -232,7 +230,7 @@ class ReadMateAndRefPosIterator(rec: SamRecord,
 }
 
 object ReadMateAndRefPosIterator {
-  /** Stores a 1-based position in the read and reference
+  /** Stores a 1-based position in the read, mate and reference
     *
     * @param readPos 1-based position in the read
     * @param matePos 1-based position in the mate

--- a/src/test/scala/com/fulcrumgenomics/bam/OverlappingBasesConsensusCallerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/OverlappingBasesConsensusCallerTest.scala
@@ -137,6 +137,21 @@ class OverlappingBasesConsensusCallerTest extends UnitSpec {
     r2.qualsString shouldBe q10 + q20 + q10*4 + q20 + q10*3
   }
 
+  it should "not consensus call any bases when the read and mate overlap but have no mapped bases in common" in {
+    val builder     = new SamBuilder(10)
+    val Seq(r1, r2) = builder.addPair(bases1="A"*10, bases2="C"*10, start1=1, cigar1="2M6D8M", start2=3, cigar2="2S6M2S",
+      quals1=quals(q=10, rl=10), quals2=quals(q=20, rl=10)
+    )
+    r1.matesOverlap.contains(true) shouldBe true
+    r2.matesOverlap.contains(true) shouldBe true
+
+    caller().call(r1, r2) shouldBe CorrectionStats(0, 0, 0)
+    r1.basesString shouldBe "A"*10
+    r1.qualsString shouldBe q10*10
+    r2.basesString shouldBe "C"*10
+    r2.qualsString shouldBe q20*10
+  }
+
   it should "apply the given agreement strategy with a single base overlap and agreement" in {
     def build(): (SamRecord, SamRecord) = {
       val builder = new SamBuilder(readLength=10)

--- a/src/test/scala/com/fulcrumgenomics/bam/ReadAndRefPosIteratorTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/ReadAndRefPosIteratorTest.scala
@@ -263,4 +263,36 @@ class ReadAndRefPosIteratorTest extends UnitSpec {
     positions2.map(_.readPos) should contain theSameElementsInOrderAs Range.inclusive(start=1, end=28)
     positions2.map(_.refPos) should contain theSameElementsInOrderAs Range.inclusive(start=50, end=77)
   }
+
+  "ReadMateAndRefPosIterator" should "should not return a value when there are no mapped bases in common (1/3)" in {
+    val builder     = new SamBuilder(100)
+    val Seq(r1, r2) = builder.addPair(start1=1, cigar1="100M", start2=101, cigar2="100M")
+    val positions1  = new ReadMateAndRefPosIterator(r1, r2).toIndexedSeq
+    val positions2  = new ReadMateAndRefPosIterator(r2, r1).toIndexedSeq
+
+    positions1 should contain theSameElementsInOrderAs Seq.empty
+    positions2 should contain theSameElementsInOrderAs Seq.empty
+  }
+
+  // See: https://github.com/fulcrumgenomics/fgbio/issues/821
+  it should "should not return a value when there are no mapped bases in common (2/3)" in {
+    val builder     = new SamBuilder(144)
+    val Seq(r1, r2) = builder.addPair(start1=1, cigar1="46M24D98M", start2=47, cigar2="52S21M71S")
+    val positions1  = new ReadMateAndRefPosIterator(r1, r2).toIndexedSeq
+    val positions2  = new ReadMateAndRefPosIterator(r2, r1).toIndexedSeq
+
+    positions1 should contain theSameElementsInOrderAs Seq.empty
+    positions2 should contain theSameElementsInOrderAs Seq.empty
+  }
+
+  // See: https://github.com/fulcrumgenomics/fgbio/issues/821
+  it should "should not return a value when there are no mapped bases in common (3/3)" in {
+    val builder     = new SamBuilder(144)
+    val Seq(r1, r2) = builder.addPair(start1=1, cigar1="90M30D54M", start2=91, cigar2="82S24M38S")
+    val positions1  = new ReadMateAndRefPosIterator(r1, r2).toIndexedSeq
+    val positions2  = new ReadMateAndRefPosIterator(r2, r1).toIndexedSeq
+
+    positions1 should contain theSameElementsInOrderAs Seq.empty
+    positions2 should contain theSameElementsInOrderAs Seq.empty
+  }
 }


### PR DESCRIPTION
bases that map in both the read and ref

Fixes issue #821.