### PR TITLE
Ensure SamWriter always logs how many it wrote before close()

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/bam/api/SamWriter.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/api/SamWriter.scala
@@ -128,14 +128,14 @@ final class SamWriter private (private val writer: SAMFileWriter,
   /** Closes the writer. */
   override def close(): Unit = {
     this.sorter.foreach { s =>
-      sortProgress.foreach(_.logLast)
+      sortProgress.foreach(_.logLast())
       s.iterator.foreach { rec =>
         this.writer.addAlignment(rec.asSam)
         writeProgress.foreach(_.record(rec))
       }
       s.close()
     }
-    writeProgress.foreach(_.logLast)
+    writeProgress.foreach(_.logLast())
 
     this.writer.close()
   }

--- a/src/main/scala/com/fulcrumgenomics/bam/api/SamWriter.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/api/SamWriter.scala
@@ -131,10 +131,10 @@ final class SamWriter private (private val writer: SAMFileWriter,
         this.writer.addAlignment(rec.asSam)
         writeProgress.foreach(_.record(rec))
       }
-      writeProgress.foreach(_.logLast)
 
       s.close()
     }
+    writeProgress.foreach(_.logLast)
 
     this.writer.close()
   }


### PR DESCRIPTION
If `SamWriter` is not sorting, then you won't know how many records were written when the writer is closed. This PR makes it so you will always get a log emission on how many records were written regardless of sorting.

Before this PR, logs for unsorted writing would look like:

```console
[2022/04/22 15:02:37 | MainCli   | Info] Executing Tool from tools version XXX as XXX on XXX with snappy, IntelInflater, and IntelDeflater
[2022/04/22 15:03:53 | SamWriter | Info] Wrote      2,000,000 records.  Elapsed time: 00:01:15s.  Time for last 2,000,000:   74s.  Last read position: chr4:105,235,709
[2022/04/22 15:05:03 | SamWriter | Info] Wrote      4,000,000 records.  Elapsed time: 00:02:25s.  Time for last 2,000,000:   69s.  Last read position: chr11:32,392,057
[2022/04/22 15:06:17 | SamWriter | Info] Wrote      6,000,000 records.  Elapsed time: 00:03:38s.  Time for last 2,000,000:   73s.  Last read position: chr20:32,436,657
[2022/04/22 15:06:54 | MainCli   | Info] Tool completed. Elapsed time: 4.31 minutes.
```