### PR TITLE
Fix a bug where consensus reads are produced with zero depth

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCaller.scala
@@ -196,7 +196,6 @@ class VanillaUmiConsensusCaller(override val readNamePrefix: String,
     else {
       // First limit to max reads if necessary
       val capped  = if (reads.size <= this.options.maxReads) reads else this.random.shuffle(reads).take(this.options.maxReads)
-
       // get the most likely consensus bases and qualities
       val consensusLength = consensusReadLength(capped, this.options.minReads)
       val consensusBases  = new Array[Base](consensusLength)

--- a/src/main/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCaller.scala
@@ -211,7 +211,7 @@ class VanillaUmiConsensusCaller(override val readNamePrefix: String,
           val rawBase      = inBases(i)
           val rawQual      = SingleInputConsensusQuals(inQuals(i))
           val (base, qual) = if (rawQual < this.options.minConsensusBaseQuality) (NoCall, TooLowQualityQual) else (rawBase, rawQual)
-          val isNoCall     = base == NoCall
+          val isNoCall     = rawBase == NoCall
 
           consensusBases(i)  = base
           consensusQuals(i)  = qual

--- a/src/main/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCaller.scala
@@ -211,11 +211,10 @@ class VanillaUmiConsensusCaller(override val readNamePrefix: String,
           val rawBase      = inBases(i)
           val rawQual      = SingleInputConsensusQuals(inQuals(i))
           val (base, qual) = if (rawQual < this.options.minConsensusBaseQuality) (NoCall, TooLowQualityQual) else (rawBase, rawQual)
-          val isNoCall     = rawBase == NoCall
 
           consensusBases(i)  = base
           consensusQuals(i)  = qual
-          consensusDepths(i) = if (isNoCall) 0 else 1
+          consensusDepths(i) = if (rawBase == NoCall) 0 else 1
           consensusErrors(i) = 0
         }
       }

--- a/src/test/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCallerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCallerTest.scala
@@ -281,7 +281,7 @@ class VanillaUmiConsensusCallerTest extends UnitSpec with OptionValues {
     // The base qualities for the first three read (Q20) are less than `minInputBaseQuality`, so the bases gets masked
     // (all Ns). Thus, only one read is used for consensus calling.  The resulting consensus base qualities are Q30
     // which is less than the minimum consensus base quality (Q40), so a consensus of all Ns is produced and consensus
-    // depth is set to zero for all bases, which is wrong, as it should be set to 1.
+    // depth is set to one for all bases.
     val builder = new SamBuilder(readLength=7)
     builder.addFrag(start=100, bases="GATTACA", quals="5555555", attrs=Map("MI" -> "1")) // Q20
     builder.addFrag(start=100, bases="GATTACA", quals="5555555", attrs=Map("MI" -> "1")) // Q20

--- a/src/test/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCallerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCallerTest.scala
@@ -277,6 +277,34 @@ class VanillaUmiConsensusCallerTest extends UnitSpec with OptionValues {
     }
   }
 
+  it should "produce a consensus with Ns with per-base zero depths when consensus base quality is too low due to masking input bases" in {
+    // The base qualities for the first three read (Q20) are less than `minInputBaseQuality`, so the bases gets masked
+    // (all Ns). Thus, only one read is used for consensus calling.  The resulting consensus base qualities are Q30
+    // which is less than the minimum consensus base quality (Q40), so a consensus of all Ns is produced and consensus
+    // depth is set to zero for all bases, which is wrong, as it should be set to 1.
+    val builder = new SamBuilder(readLength=7)
+    builder.addFrag(start=100, bases="GATTACA", quals="5555555", attrs=Map("MI" -> "1")) // Q20
+    builder.addFrag(start=100, bases="GATTACA", quals="5555555", attrs=Map("MI" -> "1")) // Q20
+    builder.addFrag(start=100, bases="GATTACA", quals="5555555", attrs=Map("MI" -> "1")) // Q20
+    builder.addFrag(start=100, bases="CTAATGT", quals="???????", attrs=Map("MI" -> "1")) // Q30
+    val opts = cco(
+      errorRatePreUmi             = PhredScore.MaxValue,
+      errorRatePostUmi            = PhredScore.MaxValue,
+      minInputBaseQuality         = 30.toByte,
+      minConsensusBaseQuality     = 40.toByte,
+      minReads                    = 1
+    )
+
+    cc(opts).consensusFromSamRecords(builder.toSeq) match {
+      case None => fail()
+      case Some(consensus) =>
+        consensus.baseString shouldBe "NNNNNNN"
+        consensus.quals.foreach(q => q shouldBe 2.toByte)
+        consensus.errors.foreach(d => d shouldBe 0)
+        consensus.depths.foreach(d => d shouldBe 1)
+    }
+  }
+
   it should "should create two consensus for two UMI groups" in {
     val builder = new SamBuilder()
     builder.addFrag(name="READ1", start=1, attrs=Map(DefaultTag -> "GATTACA"), bases="A"*builder.readLength, quals="|"*builder.readLength)


### PR DESCRIPTION
I think this may solve #858.

As described in the added unit test, consider four reads where the  base qualities for the first three read (Q20) are less than `minInputBaseQuality` (Q30), so the bases gets masked (all Ns with baseq Q2s). Thus, only one read is used for consensus calling and we used the optimized path in #790 (this is important).  The resulting consensus base qualities are Q30 which are less than the minimum consensus base quality (Q40), so a consensus of all Ns is produced.   Due to the optimized path in #790 and consensus depth is set to zero for all bases.  Instead, even if the consensus base is N due to low consensus base quality, the depth should be equal to the # of (non-N) contributions like in the other code path.

I tried other paths to get reads with all Ns to be passed to `consensusCall`, but they'd be filtered out/rejected.

@tfenne I'd also be curious if you think we should remove this check in [`FilterConsensusReads`](https://github.com/fulcrumgenomics/fgbio/blob/7326a777cdf5b8e2760f3682942d28a15a260eaf/src/main/scala/com/fulcrumgenomics/umi/FilterConsensusReads.scala#L381).
