### PR TITLE
bugfix: ReviewConsensusVariants should not require grouped raw reads to

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/ReviewConsensusVariants.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/ReviewConsensusVariants.scala
@@ -252,7 +252,7 @@ class ReviewConsensusVariants
           val rec = c.getRecord.asInstanceOf[SamRecord]
           val mi = toMi(rec)
           val consensusReadName = c.getRecord.getReadName + readNumberSuffix(rec)
-          val rawCounts = BaseCounts(rawByMiAndReadNum(mi + readNumberSuffix(rec)))
+          val rawCounts = BaseCounts(rawByMiAndReadNum.getOrElse(mi + readNumberSuffix(rec), Seq.empty))
 
           val m = ConsensusVariantReviewInfo(
             chrom = variant.chrom,


### PR DESCRIPTION
overlap each variant.

In some cases, the consensus call may change the span of the alignment
to cover a base that's not covered by any grouped raw read used in that
consensus.

Fixed #604 