### PR TITLE
[bugfix] fix issue #858 in CallDuplexConsensusReads

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/DuplexConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/DuplexConsensusCaller.scala
@@ -345,6 +345,10 @@ class DuplexConsensusCaller(override val readNamePrefix: String,
       case (None, Some(b))    => Some(DuplexConsensusRead(id=b.id, b.bases, b.quals, b.errors, b, None))
       case (Some(a), Some(b)) =>
         val len = min(a.length, b.length)
+        if (a.depths.take(len).forall(_ == 0)) {
+          require(b.depths.take(len).exists(_ > 0), "Bug: both consensus reads had zero depths across all bases")
+          return duplexConsensus(ba, ab, sourceReads)
+        }
         val id  = a.id
         val bases  = new Array[Byte](len)
         val quals  = new Array[Byte](len)


### PR DESCRIPTION
Fixes #858 where the AB strand single strand consensus read could have
zero depth and all Ns, such that the consensus read produced has an aD
value of zero but bD value > 0, causing issues in FilterConsensus Reads.