### PR TITLE
Add an option to sort by sequence role in CollectAlternateContigNames

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/fasta/CollectAlternateContigNames.scala
+++ b/src/main/scala/com/fulcrumgenomics/fasta/CollectAlternateContigNames.scala
@@ -216,7 +216,7 @@ class CollectAlternateContigNames
 
     // Apply to an existing sequence dictionary if necessary
     val dict: SequenceDictionary = existing match {
-      case None if sortBySequencingRole => SequenceDictionary(metadatas.toSeq:_*)
+      case None if !sortBySequencingRole => SequenceDictionary(metadatas.toSeq:_*)
       case None =>
         // Use the user-provided roles, otherwise use all role
         val roles = (if (sequenceRoles.nonEmpty) sequenceRoles.toIndexedSeq else SequenceRole.values)

--- a/src/test/scala/com/fulcrumgenomics/fasta/CollectAlternateContigNamesTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/fasta/CollectAlternateContigNamesTest.scala
@@ -147,4 +147,45 @@ class CollectAlternateContigNamesTest extends UnitSpec {
     dict.last.name shouldBe "NC_012920.1"
     dict.last.aliases should contain theSameElementsInOrderAs Seq("J01415.2", "chrM")
   }
+
+  it should "sort by sequencing roles when they all are defined" in {
+    val output = makeTempFile("test.", ".dict")
+    val tool = new CollectAlternateContigNames(
+      input                = reportHg19,
+      output               = output,
+      primary              = Column.RefSeqAccession,
+      alternates           = Seq(Column.UcscName),
+      sequenceRoles        = Seq(UnplacedScaffold, UnlocalizedScaffold, AssembledMolecule),
+      sortBySequencingRole = true
+    )
+    executeFgbioTool(tool)
+
+    val dict = SequenceDictionary(output)
+    dict should have length 84
+    dict.head.name shouldBe "NT_113961.1"
+    dict.head.aliases should contain theSameElementsInOrderAs Seq("chrUn_gl000211")
+    dict.last.name shouldBe "NC_012920.1"
+    dict.last.aliases should contain theSameElementsInOrderAs Seq("chrM")
+    dict.map(m => m(Column.SequenceRole.tag)).toIndexedSeq.distinct should contain theSameElementsInOrderAs Seq(UnplacedScaffold, UnlocalizedScaffold, AssembledMolecule).map(_.key)
+  }
+
+  it should "sort by sequencing roles when no roles are defined" in {
+    val output = makeTempFile("test.", ".dict")
+    val tool = new CollectAlternateContigNames(
+      input                = reportHg19,
+      output               = output,
+      primary              = Column.RefSeqAccession,
+      alternates           = Seq(Column.UcscName),
+      sortBySequencingRole = true
+    )
+    executeFgbioTool(tool)
+
+    val dict = SequenceDictionary(output)
+    dict should have length 93
+    dict.head.name shouldBe "NC_000001.10"
+    dict.head.aliases should contain theSameElementsInOrderAs Seq("chr1")
+    dict.last.name shouldBe "NT_167243.1"
+    dict.last.aliases should contain theSameElementsInOrderAs Seq("chrUn_gl000249")
+    dict.map(m => m(Column.SequenceRole.tag)).toIndexedSeq.distinct should contain theSameElementsInOrderAs Seq(AssembledMolecule, AltScaffold, UnlocalizedScaffold, UnplacedScaffold).map(_.key)
+  }
 }


### PR DESCRIPTION
This is so that I can have assembled molecules first, whereas in some assembly reports chrM (an assembled molecule) is listed at the end of the report.