### PR TITLE
Tweak the size of caches for parallel consensus calling down to reduc…

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/ConsensusCallingIterator.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/ConsensusCallingIterator.scala
@@ -67,7 +67,7 @@ class ConsensusCallingIterator[ConsensusRead <: SimpleRead](sourceIterator: Iter
       groupingIterator.flatMap(caller.consensusReadsFromSamRecords)
     }
     else {
-      ParIterator(groupingIterator, threads=threads).flatMap { rs =>
+      ParIterator(groupingIterator, threads=threads, chunkSize=threads * 16, chunkBuffer=1).flatMap { rs =>
         val caller = callers.get()
         caller.synchronized { caller.consensusReadsFromSamRecords(rs) }
       }.toAsync(chunkSize * 8)


### PR DESCRIPTION
…e memory usage.

@nh13 In my hands this is no slower on "normal" looking data (i.e. 1-10s of reads per tag family), but significantly reduces memory usage when pathological data is present (e.g. tag families with 10,000s of reads).  Do you think it's ok to just tweak these down, or do you think we should add command line parameters to control cache sizing?