### PR TITLE
Improve docs for consensus reads being unaligned

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/CallDuplexConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CallDuplexConsensusReads.scala
@@ -52,6 +52,10 @@ import com.fulcrumgenomics.util.ProgressLogger
     |input they are _ignored_.  Similarly, read pairs for which consensus reads cannot be generated for one or
     |other read (R1 or R2) are omitted from the output.
     |
+    |The consensus reads produced are unaligned, due to the difficulty and error-prone nature of inferring the conesensus
+    |alignment.  Consensus reads should therefore be aligned after, which should not be too expensive as likely there
+    |are far fewer conesnsus reads than input raw raws.
+    |
     |Consensus reads have a number of additional optional tags set in the resulting BAM file.  The tag names follow
     |a pattern where the first letter (a, b or c) denotes that the tag applies to the first single strand consensus (a),
     |second single-strand consensus (b) or the final duplex consensus (c).  The second letter is intended to capture

--- a/src/main/scala/com/fulcrumgenomics/umi/CallDuplexConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CallDuplexConsensusReads.scala
@@ -54,7 +54,8 @@ import com.fulcrumgenomics.util.ProgressLogger
     |
     |The consensus reads produced are unaligned, due to the difficulty and error-prone nature of inferring the conesensus
     |alignment.  Consensus reads should therefore be aligned after, which should not be too expensive as likely there
-    |are far fewer conesnsus reads than input raw raws.
+    |are far fewer consensus reads than input raw raws.  Please see how best to use this tool within the best-practice
+    |pipeline: https://github.com/fulcrumgenomics/fgbio/blob/main/docs/best-practice-consensus-pipeline.md
     |
     |Consensus reads have a number of additional optional tags set in the resulting BAM file.  The tag names follow
     |a pattern where the first letter (a, b or c) denotes that the tag applies to the first single strand consensus (a),

--- a/src/main/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReads.scala
@@ -72,6 +72,11 @@ import htsjdk.samtools.SAMFileHeader.{GroupOrder, SortOrder}
     |calls each end of a pair independently, and does not jointly call bases that overlap within a pair.  Insertion or
     |deletion errors in the reads are not considered in the consensus model.
     |
+    |The consensus reads produced are unaligned, due to the difficulty and error-prone nature of inferring the conesensus
+    |alignment.  Consensus reads should therefore be aligned after, which should not be too expensive as likely there
+    |are far fewer consensus reads than input raw raws.  Please see how best to use this tool within the best-practice
+    |pipeline: https://github.com/fulcrumgenomics/fgbio/blob/main/docs/best-practice-consensus-pipeline.md
+    |
     |Particular attention should be paid to setting the `--min-reads` parameter as this can have a dramatic effect on
     |both results and runtime.  For libraries with low duplication rates (e.g. 100-300X exomes libraries) in which it
     |is desirable to retain singleton reads while making consensus reads from sets of duplicates, `--min-reads=1` is


### PR DESCRIPTION
See #896.  Will apply to `CallMolecularConsensusReads` if this working is accepted.