### PR TITLE
Update broad snapshot artifactory url in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -97,7 +97,7 @@ lazy val commonSettings = Seq(
   Test / fork          := true,
   resolvers            += Resolver.sonatypeRepo("public"),
   resolvers            += Resolver.mavenLocal,
-  resolvers            += "broad-snapshots" at "https://artifactory.broadinstitute.org/artifactory/libs-snapshot/",
+  resolvers            += "broad-snapshots" at "https://broadinstitute.jfrog.io/artifactory/libs-snapshot/",
   shellPrompt          := { state => "%s| %s> ".format(GitCommand.prompt.apply(state), version.value) },
   updateOptions        := updateOptions.value.withCachedResolution(true)
 ) ++ Defaults.coreDefaultSettings


### PR DESCRIPTION
Fixes #924 

Sadly, it seems any existing fgbio commits cannot be rebuilt due to this move by the Broad.

See: https://broadinstitute.jfrog.io/ui/repos/tree/General/libs-snapshot

<img width="685" alt="Screenshot 2023-08-07 at 10 02 50 AM" src="https://github.com/fulcrumgenomics/fgbio/assets/19941609/ce629840-0107-4989-b7c7-5f8a5d188b49">

