### PR TITLE
bugfix: ZipperBams should consume any remaining mapped reads

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/bam/ZipperBams.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ZipperBams.scala
@@ -242,9 +242,11 @@ class ZipperBams
 
     // There really should be no more reads, but lets continue on if so
     if (mappedIter.hasNext) {
-      logger.warning("Processed all unmapped reads but mapped reads remaining, continuing")
-      // consume the remaining so piping in strict mode does not fail
-      mappedIter.foreach { _ => }
+      throw new IllegalStateException(
+        """Error: processed all unmapped reads but there are mapped reads remaining to be read.
+        |Please ensure the unmapped and mapped reads have the same set of read names in the same
+        |order, and reads with the same name are consecutive (grouped) in each input""".stripMargin
+      )
     }
 
     out.close()

--- a/src/main/scala/com/fulcrumgenomics/bam/ZipperBams.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ZipperBams.scala
@@ -240,6 +240,13 @@ class ZipperBams
       }
     }
 
+    // There really should be no more reads, but lets continue on if so
+    if (mappedIter.hasNext) {
+      logger.warning("Processed all unmapped reads but mapped reads remaining, continuing")
+      // consume the remaining so piping in strict mode does not fail
+      mappedIter.foreach { _ => }
+    }
+
     out.close()
     unmappedSource.safelyClose()
     mappedSource.safelyClose()

--- a/src/main/scala/com/fulcrumgenomics/bam/ZipperBams.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ZipperBams.scala
@@ -240,7 +240,7 @@ class ZipperBams
       }
     }
 
-    // There really should be no more reads, but lets continue on if so
+    // There really should be no more mapped reads!
     if (mappedIter.hasNext) {
       throw new IllegalStateException(
         """Error: processed all unmapped reads but there are mapped reads remaining to be read.

--- a/src/main/scala/com/fulcrumgenomics/bam/ZipperBams.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ZipperBams.scala
@@ -240,6 +240,8 @@ class ZipperBams
       }
     }
 
+    out.close()
+
     // There really should be no more mapped reads!
     if (mappedIter.hasNext) {
       throw new IllegalStateException(
@@ -248,8 +250,7 @@ class ZipperBams
         |order, and reads with the same name are consecutive (grouped) in each input""".stripMargin
       )
     }
-
-    out.close()
+    
     unmappedSource.safelyClose()
     mappedSource.safelyClose()
   }


### PR DESCRIPTION
So that pipes do not cause failure when unread data exists in bash strict mode.

@jacarey 