### PR TITLE
Mark Duplicate Bitflag & include secondary & Supplimentary Reads

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
@@ -482,6 +482,8 @@ class GroupReadsByUmi
  @arg(flag='d', doc="Mark Duplicate Flag will be set on primary read.")     val markDup: Boolean = false,
  @arg(flag='D', doc="If -d is set, primary read assignment strategy, default = Sum Of Base Qualities.")
   val dupStrategy: DuplicateScoringStrategy.ScoringStrategy = DuplicateScoringStrategy.ScoringStrategy.SUM_OF_BASE_QUALITIES,
+ @arg(flag='S', doc="Include secondary reads.")         val includeSecondary: Boolean = false,
+ @arg(flag='U', doc="Include supplementary reads.")     val includeSupplementary: Boolean = false,
  @arg(flag='m', doc="Minimum mapping quality for mapped reads.")         val minMapQ: Int      = 1,
  @arg(flag='n', doc="Include non-PF reads.")            val includeNonPfReads: Boolean = false,
  @arg(flag='s', doc="The UMI assignment strategy.")     val strategy: Strategy,
@@ -548,7 +550,8 @@ class GroupReadsByUmi
     // Filter and sort the input BAM file
     logger.info("Filtering the input.")
     val filteredIterator = in.iterator
-      .filter(r => !r.secondary && !r.supplementary)
+      .filter(r => includeSecondary || !r.secondary  )
+      .filter(r => includeSupplementary || !r.supplementary )
       .filter(r => (includeNonPfReads || r.pf)                                      || { filteredNonPf += 1; false })
       .filter(r => (r.mapped || (r.paired && r.mateMapped))                         || { filteredPoorAlignment += 1; false })
       .filter(r => (allowInterContig || r.unpaired || r.refIndex == r.mateRefIndex) || { filteredPoorAlignment += 1; false })

--- a/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
@@ -474,16 +474,19 @@ object Strategy extends FgBioEnum[Strategy] {
   """
 )
 class GroupReadsByUmi
-( @arg(flag='i', doc="The input BAM file.")              val input: PathToBam  = Io.StdIn,
-  @arg(flag='o', doc="The output BAM file.")             val output: PathToBam = Io.StdOut,
-  @arg(flag='f', doc="Optional output of tag family size counts.") val familySizeHistogram: Option[FilePath] = None,
-  @arg(flag='t', doc="The tag containing the raw UMI.")  val rawTag: String    = "RX",
-  @arg(flag='T', doc="The output tag for UMI grouping.") val assignTag: String = "MI",
-  @arg(flag='m', doc="Minimum mapping quality for mapped reads.")         val minMapQ: Int      = 1,
-  @arg(flag='n', doc="Include non-PF reads.")            val includeNonPfReads: Boolean = false,
-  @arg(flag='s', doc="The UMI assignment strategy.")     val strategy: Strategy,
-  @arg(flag='e', doc="The allowable number of edits between UMIs.") val edits: Int = 1,
-  @arg(flag='l', doc= """The minimum UMI length. If not specified then all UMIs must have the same length,
+(@arg(flag='i', doc="The input BAM file.")              val input: PathToBam  = Io.StdIn,
+ @arg(flag='o', doc="The output BAM file.")             val output: PathToBam = Io.StdOut,
+ @arg(flag='f', doc="Optional output of tag family size counts.") val familySizeHistogram: Option[FilePath] = None,
+ @arg(flag='t', doc="The tag containing the raw UMI.")  val rawTag: String    = "RX",
+ @arg(flag='T', doc="The output tag for UMI grouping.") val assignTag: String = "MI",
+ @arg(flag='d', doc="Mark Duplicate Flag will be set on primary read.")     val markDup: Boolean = false,
+ @arg(flag='D', doc="If -d is set, primary read assignment strategy, default = Sum Of Base Qualities.")
+  val dupStrategy: DuplicateScoringStrategy.ScoringStrategy = DuplicateScoringStrategy.ScoringStrategy.SUM_OF_BASE_QUALITIES,
+ @arg(flag='m', doc="Minimum mapping quality for mapped reads.")         val minMapQ: Int      = 1,
+ @arg(flag='n', doc="Include non-PF reads.")            val includeNonPfReads: Boolean = false,
+ @arg(flag='s', doc="The UMI assignment strategy.")     val strategy: Strategy,
+ @arg(flag='e', doc="The allowable number of edits between UMIs.") val edits: Int = 1,
+ @arg(flag='l', doc= """The minimum UMI length. If not specified then all UMIs must have the same length,
                        |otherwise discard reads with UMIs shorter than this length and allow for differing UMI lengths.
                        |""")
   val minUmiLength: Option[Int] = None,

--- a/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
@@ -488,28 +488,28 @@ object Strategy extends FgBioEnum[Strategy] {
   """
 )
 class GroupReadsByUmi
-  (@arg(flag='i', doc="The input BAM file.")              val input: PathToBam  = Io.StdIn,
-   @arg(flag='o', doc="The output BAM file.")             val output: PathToBam = Io.StdOut,
-   @arg(flag='f', doc="Optional output of tag family size counts.") val familySizeHistogram: Option[FilePath] = None,
-   @arg(flag='t', doc="The tag containing the raw UMI.")  val rawTag: String    = "RX",
-   @arg(flag='T', doc="The output tag for UMI grouping.") val assignTag: String = "MI",
-   @arg(flag='d', doc="Mark duplicates, duplicate bitflag will be set on non-representative reads.")     val markDup: Boolean = false,
-   @arg(flag='D', doc="If -d is set, representative read assignment strategy, default = Sum Of Base Qualities.")
+( @arg(flag='i', doc="The input BAM file.")              val input: PathToBam  = Io.StdIn,
+  @arg(flag='o', doc="The output BAM file.")             val output: PathToBam = Io.StdOut,
+  @arg(flag='f', doc="Optional output of tag family size counts.") val familySizeHistogram: Option[FilePath] = None,
+  @arg(flag='t', doc="The tag containing the raw UMI.")  val rawTag: String    = "RX",
+  @arg(flag='T', doc="The output tag for UMI grouping.") val assignTag: String = "MI",
+  @arg(flag='d', doc="Mark duplicates, duplicate bitflag will be set on non-representative reads.")     val markDup: Boolean = false,
+  @arg(flag='D', doc="If -d is set, representative read assignment strategy, default = Sum Of Base Qualities.")
     val dupStrategy: DuplicateScoringStrategy.ScoringStrategy = DuplicateScoringStrategy.ScoringStrategy.SUM_OF_BASE_QUALITIES,
-   @arg(flag='S', doc="Include secondary reads.")         val includeSecondary: Boolean = false,
-   @arg(flag='U', doc="Include supplementary reads.")     val includeSupplementary: Boolean = false,
-   @arg(flag='m', doc="Minimum mapping quality for mapped reads.")         val minMapQ: Int      = 1,
-   @arg(flag='n', doc="Include non-PF reads.")            val includeNonPfReads: Boolean = false,
-   @arg(flag='s', doc="The UMI assignment strategy.")     val strategy: Strategy,
-   @arg(flag='e', doc="The allowable number of edits between UMIs.") val edits: Int = 1,
-   @arg(flag='l', doc= """The minimum UMI length. If not specified then all UMIs must have the same length,
+  @arg(flag='S', doc="Include secondary reads.")         val includeSecondary: Boolean = false,
+  @arg(flag='U', doc="Include supplementary reads.")     val includeSupplementary: Boolean = false,
+  @arg(flag='m', doc="Minimum mapping quality for mapped reads.")         val minMapQ: Int      = 1,
+  @arg(flag='n', doc="Include non-PF reads.")            val includeNonPfReads: Boolean = false,
+  @arg(flag='s', doc="The UMI assignment strategy.")     val strategy: Strategy,
+  @arg(flag='e', doc="The allowable number of edits between UMIs.") val edits: Int = 1,
+  @arg(flag='l', doc= """The minimum UMI length. If not specified then all UMIs must have the same length,
                          |otherwise discard reads with UMIs shorter than this length and allow for differing UMI lengths.
                          |""")
     val minUmiLength: Option[Int] = None,
-   @arg(flag='x', doc= """
+  @arg(flag='x', doc= """
                          |DEPRECATED: this option will be removed in future versions and inter-contig reads will be
                          |automatically processed.""")
-   @deprecated val allowInterContig: Boolean = true
+  @deprecated val allowInterContig: Boolean = true
 )extends FgBioTool with LazyLogging {
   import GroupReadsByUmi._
 

--- a/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
@@ -488,28 +488,28 @@ object Strategy extends FgBioEnum[Strategy] {
   """
 )
 class GroupReadsByUmi
-(@arg(flag='i', doc="The input BAM file.")              val input: PathToBam  = Io.StdIn,
- @arg(flag='o', doc="The output BAM file.")             val output: PathToBam = Io.StdOut,
- @arg(flag='f', doc="Optional output of tag family size counts.") val familySizeHistogram: Option[FilePath] = None,
- @arg(flag='t', doc="The tag containing the raw UMI.")  val rawTag: String    = "RX",
- @arg(flag='T', doc="The output tag for UMI grouping.") val assignTag: String = "MI",
- @arg(flag='d', doc="Mark duplicates, duplicate bitflag will be set on non-representative reads.")     val markDup: Boolean = false,
- @arg(flag='D', doc="If -d is set, representative read assignment strategy, default = Sum Of Base Qualities.")
-  val dupStrategy: DuplicateScoringStrategy.ScoringStrategy = DuplicateScoringStrategy.ScoringStrategy.SUM_OF_BASE_QUALITIES,
- @arg(flag='S', doc="Include secondary reads.")         val includeSecondary: Boolean = false,
- @arg(flag='U', doc="Include supplementary reads.")     val includeSupplementary: Boolean = false,
- @arg(flag='m', doc="Minimum mapping quality for mapped reads.")         val minMapQ: Int      = 1,
- @arg(flag='n', doc="Include non-PF reads.")            val includeNonPfReads: Boolean = false,
- @arg(flag='s', doc="The UMI assignment strategy.")     val strategy: Strategy,
- @arg(flag='e', doc="The allowable number of edits between UMIs.") val edits: Int = 1,
- @arg(flag='l', doc= """The minimum UMI length. If not specified then all UMIs must have the same length,
-                       |otherwise discard reads with UMIs shorter than this length and allow for differing UMI lengths.
-                       |""")
-  val minUmiLength: Option[Int] = None,
- @arg(flag='x', doc= """
-                       |DEPRECATED: this option will be removed in future versions and inter-contig reads will be
-                       |automatically processed.""")
-  @deprecated val allowInterContig: Boolean = true
+  (@arg(flag='i', doc="The input BAM file.")              val input: PathToBam  = Io.StdIn,
+   @arg(flag='o', doc="The output BAM file.")             val output: PathToBam = Io.StdOut,
+   @arg(flag='f', doc="Optional output of tag family size counts.") val familySizeHistogram: Option[FilePath] = None,
+   @arg(flag='t', doc="The tag containing the raw UMI.")  val rawTag: String    = "RX",
+   @arg(flag='T', doc="The output tag for UMI grouping.") val assignTag: String = "MI",
+   @arg(flag='d', doc="Mark duplicates, duplicate bitflag will be set on non-representative reads.")     val markDup: Boolean = false,
+   @arg(flag='D', doc="If -d is set, representative read assignment strategy, default = Sum Of Base Qualities.")
+    val dupStrategy: DuplicateScoringStrategy.ScoringStrategy = DuplicateScoringStrategy.ScoringStrategy.SUM_OF_BASE_QUALITIES,
+   @arg(flag='S', doc="Include secondary reads.")         val includeSecondary: Boolean = false,
+   @arg(flag='U', doc="Include supplementary reads.")     val includeSupplementary: Boolean = false,
+   @arg(flag='m', doc="Minimum mapping quality for mapped reads.")         val minMapQ: Int      = 1,
+   @arg(flag='n', doc="Include non-PF reads.")            val includeNonPfReads: Boolean = false,
+   @arg(flag='s', doc="The UMI assignment strategy.")     val strategy: Strategy,
+   @arg(flag='e', doc="The allowable number of edits between UMIs.") val edits: Int = 1,
+   @arg(flag='l', doc= """The minimum UMI length. If not specified then all UMIs must have the same length,
+                         |otherwise discard reads with UMIs shorter than this length and allow for differing UMI lengths.
+                         |""")
+    val minUmiLength: Option[Int] = None,
+   @arg(flag='x', doc= """
+                         |DEPRECATED: this option will be removed in future versions and inter-contig reads will be
+                         |automatically processed.""")
+   @deprecated val allowInterContig: Boolean = true
 )extends FgBioTool with LazyLogging {
   import GroupReadsByUmi._
 

--- a/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
@@ -632,7 +632,7 @@ class GroupReadsByUmi
       // Then group the records in the right order (assigned tag, read name, r1, r2)
       val templatesByMi = templates.groupBy { t => t.r1.get.apply[String](this.assignTag) }
 
-      // If marking duplicate, assign bitflag to non-duplicate
+      // If marking duplicates, assign bitflag to all duplicate reads
       if (this.markDup) {
         templatesByMi.values.foreach(t => assignRepReadToGroup(t))
       }

--- a/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
@@ -755,6 +755,8 @@ class GroupReadsByUmi
     val deDupGroup = group.sortWith{ (t1, t2) =>
       compareScore(t1.primaryReads, t2.primaryReads)
     }
+    //0 element is highest scoring item, therefor is the representative read.
+    //mark all SamRecords in other elements as duplicate.
     deDupGroup.slice(1,deDupGroup.length).foreach { t => t.allReads.foreach( r => r.duplicate = true) }
   }
 

--- a/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
@@ -513,7 +513,6 @@ class GroupReadsByUmi
 )extends FgBioTool with LazyLogging {
   import GroupReadsByUmi._
 
-
   require(this.minUmiLength.forall(_ => this.strategy != Strategy.Paired), "Paired strategy cannot be used with --min-umi-length")
 
   private val assigner = strategy.newStrategy(this.edits)

--- a/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
@@ -42,9 +42,8 @@ import enumeratum.EnumEntry
 import htsjdk.samtools._
 import htsjdk.samtools.util.SequenceUtil
 
-import scala.collection.BufferedIterator
+import scala.collection.{BufferedIterator, Iterator, mutable}
 import scala.collection.immutable.IndexedSeq
-import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 
 
@@ -488,7 +487,7 @@ class GroupReadsByUmi
                        |otherwise discard reads with UMIs shorter than this length and allow for differing UMI lengths.
                        |""")
   val minUmiLength: Option[Int] = None,
-  @arg(flag='x', doc= """
+ @arg(flag='x', doc= """
                        |DEPRECATED: this option will be removed in future versions and inter-contig reads will be
                        |automatically processed.""")
   @deprecated val allowInterContig: Boolean = true

--- a/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
@@ -612,10 +612,15 @@ class GroupReadsByUmi
       // Take the next set of templates by position and assign UMIs
       val templates = takeNextGroup(templateCoordinateIterator, canTakeNextGroupByUmi=canTakeNextGroupByUmi)
       assignUmiGroups(templates)
-
-      // Then output the records in the right order (assigned tag, read name, r1, r2)
+      // Then group the records in the right order (assigned tag, read name, r1, r2)
       val templatesByMi = templates.groupBy { t => t.r1.get.apply[String](this.assignTag) }
 
+      // If marking duplicate, assign bitflag to non-duplicate
+      if (this.markDup) {
+        templatesByMi.values.foreach(t => assignRepReadToGroup(t))
+      }
+
+      // Then output the records in the right order (assigned tag, read name, r1, r2)
       templatesByMi.keys.toSeq.sortBy(id => (id.length, id)).foreach(tag => {
         templatesByMi(tag).sortBy(t => t.name).flatMap(t => t.primaryReads).foreach(rec => {
           out += rec

--- a/src/test/scala/com/fulcrumgenomics/umi/GroupReadsByUmiTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/GroupReadsByUmiTest.scala
@@ -267,7 +267,10 @@ class GroupReadsByUmiTest extends UnitSpec with OptionValues with PrivateMethodT
     val in = builder.toTempFile()
     val out = Files.createTempFile("umi_grouped.", ".sam")
     val hist = Files.createTempFile("umi_grouped.", ".histogram.txt")
-    new GroupReadsByUmi(minMapQ = 0, input = in, output = out, familySizeHistogram = Some(hist), rawTag = "RX", assignTag = "MI", strategy = Strategy.Paired, edits = 1, markDup = true).execute()
+    val gr = new GroupReadsByUmi(minMapQ = 0, input = in, output = out, familySizeHistogram = Some(hist), rawTag = "RX", assignTag = "MI", strategy = Strategy.Paired, edits = 1, markDup = true)
+
+    gr.markDup shouldBe true
+    gr.dupStrategy shouldBe DuplicateScoringStrategy.ScoringStrategy.SUM_OF_BASE_QUALITIES
 
     val recs = readBamRecs(out)
     recs.filter(_.name.equals("a01")).forall(_.duplicate == true) shouldBe true
@@ -275,6 +278,27 @@ class GroupReadsByUmiTest extends UnitSpec with OptionValues with PrivateMethodT
     recs.filter(_.name.equals("a03")).forall(_.duplicate == false) shouldBe true
     recs.filter(_.name.equals("a04")).forall(_.duplicate == true) shouldBe true
   }
+
+  it should "does not mark duplicates on reads in group, when flag is not passed" in {
+    val builder = new SamBuilder(readLength = 100, sort = Some(SamOrder.Coordinate))
+    // Mapping Quality is a tie breaker, so use that to our advantage here.
+    builder.addPair(mapq1 = 10, mapq2 = 10, name = "a01", start1 = 100, start2 = 300, strand1 = Plus, strand2 = Minus, attrs = Map("RX" -> "ACT-ACT"))
+    builder.addPair(mapq1 = 30, mapq2 = 30, name = "a02", start1 = 100, start2 = 300, strand1 = Plus, strand2 = Minus, attrs = Map("RX" -> "ACT-ACT"))
+    builder.addPair(mapq1 = 100, mapq2 = 10, name = "a03", start1 = 100, start2 = 300, strand1 = Plus, strand2 = Minus, attrs = Map("RX" -> "ACT-ACT"))
+    builder.addPair(mapq1 = 0, mapq2 = 0, name = "a04", start1 = 100, start2 = 300, strand1 = Plus, strand2 = Minus, attrs = Map("RX" -> "ACT-ACT"))
+
+    val in = builder.toTempFile()
+    val out = Files.createTempFile("umi_grouped.", ".sam")
+    val hist = Files.createTempFile("umi_grouped.", ".histogram.txt")
+    new GroupReadsByUmi(minMapQ = 0, input = in, output = out, familySizeHistogram = Some(hist), rawTag = "RX", assignTag = "MI", strategy = Strategy.Paired, edits = 1).execute()
+
+    val recs = readBamRecs(out)
+    recs.filter(_.name.equals("a01")).forall(_.duplicate == false) shouldBe true
+    recs.filter(_.name.equals("a02")).forall(_.duplicate == false) shouldBe true
+    recs.filter(_.name.equals("a03")).forall(_.duplicate == false) shouldBe true
+    recs.filter(_.name.equals("a04")).forall(_.duplicate == false) shouldBe true
+  }
+
 
   it should "correctly mark duplicates on duplicate single-end reads with UMIs" in {
     val builder = new SamBuilder(readLength = 100, sort = Some(SamOrder.Coordinate))
@@ -293,7 +317,6 @@ class GroupReadsByUmiTest extends UnitSpec with OptionValues with PrivateMethodT
     recs.filter(_.name.equals("a02")).forall(_.duplicate == true) shouldBe true
     recs.filter(_.name.equals("a03")).forall(_.duplicate == false) shouldBe true
     recs.filter(_.name.equals("a04")).forall(_.duplicate == true) shouldBe true
-
   }
 
   it should "correctly group reads with the paired assigner when the two UMIs are the same" in {

--- a/src/test/scala/com/fulcrumgenomics/umi/GroupReadsByUmiTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/GroupReadsByUmiTest.scala
@@ -299,7 +299,6 @@ class GroupReadsByUmiTest extends UnitSpec with OptionValues with PrivateMethodT
     recs.filter(_.name.equals("a04")).forall(_.duplicate == false) shouldBe true
   }
 
-
   it should "correctly mark duplicates on duplicate single-end reads with UMIs" in {
     val builder = new SamBuilder(readLength = 100, sort = Some(SamOrder.Coordinate))
     builder.addFrag(mapq = 100, name = "a01", start = 100, attrs = Map("RX" -> "AAAAAAAA"))

--- a/src/test/scala/com/fulcrumgenomics/umi/GroupReadsByUmiTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/GroupReadsByUmiTest.scala
@@ -275,6 +275,26 @@ class GroupReadsByUmiTest extends UnitSpec with OptionValues with PrivateMethodT
     recs.filter(_.name.equals("a04")).forall(_.duplicate == true) shouldBe true
   }
 
+  it should "correctly mark duplicates on duplicate single-end reads with UMIs" in {
+    val builder = new SamBuilder(readLength = 100, sort = Some(SamOrder.Coordinate))
+    builder.addFrag(mapq = 100, name = "a01", start = 100, attrs = Map("RX" -> "AAAAAAAA"))
+    builder.addFrag(mapq = 10, name = "a02", start = 100, attrs = Map("RX" -> "AAAAAAAA"))
+    builder.addFrag(mapq = 100, name = "a03", start = 100, attrs = Map("RX" -> "CACACACA"))
+    builder.addFrag(mapq = 10, name = "a04", start = 100, attrs = Map("RX" -> "CACACACC"))
+
+    val in = builder.toTempFile()
+    val out = Files.createTempFile("umi_grouped.", ".sam")
+    val hist = Files.createTempFile("umi_grouped.", ".histogram.txt")
+    new GroupReadsByUmi(input = in, output = out, familySizeHistogram = Some(hist), rawTag = "RX", assignTag = "MI", strategy = Strategy.Edit, edits = 1, markDup = true).execute()
+
+    val recs = readBamRecs(out)
+    recs.filter(_.name.equals("a01")).forall(_.duplicate == false) shouldBe true
+    recs.filter(_.name.equals("a02")).forall(_.duplicate == true) shouldBe true
+    recs.filter(_.name.equals("a03")).forall(_.duplicate == false) shouldBe true
+    recs.filter(_.name.equals("a04")).forall(_.duplicate == true) shouldBe true
+
+  }
+
   it should "correctly group reads with the paired assigner when the two UMIs are the same" in {
     val builder = new SamBuilder(readLength=100, sort=Some(SamOrder.Coordinate))
     builder.addPair(name="a01", start1=100, start2=300, strand1=Plus,  strand2=Minus, attrs=Map("RX" -> "ACT-ACT"))

--- a/src/test/scala/com/fulcrumgenomics/umi/GroupReadsByUmiTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/GroupReadsByUmiTest.scala
@@ -255,6 +255,26 @@ class GroupReadsByUmiTest extends UnitSpec with OptionValues with PrivateMethodT
     }
   }
 
+  it should "correctly mark duplicates on duplicate reads in group, when flag is passed" in {
+    val builder = new SamBuilder(readLength = 100, sort = Some(SamOrder.Coordinate))
+    // Mapping Quality is a tie breaker in all HTSLIB strategies, so use that to our advantage here.
+    builder.addPair(mapq1 = 100, mapq2 = 100, name = "a01", start1 = 100, start2 = 300, strand1 = Plus, strand2 = Minus, attrs = Map("RX" -> "ACT-ACT"))
+    builder.addPair(mapq1 = 30, mapq2 = 30, name = "a02", start1 = 100, start2 = 300, strand1 = Plus, strand2 = Minus, attrs = Map("RX" -> "ACT-ACT"))
+    builder.addPair(mapq1 = 10, mapq2 = 10, name = "a03", start1 = 100, start2 = 300, strand1 = Plus, strand2 = Minus, attrs = Map("RX" -> "ACT-ACT"))
+    builder.addPair(mapq1 = 0, mapq2 = 0, name = "a04", start1 = 100, start2 = 300, strand1 = Plus, strand2 = Minus, attrs = Map("RX" -> "ACT-ACT"))
+
+    val in = builder.toTempFile()
+    val out = Files.createTempFile("umi_grouped.", ".sam")
+    val hist = Files.createTempFile("umi_grouped.", ".histogram.txt")
+    new GroupReadsByUmi(minMapQ = 0, input = in, output = out, familySizeHistogram = Some(hist), rawTag = "RX", assignTag = "MI", strategy = Strategy.Paired, edits = 1, markDup = true).execute()
+
+    val recs = readBamRecs(out)
+    recs.filter(_.name.equals("a01")).forall(_.duplicate == false) shouldBe true
+    recs.filter(_.name.equals("a02")).forall(_.duplicate == true) shouldBe true
+    recs.filter(_.name.equals("a03")).forall(_.duplicate == true) shouldBe true
+    recs.filter(_.name.equals("a04")).forall(_.duplicate == true) shouldBe true
+  }
+
   it should "correctly group reads with the paired assigner when the two UMIs are the same" in {
     val builder = new SamBuilder(readLength=100, sort=Some(SamOrder.Coordinate))
     builder.addPair(name="a01", start1=100, start2=300, strand1=Plus,  strand2=Minus, attrs=Map("RX" -> "ACT-ACT"))


### PR DESCRIPTION
Closes #906 & #920

This exposes a few new options

`-d` Set duplicate bit flag on all non-representative reads
`-D` representative read strategy, accepts strategies from [htslib](https://github.com/samtools/htsjdk/blob/6d3fc7bc1f613ecfce1c22d368f3ae17cb86823d/src/main/java/htsjdk/samtools/DuplicateScoringStrategy.java#L36-L39). 
Representative read is chosen by the sum scores ( from the scoring strategy ) across all primary reads, ties are broken with sum of mapping qualities from primary reads.

`-S` include secondary reads in output ( also mark duplicates on as needed ) 
`-U` include supplementary reads in output ( mark as needed ) 