### PR TITLE
Bug Fix - SamRecordClipper.numBasesExtendingPastMate

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/bam/ClipBam.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ClipBam.scala
@@ -86,6 +86,7 @@ class ClipBam
   @arg(          doc="Require at least this number of bases to be clipped on the 3' end of R2") val readTwoThreePrime: Int = 0,
   @arg(          doc="Clip overlapping reads.") val clipOverlappingReads: Boolean = false,
   @arg(          doc="Clip reads in FR pairs that sequence past the far end of their mate.") val clipBasesPastMate: Boolean = false,
+  @arg(          doc="Clip bases past mate before clipping overlapping reads") val clipPastFirst: Boolean = false,
   @arg(flag='S', doc="The sort order of the output. If not given, output will be in the same order as input if the input.")
   val sortOrder: Option[SamOrder] = None
 ) extends FgBioTool with LazyLogging {
@@ -96,9 +97,8 @@ class ClipBam
   validate(upgradeClipping || clipOverlappingReads || clipBasesPastMate || Seq(readOneFivePrime, readOneThreePrime, readTwoFivePrime, readTwoThreePrime).exists(_ != 0),
     "At least one clipping option is required")
 
-  if (clipBasesPastMate && clipOverlappingReads) {
-    logger.info("Clipping overlapping reads supersedes clipping past the far end of their mate.")
-  }
+  validate(clipPastFirst && (clipBasesPastMate && clipOverlappingReads) || (! clipPastFirst),
+    "Both clipBasesPastMate & clipOverlappingReads must be passed if clipPastFirst is.")
 
   private val clipper = new SamRecordClipper(mode=clippingMode, autoClipAttributes=autoClipAttributes)
 
@@ -174,6 +174,10 @@ class ClipBam
   private[bam] def clipPair(r1: SamRecord, r2: SamRecord, r1Metric: Option[ClippingMetrics] = None, r2Metric: Option[ClippingMetrics] = None): Unit = {
     val priorBasesClippedReadOne = r1.cigar.clippedBases
     val priorBasesClippedReadTwo = r2.cigar.clippedBases
+    var numOverlappingBasesReadOne = 0
+    var numOverlappingBasesReadTwo = 0
+    var numExtendingPastMateStartReadOne = 0
+    var numExtendingPastMateStartReadTwo = 0
 
     // Clip the read!
     val numReadOneFivePrime  = this.clipper.clip5PrimeEndOfRead(r1, readOneFivePrime)
@@ -181,18 +185,27 @@ class ClipBam
     val numReadTwoFivePrime  = this.clipper.clip5PrimeEndOfRead(r2, readTwoFivePrime)
     val numReadTwoThreePrime = this.clipper.clip3PrimeEndOfRead(r2, readTwoThreePrime)
 
-    val (numOverlappingBasesReadOne, numOverlappingBasesReadTwo) = {
-      if (clipOverlappingReads && r1.isFrPair) this.clipper.clipOverlappingReads(r1, r2)
-      else (0, 0)
-    }
+    // This logic is more complex given the optional ordering possible.
+    if (clipPastFirst && clipBasesPastMate && r1.isFrPair) {
+      numExtendingPastMateStartReadOne = this.clipper.clipExtendingPastMateEnd(rec = r1, mateEnd = r2.end)
+      numExtendingPastMateStartReadTwo = this.clipper.clipExtendingPastMateEnd(rec = r2, mateEnd = r1.end)
 
-    val (numExtendingPastMateStartReadOne, numExtendingPastMateStartReadTwo) = {
-      if (clipBasesPastMate && r1.isFrPair) {
-        val clip1 = this.clipper.clipExtendingPastMateEnd(rec=r1, mateEnd=r2.end)
-        val clip2 = this.clipper.clipExtendingPastMateEnd(rec=r2, mateEnd=r1.end)
-        (clip1, clip2)
+      if (clipOverlappingReads && r1.isFrPair) {
+        val (overHolderR1, overHolderR2) = this.clipper.clipOverlappingReads(r1, r2)
+        numOverlappingBasesReadOne = overHolderR1
+        numOverlappingBasesReadTwo = overHolderR2
       }
-      else (0, 0)
+    }
+    else {
+      if (clipOverlappingReads && r1.isFrPair) {
+        val (overHolderR1, overHolderR2) = this.clipper.clipOverlappingReads(r1, r2)
+        numOverlappingBasesReadOne = overHolderR1
+        numOverlappingBasesReadTwo = overHolderR2
+      }
+      if (clipBasesPastMate && r1.isFrPair) {
+        numExtendingPastMateStartReadOne = this.clipper.clipExtendingPastMateEnd(rec = r1, mateEnd = r2.end)
+        numExtendingPastMateStartReadTwo = this.clipper.clipExtendingPastMateEnd(rec = r2, mateEnd = r1.end)
+      }
     }
 
     r1Metric.foreach { m =>

--- a/src/test/scala/com/fulcrumgenomics/bam/ClipBamTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/ClipBamTest.scala
@@ -549,6 +549,18 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
     r2.start shouldBe r1.end + 1
   }
 
+  it should "clip FR reads that extend past mate in asymmetrical read" in {
+    val builder = new SamBuilder(readLength = 200, sort = Some(Queryname))
+    val clipper = new ClipBam(input = dummyBam, output = dummyBam, ref = ref, clipBasesPastMate = true,
+      readTwoFivePrime = 50)
+    val Seq(r1, r2) = builder.addPair(start1 = 100, start2 = 90)
+
+    r1.end shouldBe 299
+    r2.end shouldBe 289
+    clipper.clipPair(r1, r2)
+    r2.end shouldBe r2.end
+  }
+
   it should "clip FR reads that extend past mate, and remove overlap in asymmetrical read" in {
     val builder = new SamBuilder(readLength = 200, sort = Some(Queryname))
     val clipper = new ClipBam(input = dummyBam, output = dummyBam, ref = ref, clipBasesPastMate = true,
@@ -558,10 +570,27 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
     r1.end shouldBe 299
     r2.end shouldBe 289
     clipper.clipPair(r1, r2)
+    r1.start shouldBe 100
     r2.start shouldBe r1.end + 1
+    r2.start shouldBe 170
+    r2.end shouldBe 239
   }
 
+  it should "clip FR reads that extend past mate, and remove overlap in asymmetrical read, " +
+    "should result in even length reads when clipPast first" in {
+    val builder = new SamBuilder(readLength = 200, sort = Some(Queryname))
+    val clipper = new ClipBam(input = dummyBam, output = dummyBam, ref = ref, clipBasesPastMate = true,
+      clipOverlappingReads = true, readTwoThreePrime = 50, clipPastFirst = true)
+    val Seq(r1, r2) = builder.addPair(start1 = 100, start2 = 90)
 
+    r1.end shouldBe 299
+    r2.end shouldBe 289
+    clipper.clipPair(r1, r2)
+    r1.start shouldBe 100
+    r2.start shouldBe r1.end + 1
+    r2.start shouldBe 195
+    r2.end shouldBe 289
+  }
 
 }
 

--- a/src/test/scala/com/fulcrumgenomics/bam/ClipBamTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/ClipBamTest.scala
@@ -578,7 +578,7 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
   }
 
   it should "clip FR reads that extend past mate, and remove overlap in asymmetrical read, " +
-    "should result in even length reads when clipPast first extreme" in {
+    "should result in even length reads extremely different" in {
     val builder = new SamBuilder(readLength = 200, sort = Some(Queryname))
     val clipper = new ClipBam(input = dummyBam, output = dummyBam, ref = ref, clipBasesPastMate = true,
       clipOverlappingReads = true, readTwoThreePrime = 175, readOneFivePrime = 25)

--- a/src/test/scala/com/fulcrumgenomics/bam/ClipBamTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/ClipBamTest.scala
@@ -49,7 +49,7 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
   private val dummyBam = makeTempFile("dummy.", ".bam")
 
   private object StartAndEnd {
-    def apply(r: SamRecord): StartAndEnd = StartAndEnd(start=r.start, end=r.end)
+    def apply(r: SamRecord): StartAndEnd = StartAndEnd(start = r.start, end = r.end)
   }
 
   private case class StartAndEnd(start: Int, end: Int) {
@@ -69,32 +69,33 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
   private case class StartsAndEnds(r1: SamRecord, r2: SamRecord) {
     private val prior1 = StartAndEnd(r1)
     private val prior2 = StartAndEnd(r2)
+
     // NB: assumes FR reads
     def checkClipping(r1: SamRecord, r2: SamRecord,
                       readOneFivePrime: Int, readOneThreePrime: Int,
                       readTwoFivePrime: Int, readTwoThreePrime: Int): Unit = {
-      prior1.checkClipping(r=r1, readOneFivePrime, readOneThreePrime)
-      prior2.checkClipping(r=r2, readTwoFivePrime, readTwoThreePrime)
+      prior1.checkClipping(r = r1, readOneFivePrime, readOneThreePrime)
+      prior2.checkClipping(r = r2, readTwoFivePrime, readTwoThreePrime)
     }
   }
 
   "ClipBam.clip" should "should fail when no clipping options are given" in {
-    an[Exception] should be thrownBy new ClipBam(input=dummyBam, output=dummyBam, ref=ref)
+    an[Exception] should be thrownBy new ClipBam(input = dummyBam, output = dummyBam, ref = ref)
   }
 
   it should "not clip reads where either read is unaligned" in {
-    val builder = new SamBuilder(readLength=50)
-    val clipper = new ClipBam(input=dummyBam, output=dummyBam, ref=ref, clipOverlappingReads=true)
-    val Seq(r1, r2) = builder.addPair(start1=100, start2=100, unmapped2=true)
+    val builder = new SamBuilder(readLength = 50)
+    val clipper = new ClipBam(input = dummyBam, output = dummyBam, ref = ref, clipOverlappingReads = true)
+    val Seq(r1, r2) = builder.addPair(start1 = 100, start2 = 100, unmapped2 = true)
     val expected = r1.cigar
     clipper.clipPair(r1, r2)
     r1.cigar shouldBe expected
   }
 
   it should "not clip reads that are on different chromosomes" in {
-    val builder = new SamBuilder(readLength=50)
-    val clipper = new ClipBam(input=dummyBam, output=dummyBam, ref=ref, clipOverlappingReads=true)
-    val Seq(r1, r2) = builder.addPair(start1=100, start2=100)
+    val builder = new SamBuilder(readLength = 50)
+    val clipper = new ClipBam(input = dummyBam, output = dummyBam, ref = ref, clipOverlappingReads = true)
+    val Seq(r1, r2) = builder.addPair(start1 = 100, start2 = 100)
     r2.refIndex = 1
     r1.mateRefIndex = 1
 
@@ -105,9 +106,9 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
   }
 
   it should "not clip reads that are abutting but not overlapped" in {
-    val builder = new SamBuilder(readLength=50)
-    val clipper = new ClipBam(input=dummyBam, output=dummyBam, ref=ref, clipOverlappingReads=true)
-    val Seq(r1, r2) = builder.addPair(start1=100, start2=150)
+    val builder = new SamBuilder(readLength = 50)
+    val clipper = new ClipBam(input = dummyBam, output = dummyBam, ref = ref, clipOverlappingReads = true)
+    val Seq(r1, r2) = builder.addPair(start1 = 100, start2 = 150)
 
     val (r1Exp, r2Exp) = (r1.cigar, r2.cigar)
     clipper.clipPair(r1, r2)
@@ -116,9 +117,9 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
   }
 
   it should "not clip non-FR reads " in {
-    val builder = new SamBuilder(readLength=50)
-    val clipper = new ClipBam(input=dummyBam, output=dummyBam, ref=ref, clipOverlappingReads=true)
-    val Seq(r1, r2) = builder.addPair(start1=100, start2=100, strand2=Plus)
+    val builder = new SamBuilder(readLength = 50)
+    val clipper = new ClipBam(input = dummyBam, output = dummyBam, ref = ref, clipOverlappingReads = true)
+    val Seq(r1, r2) = builder.addPair(start1 = 100, start2 = 100, strand2 = Plus)
 
     val (r1Exp, r2Exp) = (r1.cigar, r2.cigar)
     clipper.clipPair(r1, r2)
@@ -127,9 +128,9 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
   }
 
   it should "clip reads that are fully overlapped" in {
-    val builder = new SamBuilder(readLength=50)
-    val clipper = new ClipBam(input=dummyBam, output=dummyBam, ref=ref, clipOverlappingReads=true)
-    val Seq(r1, r2) = builder.addPair(start1=100, start2=100)
+    val builder = new SamBuilder(readLength = 50)
+    val clipper = new ClipBam(input = dummyBam, output = dummyBam, ref = ref, clipOverlappingReads = true)
+    val Seq(r1, r2) = builder.addPair(start1 = 100, start2 = 100)
 
     clipper.clipPair(r1, r2)
     r1.cigar.toString shouldBe "25M25H"
@@ -137,9 +138,9 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
   }
 
   it should "clip reads that are overlapped by just one base" in {
-    val builder = new SamBuilder(readLength=50)
-    val clipper = new ClipBam(input=dummyBam, output=dummyBam, ref=ref, clipOverlappingReads=true)
-    val Seq(r1, r2) = builder.addPair(start1=100, start2=149)
+    val builder = new SamBuilder(readLength = 50)
+    val clipper = new ClipBam(input = dummyBam, output = dummyBam, ref = ref, clipOverlappingReads = true)
+    val Seq(r1, r2) = builder.addPair(start1 = 100, start2 = 149)
 
     r1.end shouldBe r2.start
     clipper.clipPair(r1, r2)
@@ -147,9 +148,9 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
   }
 
   it should "handle reads that contain insertions" in {
-    val builder = new SamBuilder(readLength=50)
-    val clipper = new ClipBam(input=dummyBam, output=dummyBam, ref=ref, clipOverlappingReads=true)
-    val Seq(r1, r2) = builder.addPair(start1=100, start2=130, cigar1="40M2I8M", cigar2="10M2I38M")
+    val builder = new SamBuilder(readLength = 50)
+    val clipper = new ClipBam(input = dummyBam, output = dummyBam, ref = ref, clipOverlappingReads = true)
+    val Seq(r1, r2) = builder.addPair(start1 = 100, start2 = 130, cigar1 = "40M2I8M", cigar2 = "10M2I38M")
 
     r1.end >= r2.start shouldBe true
     clipper.clipPair(r1, r2)
@@ -157,9 +158,9 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
   }
 
   it should "handle reads that contain deletions" in {
-    val builder = new SamBuilder(readLength=50)
-    val clipper = new ClipBam(input=dummyBam, output=dummyBam, ref=ref, clipOverlappingReads=true)
-    val Seq(r1, r2) = builder.addPair(start1=100, start2=130, cigar1="40M2D10M", cigar2="10M2D40M")
+    val builder = new SamBuilder(readLength = 50)
+    val clipper = new ClipBam(input = dummyBam, output = dummyBam, ref = ref, clipOverlappingReads = true)
+    val Seq(r1, r2) = builder.addPair(start1 = 100, start2 = 130, cigar1 = "40M2D10M", cigar2 = "10M2D40M")
 
     r1.end >= r2.start shouldBe true
     clipper.clipPair(r1, r2)
@@ -167,10 +168,10 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
   }
 
   it should "clip a fixed amount on the ends of the reads with reads that do not overlap" in {
-    val builder = new SamBuilder(readLength=50)
-    val clipper = new ClipBam(input=dummyBam, output=dummyBam, ref=ref,
-      readOneFivePrime=1, readOneThreePrime=2, readTwoFivePrime=3, readTwoThreePrime=4)
-    val Seq(r1, r2) = builder.addPair(start1=100, start2=150)
+    val builder = new SamBuilder(readLength = 50)
+    val clipper = new ClipBam(input = dummyBam, output = dummyBam, ref = ref,
+      readOneFivePrime = 1, readOneThreePrime = 2, readTwoFivePrime = 3, readTwoThreePrime = 4)
+    val Seq(r1, r2) = builder.addPair(start1 = 100, start2 = 150)
 
     val prior = StartsAndEnds(r1, r2)
     r1.end shouldBe (r2.start - 1)
@@ -179,10 +180,10 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
   }
 
   it should "clip a fixed amount on the ends of the reads with reads with clipping present" in {
-    val builder = new SamBuilder(readLength=50)
-    val clipper = new ClipBam(input=dummyBam, output=dummyBam, ref=ref,
-      readOneFivePrime=5, readOneThreePrime=2, readTwoFivePrime=3, readTwoThreePrime=4)
-    val Seq(r1, r2) = builder.addPair(start1=104, start2=150)
+    val builder = new SamBuilder(readLength = 50)
+    val clipper = new ClipBam(input = dummyBam, output = dummyBam, ref = ref,
+      readOneFivePrime = 5, readOneThreePrime = 2, readTwoFivePrime = 3, readTwoThreePrime = 4)
+    val Seq(r1, r2) = builder.addPair(start1 = 104, start2 = 150)
 
     r1.cigar = "4H46M"
     r2.cigar = "44M6H"
@@ -198,10 +199,10 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
   }
 
   it should "clip a fixed amount on the ends of the reads then clip overlapping reads" in {
-    val builder = new SamBuilder(readLength=50)
-    val clipper = new ClipBam(input=dummyBam, output=dummyBam, ref=ref,
-      readOneFivePrime=0, readOneThreePrime=1, readTwoFivePrime=0, readTwoThreePrime=1, clipOverlappingReads=true)
-    val Seq(r1, r2) = builder.addPair(start1=100, start2=146)
+    val builder = new SamBuilder(readLength = 50)
+    val clipper = new ClipBam(input = dummyBam, output = dummyBam, ref = ref,
+      readOneFivePrime = 0, readOneThreePrime = 1, readTwoFivePrime = 0, readTwoThreePrime = 1, clipOverlappingReads = true)
+    val Seq(r1, r2) = builder.addPair(start1 = 100, start2 = 146)
 
     val prior = StartsAndEnds(r1, r2)
     r1.end shouldBe (r2.start + 3) // four bases overlap!
@@ -213,10 +214,10 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
   Seq(Plus, Minus).foreach { strand1 =>
     Seq(Plus, Minus).foreach { strand2 =>
       it should s"clip a fixed amount on the ends of the reads in $strand1/$strand2" in {
-        val builder = new SamBuilder(readLength=50)
-        val clipper = new ClipBam(input=dummyBam, output=dummyBam, ref=ref,
-          readOneFivePrime=1, readOneThreePrime=2, readTwoFivePrime=3, readTwoThreePrime=4)
-        val Seq(r1, r2) = builder.addPair(start1=100, start2=150, strand1=strand1, strand2=strand2)
+        val builder = new SamBuilder(readLength = 50)
+        val clipper = new ClipBam(input = dummyBam, output = dummyBam, ref = ref,
+          readOneFivePrime = 1, readOneThreePrime = 2, readTwoFivePrime = 3, readTwoThreePrime = 4)
+        val Seq(r1, r2) = builder.addPair(start1 = 100, start2 = 150, strand1 = strand1, strand2 = strand2)
 
         val prior = StartsAndEnds(r1, r2)
         r1.end shouldBe (r2.start - 1)
@@ -227,13 +228,13 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
   }
 
   "ClippingMetrics.add" should "add two metrics" in {
-    val fragment = ClippingMetrics(ReadType.Fragment, 1, 2,  3,  4,  5,  6, 7,  8,   9, 10, 11, 12, 13, 14, 15)
-    val readOne  = ClippingMetrics(ReadType.ReadTwo,  2, 3,  4,  5,  6,  7, 8,  9,  10, 11, 12, 13, 14, 15, 16)
-    val readTwo  = ClippingMetrics(ReadType.ReadTwo,  3, 4,  5,  6,  7,  8, 9,  10, 11, 12, 13, 14, 15, 16, 17)
-    val all      = ClippingMetrics(ReadType.All,      6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45, 48)
+    val fragment = ClippingMetrics(ReadType.Fragment, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+    val readOne = ClippingMetrics(ReadType.ReadTwo, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
+    val readTwo = ClippingMetrics(ReadType.ReadTwo, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17)
+    val all = ClippingMetrics(ReadType.All, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45, 48)
 
     // Check that adding fragment, readOne, and readTwo is correct
-    val added    = ClippingMetrics(ReadType.All)
+    val added = ClippingMetrics(ReadType.All)
     added.add(fragment, readOne, readTwo)
     added.productIterator.toSeq should contain theSameElementsInOrderAs all.productIterator.toSeq
 
@@ -243,32 +244,32 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
 
   "ClipBam" should "clip overlapping reads, update mate info, and reset NM, UQ & MD" in {
     val random = new Random(1)
-    val builder = new SamBuilder(readLength=50, sort=Some(Queryname))
-    builder.addPair(name="q1", start1=100, start2=140) // overlaps by ten
-    builder.addPair(name="q2", start1=200, start2=242) // overlaps by eight
-    builder.addPair(name="q3", start1=300, start2=344) // overlaps by six
-    builder.addPair(name="q4", start1=400, start2=446) // overlaps by four
-    builder.addPair(name="q5", start1=500, start2=548) // overlaps by two
-    builder.addPair(name="q6", start1=600, start2=650) // does not overlap
+    val builder = new SamBuilder(readLength = 50, sort = Some(Queryname))
+    builder.addPair(name = "q1", start1 = 100, start2 = 140) // overlaps by ten
+    builder.addPair(name = "q2", start1 = 200, start2 = 242) // overlaps by eight
+    builder.addPair(name = "q3", start1 = 300, start2 = 344) // overlaps by six
+    builder.addPair(name = "q4", start1 = 400, start2 = 446) // overlaps by four
+    builder.addPair(name = "q5", start1 = 500, start2 = 548) // overlaps by two
+    builder.addPair(name = "q6", start1 = 600, start2 = 650) // does not overlap
 
     // Set appropriate bases and tags on each read
     val refFile = ReferenceSequenceFileFactory.getReferenceSequenceFile(ref)
-    val chr1    = refFile.nextSequence().getBases
+    val chr1 = refFile.nextSequence().getBases
     builder.iterator.foreach { r =>
       val bases = ("A" * 50).getBytes
-      val n     = random.nextInt(50)
-      bases(n)  = 'C'
+      val n = random.nextInt(50)
+      bases(n) = 'C'
       r.bases = bases
       SequenceUtil.calculateMdAndNmTags(r.asSam, chr1, true, true)
       r(SAMTag.UQ.name) = SequenceUtil.sumQualitiesOfMismatches(r.asSam, chr1, 0)
     }
 
-    val out        = makeTempFile("out.", ".bam")
+    val out = makeTempFile("out.", ".bam")
     val metricsOut = makeTempFile("out.", ".txt")
     new ClipBam(
-      input=builder.toTempFile(), output=out, metrics=Some(metricsOut), ref=ref,
-      readOneFivePrime=2, readOneThreePrime=0, readTwoFivePrime=3, readTwoThreePrime=0,
-      clipOverlappingReads=true
+      input = builder.toTempFile(), output = out, metrics = Some(metricsOut), ref = ref,
+      readOneFivePrime = 2, readOneThreePrime = 0, readTwoFivePrime = 3, readTwoThreePrime = 0,
+      clipOverlappingReads = true
     ).execute()
     val clipped = SamSource(out).toSeq
 
@@ -281,11 +282,11 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
     clipped.filterNot(_.negativeStrand).count(_.cigar.head.toString == "2H") shouldBe 6
 
     // Check that everything is in coordinate order
-    clipped.sliding(2).foreach { case Seq(lhs, rhs) => lhs.start <= rhs.start shouldBe true}
+    clipped.sliding(2).foreach { case Seq(lhs, rhs) => lhs.start <= rhs.start shouldBe true }
 
     // Validate that mate information didn't get mangled
     clipped.groupBy(_.name).values.foreach { case Seq(lhs, rhs) =>
-      for ((a,b) <- Seq((lhs, rhs), (rhs, lhs))) {
+      for ((a, b) <- Seq((lhs, rhs), (rhs, lhs))) {
         a.mateStart shouldBe b.start
         a.mateNegativeStrand shouldBe b.negativeStrand
         a[String]("MC") shouldBe b.cigar.toString()
@@ -305,12 +306,12 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
     }
 
     val metrics = Metric.read[ClippingMetrics](metricsOut)
-    val pair = ClippingMetrics(read_type=ReadType.Pair)
-    pair.add(metrics.filter(m => m.read_type == ReadType.ReadOne || m.read_type == ReadType.ReadTwo):_*)
-    val all = pair.copy(read_type=ReadType.All)
+    val pair = ClippingMetrics(read_type = ReadType.Pair)
+    pair.add(metrics.filter(m => m.read_type == ReadType.ReadOne || m.read_type == ReadType.ReadTwo): _*)
+    val all = pair.copy(read_type = ReadType.All)
     metrics.foreach {
       case metric if metric.read_type == ReadType.Fragment =>
-        metric shouldBe ClippingMetrics(read_type=ReadType.Fragment)
+        metric shouldBe ClippingMetrics(read_type = ReadType.Fragment)
       case metric if metric.read_type == ReadType.ReadOne =>
         metric.reads shouldBe 6
         metric.reads_unmapped shouldBe 0
@@ -348,29 +349,29 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
 
   it should "clip fragment reads, and reset NM, UQ & MD" in {
     val random = new Random(1)
-    val builder = new SamBuilder(readLength=50, sort=Some(Queryname))
-    builder.addFrag(start=100)
-    builder.addFrag(start=200, strand=Minus)
-    builder.addFrag(start=300, cigar="40S10M") // should be fully clipped
+    val builder = new SamBuilder(readLength = 50, sort = Some(Queryname))
+    builder.addFrag(start = 100)
+    builder.addFrag(start = 200, strand = Minus)
+    builder.addFrag(start = 300, cigar = "40S10M") // should be fully clipped
 
     // Set appropriate bases and tags on each read
     val refFile = ReferenceSequenceFileFactory.getReferenceSequenceFile(ref)
-    val chr1    = refFile.nextSequence().getBases
+    val chr1 = refFile.nextSequence().getBases
     builder.iterator.foreach { r =>
       val bases = ("A" * 50).getBytes
-      val n     = random.nextInt(50)
-      bases(n)  = 'C'
+      val n = random.nextInt(50)
+      bases(n) = 'C'
       r.bases = bases
       SequenceUtil.calculateMdAndNmTags(r.asSam, chr1, true, true)
       r(SAMTag.UQ.name) = SequenceUtil.sumQualitiesOfMismatches(r.asSam, chr1, 0)
     }
 
-    val out     = makeTempFile("out.", ".bam")
+    val out = makeTempFile("out.", ".bam")
     val metrics = makeTempFile("out.", ".txt")
     new ClipBam(
-      input=builder.toTempFile(), output=out, metrics=Some(metrics), ref=ref,
-      readOneFivePrime=2, readOneThreePrime=10, readTwoFivePrime=5, readTwoThreePrime=5, // read two info will be ignored
-      clipOverlappingReads=true // overlapping will be ignored
+      input = builder.toTempFile(), output = out, metrics = Some(metrics), ref = ref,
+      readOneFivePrime = 2, readOneThreePrime = 10, readTwoFivePrime = 5, readTwoThreePrime = 5, // read two info will be ignored
+      clipOverlappingReads = true // overlapping will be ignored
     ).execute()
     val clipped = SamSource(out).toSeq
 
@@ -412,7 +413,7 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
         metric.bases_clipped_three_prime shouldBe 30 // 10*3
         metric.bases_clipped_overlapping shouldBe 0
       case metric if metric.read_type == ReadType.ReadOne | metric.read_type == ReadType.ReadTwo | metric.read_type == ReadType.Pair =>
-        metric shouldBe ClippingMetrics(read_type=metric.read_type)
+        metric shouldBe ClippingMetrics(read_type = metric.read_type)
     }
   }
 
@@ -423,13 +424,13 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
 
   Seq((Soft, SoftWithMask), (Soft, Hard), (SoftWithMask, Hard)).foreach { case (prior, mode) =>
     it should s"upgrade existing clipping from $prior to $mode with --upgrade-clipping" in {
-      val builder = new SamBuilder(readLength=50, sort=Some(Queryname))
-      val frag1 = builder.addFrag(name="q1", start=100).value
-      val frag2 = builder.addFrag(name="q2", start=200, strand=Minus).value
+      val builder = new SamBuilder(readLength = 50, sort = Some(Queryname))
+      val frag1 = builder.addFrag(name = "q1", start = 100).value
+      val frag2 = builder.addFrag(name = "q2", start = 200, strand = Minus).value
 
       // clip them
-      val softClipper = new SamRecordClipper(mode=prior, autoClipAttributes=true)
-      val priorClipper = new SamRecordClipper(mode=prior, autoClipAttributes=true)
+      val softClipper = new SamRecordClipper(mode = prior, autoClipAttributes = true)
+      val priorClipper = new SamRecordClipper(mode = prior, autoClipAttributes = true)
       Seq(frag1, frag2).foreach { frag =>
         // always soft-clip bases of soft at the start and end
         softClipper.clip5PrimeEndOfRead(frag, 10) shouldBe 10
@@ -439,9 +440,9 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
         priorClipper.clip3PrimeEndOfRead(frag, 2) shouldBe 0
       }
 
-      val out     = makeTempFile("out.", ".bam")
+      val out = makeTempFile("out.", ".bam")
       val metrics = makeTempFile("out.", ".txt")
-      new ClipBam(input=builder.toTempFile(), output=out, metrics=Some(metrics), ref=ref, clippingMode=mode, upgradeClipping=true).execute()
+      new ClipBam(input = builder.toTempFile(), output = out, metrics = Some(metrics), ref = ref, clippingMode = mode, upgradeClipping = true).execute()
       val clipped = SamSource(out).toSeq
 
       clipped.length shouldBe 2
@@ -468,20 +469,20 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
 
   Seq((Soft, Soft), (SoftWithMask, Soft), (SoftWithMask, SoftWithMask), (Hard, Hard), (Hard, SoftWithMask), (Hard, Soft)).foreach { case (prior, mode) =>
     it should s"not upgrade existing clipping from $prior to $mode with --upgrade-clipping" in {
-      val builder = new SamBuilder(readLength=50, sort=Some(Queryname))
-      val frag1 = builder.addFrag(name="q1", start=100).value
-      val frag2 = builder.addFrag(name="q2", start=200, strand=Minus).value
+      val builder = new SamBuilder(readLength = 50, sort = Some(Queryname))
+      val frag1 = builder.addFrag(name = "q1", start = 100).value
+      val frag2 = builder.addFrag(name = "q2", start = 200, strand = Minus).value
 
       // Clip some bases based on the "prior" mode
-      val priorClipper = new SamRecordClipper(mode=prior, autoClipAttributes=true)
+      val priorClipper = new SamRecordClipper(mode = prior, autoClipAttributes = true)
       Seq(frag1, frag2).foreach { frag =>
         priorClipper.clip5PrimeEndOfRead(frag, 10) shouldBe 10
         priorClipper.clip3PrimeEndOfRead(frag, 4) shouldBe 4
       }
 
-      val out     = makeTempFile("out.", ".bam")
+      val out = makeTempFile("out.", ".bam")
       val metrics = makeTempFile("out.", ".txt")
-      new ClipBam(input=builder.toTempFile(), output=out, metrics=Some(metrics), ref=ref, clippingMode=mode, upgradeClipping=true).execute()
+      new ClipBam(input = builder.toTempFile(), output = out, metrics = Some(metrics), ref = ref, clippingMode = mode, upgradeClipping = true).execute()
       val clipped = SamSource(out).toSeq
 
       clipped.length shouldBe 2
@@ -513,14 +514,54 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
   }
 
   it should "clip FR reads that extend past the mate" in {
-    val builder = new SamBuilder(readLength=50, sort=Some(Queryname))
-    val clipper = new ClipBam(input=dummyBam, output=dummyBam, ref=ref, clipBasesPastMate=true)
-    val Seq(r1, r2) = builder.addPair(start1=100, start2=90)
+    val builder = new SamBuilder(readLength = 100, sort = Some(Queryname))
+    val clipper = new ClipBam(input = dummyBam, output = dummyBam, ref = ref, clipBasesPastMate = true)
+    val Seq(r1, r2) = builder.addPair(start1 = 100, start2 = 90)
 
-    r1.end shouldBe 149
-    r2.end shouldBe 139
+    r1.end shouldBe 199
+    r2.end shouldBe 189
     clipper.clipPair(r1, r2)
-    r1.start shouldBe r2.start
+    r2.start shouldBe r1.start
     r1.end shouldBe r2.end
   }
+
+  it should "clip FR reads that extend past mate, when fixed trimming is applied" in {
+    val builder = new SamBuilder(readLength = 100, sort = Some(Queryname))
+    val clipper = new ClipBam(input = dummyBam, output = dummyBam, ref = ref, clipBasesPastMate = true, readTwoFivePrime = 20)
+    val Seq(r1, r2) = builder.addPair(start1 = 100, start2 = 90)
+
+    r1.end shouldBe 199
+    r2.end shouldBe 189
+    clipper.clipPair(r1, r2)
+    r2.start shouldBe r1.start
+    r1.end shouldBe r2.end
+  }
+
+  it should "clip FR reads that extend past mate, and remove overlap" in {
+    val builder = new SamBuilder(readLength = 100, sort = Some(Queryname))
+    val clipper = new ClipBam(input = dummyBam, output = dummyBam, ref = ref, clipBasesPastMate = true,
+      clipOverlappingReads = true)
+    val Seq(r1, r2) = builder.addPair(start1 = 100, start2 = 90)
+
+    r1.end shouldBe 199
+    r2.end shouldBe 189
+    clipper.clipPair(r1, r2)
+    r2.start shouldBe r1.end + 1
+  }
+
+  it should "clip FR reads that extend past mate, and remove overlap in asymmetrical read" in {
+    val builder = new SamBuilder(readLength = 200, sort = Some(Queryname))
+    val clipper = new ClipBam(input = dummyBam, output = dummyBam, ref = ref, clipBasesPastMate = true,
+      clipOverlappingReads = true, readTwoFivePrime = 50)
+    val Seq(r1, r2) = builder.addPair(start1 = 100, start2 = 90)
+
+    r1.end shouldBe 299
+    r2.end shouldBe 289
+    clipper.clipPair(r1, r2)
+    r2.start shouldBe r1.end + 1
+  }
+
+
+
 }
+

--- a/src/test/scala/com/fulcrumgenomics/bam/ClipBamTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/ClipBamTest.scala
@@ -552,35 +552,20 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
   it should "clip FR reads that extend past mate in asymmetrical read" in {
     val builder = new SamBuilder(readLength = 200, sort = Some(Queryname))
     val clipper = new ClipBam(input = dummyBam, output = dummyBam, ref = ref, clipBasesPastMate = true,
-      readTwoFivePrime = 50)
+      readTwoFivePrime = 50, readOneFivePrime = 10)
     val Seq(r1, r2) = builder.addPair(start1 = 100, start2 = 90)
 
     r1.end shouldBe 299
     r2.end shouldBe 289
     clipper.clipPair(r1, r2)
     r2.end shouldBe r2.end
+    r1.start shouldBe r2.start
   }
 
   it should "clip FR reads that extend past mate, and remove overlap in asymmetrical read" in {
     val builder = new SamBuilder(readLength = 200, sort = Some(Queryname))
     val clipper = new ClipBam(input = dummyBam, output = dummyBam, ref = ref, clipBasesPastMate = true,
-      clipOverlappingReads = true, readTwoFivePrime = 50)
-    val Seq(r1, r2) = builder.addPair(start1 = 100, start2 = 90)
-
-    r1.end shouldBe 299
-    r2.end shouldBe 289
-    clipper.clipPair(r1, r2)
-    r1.start shouldBe 100
-    r2.start shouldBe r1.end + 1
-    r2.start shouldBe 170
-    r2.end shouldBe 239
-  }
-
-  it should "clip FR reads that extend past mate, and remove overlap in asymmetrical read, " +
-    "should result in even length reads when clipPast first" in {
-    val builder = new SamBuilder(readLength = 200, sort = Some(Queryname))
-    val clipper = new ClipBam(input = dummyBam, output = dummyBam, ref = ref, clipBasesPastMate = true,
-      clipOverlappingReads = true, readTwoThreePrime = 50, clipPastFirst = true)
+      clipOverlappingReads = true, readTwoThreePrime = 50)
     val Seq(r1, r2) = builder.addPair(start1 = 100, start2 = 90)
 
     r1.end shouldBe 299
@@ -589,6 +574,22 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
     r1.start shouldBe 100
     r2.start shouldBe r1.end + 1
     r2.start shouldBe 195
+    r2.end shouldBe 289
+  }
+
+  it should "clip FR reads that extend past mate, and remove overlap in asymmetrical read, " +
+    "should result in even length reads when clipPast first extreme" in {
+    val builder = new SamBuilder(readLength = 200, sort = Some(Queryname))
+    val clipper = new ClipBam(input = dummyBam, output = dummyBam, ref = ref, clipBasesPastMate = true,
+      clipOverlappingReads = true, readTwoThreePrime = 175, readOneFivePrime = 25)
+    val Seq(r1, r2) = builder.addPair(start1 = 140, start2 = 90)
+
+    r1.end shouldBe 339
+    r2.end shouldBe 289
+    clipper.clipPair(r1, r2)
+    r1.start shouldBe 165
+    r2.start shouldBe r1.end + 1
+    r2.start shouldBe 265
     r2.end shouldBe 289
   }
 

--- a/src/test/scala/com/fulcrumgenomics/bam/ClipBamTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/ClipBamTest.scala
@@ -417,10 +417,10 @@ class ClipBamTest extends UnitSpec with ErrorLogLevel with OptionValues {
     }
   }
 
-  private def clipBases(rec: SamRecord, left: Int, right: Int): String = rec.basesString.slice(left, rec.length-right)
-  private def clipQuals(rec: SamRecord, left: Int, right: Int): String = rec.qualsString.slice(left, rec.length-right)
-  private def maskBases(rec: SamRecord, left: Int, right: Int): String = "N"*left + clipBases(rec, left, right) + "N"*right
-  private def maskQuals(rec: SamRecord, left: Int, right: Int): String = "#"*left + clipQuals(rec, left, right) + "#"*right
+  private def clipBases(rec: SamRecord, left: Int, right: Int): String = rec.basesString.slice(left, rec.length - right)
+  private def clipQuals(rec: SamRecord, left: Int, right: Int): String = rec.qualsString.slice(left, rec.length - right)
+  private def maskBases(rec: SamRecord, left: Int, right: Int): String = "N" * left + clipBases(rec, left, right) + "N" * right
+  private def maskQuals(rec: SamRecord, left: Int, right: Int): String = "#" * left + clipQuals(rec, left, right) + "#" * right
 
   Seq((Soft, SoftWithMask), (Soft, Hard), (SoftWithMask, Hard)).foreach { case (prior, mode) =>
     it should s"upgrade existing clipping from $prior to $mode with --upgrade-clipping" in {


### PR DESCRIPTION
@nh13 @tfenne 

When operating on SamRecords with multiple serialized operations, use of mate cigar record information is relied upon for clipping past mate end, but it is not synchronized between operations with it's corresponding SamRecord object's data.

This results in an inconsistent data model for clipping.

With previous code this test case would fail.

```
it should "clip FR reads that extend past mate in asymmetrical read" in {
    val builder = new SamBuilder(readLength = 200, sort = Some(Queryname))
    val clipper = new ClipBam(input = dummyBam, output = dummyBam, ref = ref, clipBasesPastMate = true,
      readTwoFivePrime = 50, readOneFivePrime = 10)
    val Seq(r1, r2) = builder.addPair(start1 = 100, start2 = 90)

    r1.end shouldBe 299
    r2.end shouldBe 289
    clipper.clipPair(r1, r2)
    r2.end shouldBe r2.end
    r1.start shouldBe r2.start
  }
```

It would erroneously calculate r2.start == 100 & r1.start != r2.start, because the mate.start data from the MC tag was used, which was not updated with the 5' clipping from the first operation. 

https://github.com/fulcrumgenomics/fgbio/blob/2af51acea8cd55fbc393ce435b5b13d7a32fc9ae/src/main/scala/com/fulcrumgenomics/bam/SamRecordClipper.scala#L358

This reliance on a possibly dirty MC tag is the cause of this #878 inconsistent behavior. I believe this fix, makes this issue irrelevant & it certainly might fix some other oddities that people seem to have pointed out.

I've removed convenience functions which allow this to happen, and enforce either explicit passing of mates or start / end. 

I do this rather than updating the MC record, because that extra step between each operation doesn't seem worthwhile, when we have the object loaded in memory already, the tags should be updated after all operations are complete a single time.

The exception to this is a single method which is used in consensus calling, where mate isn't easily available - this pattern still requires getting from mate cigar, which might still result in this bug occurring, as each mate could have clipping applied but again the data isn't synchronized to the MC tag.

I'll also work on that bug also, which I believe should be handled by operating on mates together, so all relevant data is loaded in memory explicitly, rather than using the tag.

As a sidenote: I don't understand the white space formatting rules for the project, do you happen to have an intellj profile i could use to keep these consistent for your formatting? 