### PR TITLE
Fix reference to transient MI tag in DuplexConsensusCaller

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/DuplexConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/DuplexConsensusCaller.scala
@@ -128,7 +128,7 @@ class DuplexConsensusCaller(override val readNamePrefix: String,
     */
   private def sourceMoleculeAndStrandId(rec: SamRecord): String = {
     // Optimization: speed up retrieving this tag by storing it in the transient attributes
-    rec.transientAttrs.get[String](ConsensusTags) match {
+    rec.transientAttrs.get[String](ConsensusTags.MolecularId) match {
       case Some(mi) => mi
       case None =>
         rec.get[String](ConsensusTags.MolecularId) match {


### PR DESCRIPTION
@nh13 I'm pretty sure this is what you meant in https://github.com/fulcrumgenomics/fgbio/pull/493?

I haven't done any benchmarking, but maybe this PR is a free speed-up!