### PR TITLE
PileupBuilder should not report insertions when checking the final mapped base before soft-clipping

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/bam/pileup/PileupBuilder.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/pileup/PileupBuilder.scala
@@ -215,8 +215,8 @@ trait PileupBuilder extends PileupParameters {
             testAndAdd(DeletionEntry(rec, deletionPosition - 1))
           } else { // This site must be a matched site within the read.
             testAndAdd(BaseEntry(rec, offset - 1))
-            // Also check to see if the subsequent base represents an insertion.
-            if (offset < rec.length - 1 && rec.refPosAtReadPos(offset + 1) == 0) testAndAdd(InsertionEntry(rec, offset))
+            // Also check to see if any subsequent base represents an insertion.
+            if (rec.end > pos && rec.refPosAtReadPos(offset + 1) == 0) testAndAdd(InsertionEntry(rec, offset))
           }
         }
       }

--- a/src/test/scala/com/fulcrumgenomics/bam/pileup/PileupBuilderTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/pileup/PileupBuilderTest.scala
@@ -171,13 +171,19 @@ class PileupBuilderTest extends UnitSpec {
       p4.iterator.collect{ case x: InsertionEntry => x }.map(_.rec.name).next() shouldBe "q5"
       p4.baseIterator.toSeq should contain theSameElementsAs p4.withoutIndels.iterator.toSeq
 
-      // Locus with the end of a read that is soft-clipped
+      // Locus with the remainder of a read that is soft-clipped
       val p5 = piler.pileup(Chr1, 247)
       p5.depth shouldBe 1
-      p5.iterator.size shouldBe 1 // should not report an insertion due to the remaining bases
+      p5.iterator.size shouldBe 1 // should not report an insertion due to the remaining soft-clipped bases
       p5.baseIterator.size shouldBe 1
       p5.baseIterator.toSeq should contain theSameElementsAs p5.withoutIndels.iterator.toSeq
 
+      // Locus at the site of a single read that is soft-clipped
+      val p6 = piler.pileup(Chr1, 248)
+      p6.depth shouldBe 0
+      p6.iterator.size shouldBe 0
+      p6.baseIterator.size shouldBe 0
+      p6.baseIterator.toSeq should contain theSameElementsAs p5.withoutIndels.iterator.toSeq
       source.safelyClose()
       piler.safelyClose()
     }

--- a/src/test/scala/com/fulcrumgenomics/bam/pileup/PileupBuilderTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/pileup/PileupBuilderTest.scala
@@ -183,7 +183,7 @@ class PileupBuilderTest extends UnitSpec {
       p6.depth shouldBe 0
       p6.iterator.size shouldBe 0
       p6.baseIterator.size shouldBe 0
-      p6.baseIterator.toSeq should contain theSameElementsAs p5.withoutIndels.iterator.toSeq
+      p6.baseIterator.toSeq should contain theSameElementsAs p6.withoutIndels.iterator.toSeq
       source.safelyClose()
       piler.safelyClose()
     }

--- a/src/test/scala/com/fulcrumgenomics/bam/pileup/PileupBuilderTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/pileup/PileupBuilderTest.scala
@@ -127,6 +127,7 @@ class PileupBuilderTest extends UnitSpec {
       builder.addFrag(name = "q3", start = 101, cigar = "31M9I10M").foreach(_.bases = "G" * ReadLength)
       builder.addFrag(name = "q4", start = 101, cigar = "30M9D20M").foreach(_.bases = "T" * ReadLength)
       builder.addFrag(name = "q5", start = 141, cigar = "10I40M"  ).foreach(_.bases = "N" * ReadLength)
+      builder.addFrag(name = "q6", start = 201, cigar = "47M3S"   ).foreach(_.bases = "N" * ReadLength)
 
       val source = builder.toSource
       val piler  = PileupBuilder(source, accessPattern = accessPattern, mappedPairsOnly = false)
@@ -169,6 +170,13 @@ class PileupBuilderTest extends UnitSpec {
       p4.baseIterator.map(_.base.toChar).toSeq.sorted.mkString shouldBe "ACGT"
       p4.iterator.collect{ case x: InsertionEntry => x }.map(_.rec.name).next() shouldBe "q5"
       p4.baseIterator.toSeq should contain theSameElementsAs p4.withoutIndels.iterator.toSeq
+
+      // Locus with the end of a read that is soft-clipped
+      val p5 = piler.pileup(Chr1, 247)
+      p5.depth shouldBe 1
+      p5.iterator.size shouldBe 1 // should not report an insertion due to the remaining bases
+      p5.baseIterator.size shouldBe 1
+      p5.baseIterator.toSeq should contain theSameElementsAs p5.withoutIndels.iterator.toSeq
 
       source.safelyClose()
       piler.safelyClose()


### PR DESCRIPTION
I was using the PileupBuilder and ran into an error when attempting to collect an insertion sequence:

```
case entry: InsertionEntry if entry.rec.start < pos  =>
  // Get insertion bases
  val insStart     = entry.rec.readPosAtRefPos(pos, returnLastBaseIfDeleted = true)
  val insEnd       = entry.rec.readPosAtRefPos(pos + 1, returnLastBaseIfDeleted = true)
  val alleleString = entry.rec.basesString.substring(insStart - 1, insEnd - 1)
```

The call to `substring` failed because `insEnd` was `0`.

I tracked this down to the `PileupBuilder` making an incorrect check. `rec.length` includes soft-clipped bases, so checking `offset < rec.length - 1` will always be true at a pileup for the last mapped base as long as there is at least 1 soft-clipped base. The second half of the check (`rec.refPosAtReadPos(offset + 1)`) will also be true, but for the wrong reason (it's soft-clipped, not an insertion).

I shoehorned in a test where it seems appropriate.