### PR TITLE
GroupReadsByUmi may fail when marking duplicates including secondary/supplementary reads

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/alignment/Alignment.scala
+++ b/src/main/scala/com/fulcrumgenomics/alignment/Alignment.scala
@@ -208,7 +208,7 @@ case class Cigar(elems: IndexedSeq[CigarElem]) extends Iterable[CigarElem] {
   def trailingSoftClippedBases: Int = stats.trailingSoftClippedBases
 
   /** Returns the number of bases that are hard-clipped at the start of the sequence. */
-  def leadingHardClippedBases = this.headOption.map { elem =>
+  def leadingHardClippedBases: Int = this.headOption.map { elem =>
     if (elem.operator == CigarOperator.H) elem.length else 0
   }.getOrElse(0)
 
@@ -216,12 +216,22 @@ case class Cigar(elems: IndexedSeq[CigarElem]) extends Iterable[CigarElem] {
   def leadingClippedBases: Int = leadingHardClippedBases + leadingSoftClippedBases
 
   /** Returns the number of bases that are hard-clipped at the end of the sequence. */
-  def trailingHardClippedBases = this.lastOption.map { elem =>
+  def trailingHardClippedBases: Int = this.lastOption.map { elem =>
     if (elem.operator == CigarOperator.H) elem.length else 0
   }.getOrElse(0)
 
   /** Returns the number of bases that are clipped at the end of the sequence. */
   def trailingClippedBases: Int = trailingHardClippedBases + trailingSoftClippedBases
+
+  /** Returns the alignment start position adjusted for leading soft and hard clipped bases. */
+  def unclippedStart(start: Int): Int = {
+    start - this.iterator.takeWhile(_.operator.isClipping).map(_.length).sum
+  }
+
+  /** Returns the alignment end position adjusted for trailing soft and hard clipped bases. */
+  def unclippedEnd(end: Int): Int = {
+    end + this.reverseIterator.takeWhile(_.operator.isClipping).map(_.length).sum
+  }
 
   /** Truncates the cigar based on either query or target length cutoff. */
   private def truncate(len: Int, shouldCount: CigarElem => Boolean): Cigar = {

--- a/src/main/scala/com/fulcrumgenomics/bam/Bams.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/Bams.scala
@@ -58,9 +58,8 @@ private[bam] case class AlignmentInfo(refIndex: Int, start: Int, positiveStrand:
   /** Returns a formatted alignment as per the SA tag: `(rname ,pos ,strand ,CIGAR ,mapQ ,NM ;)+` */
   def toSA(header: SAMFileHeader): String = {
     val strand  = if (positiveStrand) '+' else '-'
-    val refName = header.getSequence(refIndex).getSequenceName
     val cigar   = this.cigar.getOrElse("*")
-    f"${refName},${start},${strand},${cigar},${mapq},${nm}"
+    f"${refName(header)},${start},${strand},${cigar},${mapq},${nm}"
   }
 }
 

--- a/src/main/scala/com/fulcrumgenomics/bam/api/SamOrder.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/api/SamOrder.scala
@@ -24,11 +24,14 @@
 
 package com.fulcrumgenomics.bam.api
 
+import com.fulcrumgenomics.bam.{Bams, Supplementary}
 import com.fulcrumgenomics.umi.ConsensusTags
 import htsjdk.samtools.SAMFileHeader.{GroupOrder, SortOrder}
 import htsjdk.samtools.util.Murmur3
 import htsjdk.samtools.{SAMFileHeader, SAMUtils}
 import org.apache.commons.math3.genetics.RandomKey
+
+import scala.reflect.runtime.universe.Template
 
 
 /** Trait for specifying BAM orderings. */
@@ -175,24 +178,50 @@ object SamOrder {
     override val groupOrder: GroupOrder     = GroupOrder.query
     override val subSort:    Option[String] = Some("template-coordinate")
     override val sortkey: SamRecord => A = rec => {
-      val readChrom = if (rec.unmapped)     Int.MaxValue else rec.refIndex
-      val mateChrom = if (rec.unpaired || rec.mateUnmapped) Int.MaxValue else rec.mateRefIndex
-      val readNeg   = rec.negativeStrand
-      val mateNeg   = if (rec.paired) rec.mateNegativeStrand else false
-      val readPos   = if (rec.unmapped)     Int.MaxValue else if (readNeg) rec.unclippedEnd else rec.unclippedStart
-      val matePos   = if (rec.unpaired || rec.mateUnmapped) Int.MaxValue else if (mateNeg) SAMUtils.getMateUnclippedEnd(rec.asSam) else SAMUtils.getMateUnclippedStart(rec.asSam)
-      val lib       = Option(rec.readGroup).flatMap(rg => Option(rg.getLibrary)).getOrElse("Unknown")
-      val mid       = rec.get[String](ConsensusTags.MolecularId).map { m =>
-        val index: Int = m.lastIndexOf('/')
-        if (index >= 0) m.substring(0, index) else m
-      }.getOrElse("")
+      // For non-secondary/non-supplementary alignments, use the info in the record.  For secondary and supplementary
+      // alignments, use the info in the pa/pm tags.
+      if (!rec.secondary && !rec.supplementary) {
+        val readChrom = if (rec.unmapped)     Int.MaxValue else rec.refIndex
+        val mateChrom = if (rec.unpaired || rec.mateUnmapped) Int.MaxValue else rec.mateRefIndex
+        val readNeg   = rec.negativeStrand
+        val mateNeg   = if (rec.paired) rec.mateNegativeStrand else false
+        val readPos   = if (rec.unmapped)     Int.MaxValue else if (readNeg) rec.unclippedEnd else rec.unclippedStart
+        val matePos   = if (rec.unpaired || rec.mateUnmapped) Int.MaxValue else if (mateNeg) SAMUtils.getMateUnclippedEnd(rec.asSam) else SAMUtils.getMateUnclippedStart(rec.asSam)
+        val lib       = Option(rec.readGroup).flatMap(rg => Option(rg.getLibrary)).getOrElse("Unknown")
+        val mid       = rec.get[String](ConsensusTags.MolecularId).map { m =>
+          val index: Int = m.lastIndexOf('/')
+          if (index >= 0) m.substring(0, index) else m
+        }.getOrElse("")
 
-      if (readChrom < mateChrom || (readChrom == mateChrom && readPos < matePos) ||
-           (readChrom == mateChrom && readPos == matePos && !readNeg)) {
-        TemplateCoordinateKey(readChrom, mateChrom, readPos, matePos, readNeg, mateNeg, lib, mid, rec.name, false)
-      }
-      else {
-        TemplateCoordinateKey(mateChrom, readChrom, matePos, readPos, mateNeg, readNeg, lib, mid, rec.name, true)
+        if (readChrom < mateChrom || (readChrom == mateChrom && readPos < matePos) ||
+             (readChrom == mateChrom && readPos == matePos && !readNeg)) {
+          TemplateCoordinateKey(readChrom, mateChrom, readPos, matePos, readNeg, mateNeg, lib, mid, rec.name, false)
+        }
+        else {
+          TemplateCoordinateKey(mateChrom, readChrom, matePos, readPos, mateNeg, readNeg, lib, mid, rec.name, true)
+        }
+      } else {
+        val primary   = Supplementary(rec[String]("rp"))
+        val mate      = Supplementary(rec[String]("mp"))
+        val readChrom = if (rec.unmapped) Int.MaxValue else primary.refIndex(rec.header)
+        val mateChrom = if (rec.unpaired || rec.mateUnmapped) Int.MaxValue else mate.refIndex(rec.header)
+        val readNeg   = primary.negativeStrand
+        val mateNeg   = if (rec.paired) mate.negativeStrand else false
+        val readPos   = if (rec.unmapped) Int.MaxValue else if (readNeg) primary.unclippedEnd else primary.unclippedStart
+        val matePos   = if (rec.unpaired || rec.mateUnmapped) Int.MaxValue else if (mateNeg) mate.unclippedEnd else mate.unclippedStart
+        val lib       = Option(rec.readGroup).flatMap(rg => Option(rg.getLibrary)).getOrElse("Unknown")
+        val mid       = rec.get[String](ConsensusTags.MolecularId).map { m =>
+          val index: Int = m.lastIndexOf('/')
+          if (index >= 0) m.substring(0, index) else m
+        }.getOrElse("")
+
+        if (readChrom < mateChrom || (readChrom == mateChrom && readPos < matePos) ||
+          (readChrom == mateChrom && readPos == matePos && !readNeg)) {
+          TemplateCoordinateKey(readChrom, mateChrom, readPos, matePos, readNeg, mateNeg, lib, mid, rec.name, false)
+        }
+        else {
+          TemplateCoordinateKey(mateChrom, readChrom, matePos, readPos, mateNeg, readNeg, lib, mid, rec.name, true)
+        }
       }
     }
   }

--- a/src/main/scala/com/fulcrumgenomics/bam/api/SamRecord.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/api/SamRecord.scala
@@ -76,7 +76,7 @@ class TransientAttrs(private val rec: SamRecord) {
 
 /**
   * A trait that fgbio uses as a replacement for [[SAMRecord]].  The trait is self-typed as a
-  * [[SamRecordIntermediate]] which is a sub-class of SAMRecord.  It is done this wasy so that
+  * [[SamRecordIntermediate]] which is a sub-class of SAMRecord.  It is done this ways so that
   * a) we can access superclass methods via [[SamRecordIntermediate]] but that self-typing here
   * instead of extending hides the [[SAMRecord]] API from users of the class.  The result is
   * always a [[SAMRecord]] but isn't seen as such without casting.

--- a/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
@@ -734,7 +734,7 @@ class GroupReadsByUmi
 
       // Then output the records in the right order (assigned tag, read name, r1, r2)
       templatesByMi.keys.toSeq.sortBy(id => (id.length, id)).foreach(tag => {
-        templatesByMi(tag).sortBy(t => t.name).flatMap(t => t.primaryReads).foreach(rec => {
+        templatesByMi(tag).sortBy(t => t.name).flatMap(t => t.allReads).foreach(rec => {
           out += rec
         })
       })

--- a/src/test/scala/com/fulcrumgenomics/alignment/AlignmentTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/alignment/AlignmentTest.scala
@@ -121,6 +121,41 @@ class AlignmentTest extends UnitSpec {
     Cigar("10M2D20M").reverse.toString shouldBe "20M2D10M"
   }
 
+  private case class ClippingTestCase
+  (cigar: String, clippedBases: Int,
+   leadingSoftClippedBases: Int, trailingSoftClippedBases: Int,
+   leadingHardClippedBases: Int, trailingHardClippedBases: Int,
+   leadingClippedBases: Int, trailingClippedBases: Int,
+   unclippedStart: Int, unclippedEnd: Int)
+
+  Seq(
+    ClippingTestCase("50M",             0,  0,  0,  0,  0,  0,  0,   0,  0), // no clipping
+    ClippingTestCase("20S50M",         20, 20,  0,  0,  0, 20,  0, -20,  0), // leading soft clipping
+    ClippingTestCase("50M10S",         10,  0, 10,  0,  0,  0, 10,   0, 10), // trailing soft clipping
+    ClippingTestCase("20S50M10S",      30, 20, 10,  0,  0, 20, 10, -20, 10), // leading and trailing soft clipping
+    ClippingTestCase("20H50M",         20,  0,  0, 20,  0, 20,  0, -20,  0), // leading hard clipping
+    ClippingTestCase("50M10H",         10,  0,  0,  0, 10,  0, 10,   0, 10), // trailing hard clipping
+    ClippingTestCase("20H50M10H",      30,  0,  0, 20, 10, 20, 10, -20, 10), // leading and trailing hard clipping
+    ClippingTestCase("15H5S50M",       20,  5,  0, 15,  0, 20,  0, -20,  0), // leading hard-the-soft clipping
+    ClippingTestCase("50M5S15H",       20,  0,  5,  0, 15,  0, 20,   0, 20), // trailing hard-the-soft clipping
+    ClippingTestCase("20H15S50M10S5H", 50, 15, 10, 20,  5, 35, 15, -35, 15), // leading and trailing hard-the-soft clipping
+  ).foreach { testCase =>
+    "Cigar clipping methods" should s"account for leading and trailing clipping in ${testCase.cigar}" in {
+      val cigar = Cigar(testCase.cigar)
+      cigar.clippedBases shouldBe testCase.clippedBases
+      cigar.leadingSoftClippedBases shouldBe testCase.leadingSoftClippedBases
+      cigar.trailingSoftClippedBases shouldBe testCase.trailingSoftClippedBases
+      cigar.leadingHardClippedBases shouldBe testCase.leadingHardClippedBases
+      cigar.trailingHardClippedBases shouldBe testCase.trailingHardClippedBases
+      cigar.leadingClippedBases shouldBe testCase.leadingClippedBases
+      cigar.trailingClippedBases shouldBe testCase.trailingClippedBases
+      cigar.unclippedStart(100) shouldBe testCase.unclippedStart + 100
+      cigar.unclippedEnd(200) shouldBe testCase.unclippedEnd + 200
+    }
+
+  }
+
+
   /////////////////////////////////////////////////////////////////////////////
   // Tests for the Alignment class
   /////////////////////////////////////////////////////////////////////////////

--- a/src/test/scala/com/fulcrumgenomics/alignment/AlignmentTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/alignment/AlignmentTest.scala
@@ -152,9 +152,7 @@ class AlignmentTest extends UnitSpec {
       cigar.unclippedStart(100) shouldBe testCase.unclippedStart + 100
       cigar.unclippedEnd(200) shouldBe testCase.unclippedEnd + 200
     }
-
   }
-
 
   /////////////////////////////////////////////////////////////////////////////
   // Tests for the Alignment class


### PR DESCRIPTION
There's an open issue in hts-specs about how we want to handle getting the primary alignment information when looking at a secondary or supplementary read: https://github.com/samtools/hts-specs/issues/755

This PR adds the _read primary_ "rp" tag to store the primary alignment for end of the current secondary/supplementary alignment, in the same format as the "SA" tag.  The _mate's primary_ alignment is stored in the "mp" tag.  Both are currently lowercase as they are not reserved tags.

I have tested that `ZipperBams` will now add these, that `SortBam` will correctly sort in template-coordinate, and finally that `GroupReadsByUmi` passes.  I added tests for `GroupReadsByUmi` and `SamOrder`.

Also, in my hands, secondary and supplementary records will never be output by `GroupReadsByUmi` as [currently only primary alignments are output](https://github.com/fulcrumgenomics/fgbio/blob/afa634e8ef3067fe1c5dec1276049d7cf99bbc36/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala#L722).