### PR TITLE
Fix snapshot releases

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -44,6 +44,7 @@ jobs:
     
     needs: test
     runs-on: ubuntu-latest
+    environment: github-actions
     env:
       SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
       SONATYPE_PASS: ${{ secrets.SONATYPE_PASS }}


### PR DESCRIPTION
Sonatype now uses tokens, and we need to use the github-actions environment to get to the secrets