### PR TITLE
feat: a default base quality may be provided in consensus callers whe…

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/CallDuplexConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CallDuplexConsensusReads.scala
@@ -113,6 +113,7 @@ class CallDuplexConsensusReads
  val maxReadsPerStrand: Option[Int] = None,
  @arg(doc="The number of threads to use while consensus calling.") val threads: Int = 1,
  @arg(doc="Consensus call overlapping bases in mapped paired end reads") val consensusCallOverlappingBases: Boolean = true,
+ @arg(doc = "The phred-scaled base quality to use when base qualities are missing in the input") val missingBaseQuality: Option[PhredScore] = None,
 ) extends FgBioTool with LazyLogging {
 
   Io.assertReadable(input)
@@ -144,7 +145,8 @@ class CallDuplexConsensusReads
       errorRatePreUmi     = errorRatePreUmi,
       errorRatePostUmi    = errorRatePostUmi,
       minReads            = minReads,
-      maxReadsPerStrand   = maxReadsPerStrand.getOrElse(VanillaUmiConsensusCallerOptions.DefaultMaxReads)
+      maxReadsPerStrand   = maxReadsPerStrand.getOrElse(VanillaUmiConsensusCallerOptions.DefaultMaxReads),
+      missingBaseQuality  = missingBaseQuality
     )
     val progress = ProgressLogger(logger, unit=1000000)
     val iterator = new ConsensusCallingIterator(inIter, caller, Some(progress), threads)

--- a/src/main/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReads.scala
@@ -132,6 +132,7 @@ class CallMolecularConsensusReads
  @arg(flag='D', doc="Turn on debug logging.") val debug: Boolean = false,
  @arg(doc="The number of threads to use while consensus calling.") val threads: Int = 1,
  @arg(doc="Consensus call overlapping bases in mapped paired end reads") val consensusCallOverlappingBases: Boolean = true,
+ @arg(doc="The phred-scaled base quality to use when base qualities are missing in the input") val missingBaseQuality: Option[PhredScore] = None,
  val maxQualOnAgreement: Boolean = false
 ) extends FgBioTool with LazyLogging {
 
@@ -165,14 +166,15 @@ class CallMolecularConsensusReads
     val out       = SamWriter(output, outHeader, sort=sortOrder)
 
     val options = new VanillaUmiConsensusCallerOptions(
-      tag                          = tag,
-      errorRatePreUmi              = errorRatePreUmi,
-      errorRatePostUmi             = errorRatePostUmi,
-      minInputBaseQuality          = minInputBaseQuality,
-      minConsensusBaseQuality      = minConsensusBaseQuality,
-      minReads                     = minReads,
-      maxReads                     = maxReads.getOrElse(VanillaUmiConsensusCallerOptions.DefaultMaxReads),
-      producePerBaseTags           = outputPerBaseTags
+      tag                      = tag,
+      errorRatePreUmi          = errorRatePreUmi,
+      errorRatePostUmi         = errorRatePostUmi,
+      minInputBaseQuality      = minInputBaseQuality,
+      minConsensusBaseQuality  = minConsensusBaseQuality,
+      minReads                 = minReads,
+      maxReads                 = maxReads.getOrElse(VanillaUmiConsensusCallerOptions.DefaultMaxReads),
+      producePerBaseTags       = outputPerBaseTags,
+      missingBaseQuality       = missingBaseQuality
     )
 
     val caller = new VanillaUmiConsensusCaller(

--- a/src/main/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCaller.scala
@@ -57,15 +57,16 @@ object VanillaUmiConsensusCallerOptions {
   */
 case class VanillaUmiConsensusCallerOptions
 (
-  tag: String                         = DefaultTag,
-  errorRatePreUmi: PhredScore         = DefaultErrorRatePreUmi,
-  errorRatePostUmi: PhredScore        = DefaultErrorRatePostUmi,
-  minInputBaseQuality: PhredScore     = DefaultMinInputBaseQuality,
-  qualityTrim: Boolean                = DefaultQualityTrim,
-  minConsensusBaseQuality: PhredScore = DefaultMinConsensusBaseQuality,
-  minReads: Int                       = DefaultMinReads,
-  maxReads: Int                       = DefaultMaxReads,
-  producePerBaseTags: Boolean         = DefaultProducePerBaseTags
+  tag: String                            = DefaultTag,
+  errorRatePreUmi: PhredScore            = DefaultErrorRatePreUmi,
+  errorRatePostUmi: PhredScore           = DefaultErrorRatePostUmi,
+  minInputBaseQuality: PhredScore        = DefaultMinInputBaseQuality,
+  qualityTrim: Boolean                   = DefaultQualityTrim,
+  minConsensusBaseQuality: PhredScore    = DefaultMinConsensusBaseQuality,
+  minReads: Int                          = DefaultMinReads,
+  maxReads: Int                          = DefaultMaxReads,
+  producePerBaseTags: Boolean            = DefaultProducePerBaseTags,
+  missingBaseQuality: Option[PhredScore] = None
 )
 
 
@@ -165,7 +166,7 @@ class VanillaUmiConsensusCaller(override val readNamePrefix: String,
       None
     }
     else {
-      val sourceRecords   = records.flatMap(toSourceRead(_, this.options.minInputBaseQuality, this.options.qualityTrim))
+      val sourceRecords   = records.flatMap(toSourceRead(_, this.options.minInputBaseQuality, this.options.qualityTrim, this.options.missingBaseQuality))
       val filteredRecords = filterToMostCommonAlignment(sourceRecords)
 
       if (filteredRecords.size < records.size) {


### PR DESCRIPTION
…n base qualities are missing.

Fixes: #1031

This has the following improvements:

1.  A better error message is displayed, with the name of the read.  Previously, a generic `ArrayIndexOutOfBoundsException` with on mention of which read.
2. If the `--missing-base-quality` is not given, then the exception occurs (no change in current behavior)
3. If the `--missing-base-quality` is given, then it is used (gracefully)

My only question is if we should have a non-None value by default.  See #1031 for a discussion on why that might be a bad idea.