### PR TITLE
ci: add preview for gh-pages to each PR

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -2,13 +2,18 @@ name: unit tests
 
 on: [push, pull_request]
 
+concurrency:
+  group: docs-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
+    name: Unit Tests
     runs-on: ubuntu-24.04
     environment: github-actions
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           lfs: true
@@ -18,6 +23,16 @@ jobs:
         uses: olafurpg/setup-scala@v12
         with:
           java-version: adopt-openj9@1.8.0-292
+      - name: Cache .ivy2
+        uses: actions/cache@v4
+        with:
+          path: ~/.ivy2
+          key: ${{ runner.os }}-ivy2-${{ hashFiles('**/build.sbt') }}
+      - name: Cache .sbt
+        uses: actions/cache@v4
+        with:
+          path: ~/.sbt
+          key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.properties') }}
       - name: Unit Tests
         run: |
           set -e
@@ -29,16 +44,6 @@ jobs:
           flags: unittests # optional
           fail_ci_if_error: true # optional (default = false)
           verbose: true # optional (default = false)
-      - name: Cache .ivy2
-        uses: actions/cache@v4
-        with:
-          path: ~/.ivy2
-          key: ${{ runner.os }}-ivy2-${{ hashFiles('**/build.sbt') }}
-      - name: Cache .sbt
-        uses: actions/cache@v4
-        with:
-          path: ~/.sbt
-          key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.properties') }}
   release:
     if: github.repository == 'fulcrumgenomics/fgbio' && github.ref == 'refs/heads/main'
     
@@ -59,3 +64,87 @@ jobs:
       - name: Upload to Sonatype
         run: |
           sbt +publish
+  docs:
+    name: Generate tool and metric markdown docs
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # To work with the `pull_request` or any other non-`push` even with git-auto-commit
+          ref: ${{ github.head_ref }}
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          lfs: true
+          ref: gh-pages
+          path: build
+      # Note: we use sdkman to install java and scala as other actions do not provide support for
+      # Java 8 and scaladoc
+      - name: Setup sdkman
+        shell: bash -l {0}
+        run: |
+          curl -s "https://get.sdkman.io" | bash
+          source "$HOME/.sdkman/bin/sdkman-init.sh"
+          sdk version
+          echo 'source "$HOME/.sdkman/bin/sdkman-init.sh"' >> "$HOME/.bash_profile"
+      - name: Install tools
+        shell: bash -l {0}
+        run: |
+          sdk install java 8.312.07.1-amzn
+          sdk install scala 2.13.0
+          sdk install sbt 1.10.4
+      - name: Cache .ivy2
+        uses: actions/cache@v4
+        with:
+          path: ~/.ivy2
+          key: ${{ runner.os }}-ivy2-${{ hashFiles('**/build.sbt') }}
+      - name: Cache .sbt
+        uses: actions/cache@v4
+        with:
+          path: ~/.sbt
+          key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.properties') }}
+      - name: Get fgbio version
+        shell: bash -l {0}
+        run: |
+          FGBIO_VERSION=$(sbt -Dsbt.supershell=false --no-colors --error 'print ThisBuild / version' | tail -n 1)
+          if [ "${FGBIO_VERSION}" == "" ]; then
+            echo "Error: FGBIO_VERSION was empty"
+            exit 1
+          fi
+          echo "fgbio version: ${FGBIO_VERSION}"
+          echo "FGBIO_VERSION=${FGBIO_VERSION}" >> $GITHUB_ENV
+      - name: Build assembly JAR
+        shell: bash -l {0}
+        run: |
+          sbt +assembly
+      - name: Build tool docs
+        shell: bash -l {0}
+        run: |
+          mkdir -p build/tools/${FGBIO_VERSION}
+          java -cp target/scala-2.13/fgbio-*.jar com.fulcrumgenomics.internal.InternalTools BuildToolDocs -o build/tools/${FGBIO_VERSION}
+          pushd build/tools 
+          rm latest 
+          ln -s ${FGBIO_VERSION} latest
+          popd
+      - name: Build metric docs
+        shell: bash -l {0}
+        run: |
+          mkdir -p build/metrics/${FGBIO_VERSION}
+          bash run_metrics_doclet.sh
+          mv -v target/metrics.md build/metrics/${FGBIO_VERSION}/index.md
+          pushd build/metrics
+          rm latest 
+          ln -s ${FGBIO_VERSION} latest
+          popd
+      - name: Update JAR version in index.md
+        shell: bash -l {0}
+        run: |
+          sed -i -e 's_fgbio-.*.jar_fgbio-'${FGBIO_VERSION}'.jar_g' build/index.md
+      - name: Generate gh-pages preview
+        uses: rossjrw/pr-preview-action@df22037db54ab6ee34d3c1e2b8810ac040a530c6 # v1.6.0
+        with:
+          source-dir: ./build/


### PR DESCRIPTION
1/3 for #1043

** for the reviewers **

1. most important of all, is that _every commit to a PR will make a corresponding commit to the `gh-pages` branch_.  Once the PR is closed (merged or otherwise), the preview sub-folder on `gh-pages` will be removed, but the `git` history will include all the commits adding and removing the previews.
1. we set concurrency on the unit tests to be at the branch level, so that we do not end up having race conditions when uploading commits in short succession
1. we use `sdkman` to install java and scala as other actions do not provide support for Java 8 and scaladoc.  In the tests workflow we use the `olafurpg/setup-scala` [which doesn't support intalling scaladoc](https://github.com/olafurpg/setup-scala/issues/47).  The recommended solution of `coursier` doesn't have the java version (8) I am looking for.
1. we use `bash -l {0}` as shell so the profile is reloaded each time (needed for `sdkman`)
