### PR TITLE
fix: update docs GitHub action scala version

### DIFF
--- a/.github/actions/docs/action.yaml
+++ b/.github/actions/docs/action.yaml
@@ -45,16 +45,16 @@ runs:
         sdk install java 8.312.07.1-amzn
         sdk install scala 2.13.14
         sdk install sbt 1.10.4
-    - name: Cache .ivy2
-      uses: actions/cache@v4
-      with:
-        path: ~/.ivy2
-        key: ${{ runner.os }}-ivy2-${{ hashFiles('**/build.sbt') }}
-    - name: Cache .sbt
-      uses: actions/cache@v4
-      with:
-        path: ~/.sbt
-        key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.properties') }}
+#    - name: Cache .ivy2
+#      uses: actions/cache@v4
+#      with:
+#        path: ~/.ivy2
+#        key: ${{ runner.os }}-ivy2-${{ hashFiles('**/build.sbt') }}
+#    - name: Cache .sbt
+#      uses: actions/cache@v4
+#      with:
+#        path: ~/.sbt
+#        key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.properties') }}
     - name: Get fgbio version
       shell: bash -l {0}
       run: |

--- a/.github/actions/docs/action.yaml
+++ b/.github/actions/docs/action.yaml
@@ -43,7 +43,7 @@ runs:
       shell: bash -l {0}
       run: |
         sdk install java 8.312.07.1-amzn
-        sdk install scala 2.13.0
+        sdk install scala 2.13.14
         sdk install sbt 1.10.4
     - name: Cache .ivy2
       uses: actions/cache@v4

--- a/.github/actions/docs/action.yaml
+++ b/.github/actions/docs/action.yaml
@@ -74,6 +74,7 @@ runs:
       env:
         LATEST: ${{ inputs.latest }}
       run: |
+        set -euo pipefail
         if [[ "${{ env.LATEST }}" == "true" ]]; then
           OUTDIR="${{ inputs.build-dir }}/tools/${FGBIO_VERSION}";
         else
@@ -95,6 +96,7 @@ runs:
       env:
         LATEST: ${{ inputs.latest }}
       run: |
+        set -euo pipefail
         if [[ "${{ env.LATEST }}" == "true" ]]; then
           OUTDIR="${{ inputs.build-dir }}/metrics/${FGBIO_VERSION}";
         else

--- a/.github/actions/docs/action.yaml
+++ b/.github/actions/docs/action.yaml
@@ -122,4 +122,4 @@ runs:
       id: version-output
       shell: bash -l {0}
       run: |
-        echo "version=${FGBIO_VERSION}" >> GITHUB_OUTPUT
+        echo "version=${FGBIO_VERSION}" >> "${GITHUB_OUTPUT}"

--- a/src/main/scala/com/fulcrumgenomics/internal/FgMetricsDoclet.scala
+++ b/src/main/scala/com/fulcrumgenomics/internal/FgMetricsDoclet.scala
@@ -28,6 +28,8 @@ import com.fulcrumgenomics.util.Metric
 
 import java.io.PrintStream
 import java.nio.file.Paths
+import scala.annotation.unused
+import scala.reflect.internal.Reporter
 import scala.tools.nsc.Settings
 import scala.tools.nsc.doc.base.comment._
 import scala.tools.nsc.doc.html.Doclet
@@ -46,7 +48,7 @@ case class MetricDescription(name: String, description: String, columns: Seq[Col
   * Custom scaladoc Doclet for rendering the documentation for [[com.fulcrumgenomics.util.Metric]] classes into
   * MarkDown for display on the fgbio website.
   */
-class FgMetricsDoclet extends Doclet(reporter = new ConsoleReporter(new Settings())) {
+class FgMetricsDoclet(@unused reporter: Reporter)  extends Doclet(reporter = new ConsoleReporter(new Settings())) {
   /**
     * Main entry point for the doclet.  Scans for documentation for the metrics classes and
     * renders it into MarkDown.


### PR DESCRIPTION
The scala version was updated in #1047, but we forgot to update the docs action.  

The docs action didn't fail, even though an exception was thrown: https://github.com/fulcrumgenomics/fgbio/actions/runs/14528704863/job/40764918279

```console
Exception in thread "main" java.lang.NoSuchMethodError: scala.tools.nsc.doc.base.comment.Body.blocks()Lscala/collection/immutable/Seq;
	at com.fulcrumgenomics.internal.FgMetricsDoclet.renderBody(FgMetricsDoclet.scala:167)
two warnings found
	at com.fulcrumgenomics.internal.FgMetricsDoclet.$anonfun$metrics$2(FgMetricsDoclet.scala:107)
	at scala.Option.map(Option.scala:243)
	at com.fulcrumgenomics.internal.FgMetricsDoclet.$anonfun$metrics$1(FgMetricsDoclet.scala:107)
	at scala.collection.immutable.List.map(List.scala:222)
	at com.fulcrumgenomics.internal.FgMetricsDoclet.metrics$lzycompute(FgMetricsDoclet.scala:105)
	at com.fulcrumgenomics.internal.FgMetricsDoclet.metrics(FgMetricsDoclet.scala:102)
	at com.fulcrumgenomics.internal.FgMetricsDoclet.generateImpl(FgMetricsDoclet.scala:69)
	at scala.tools.nsc.doc.doclet.Generator.generate(Generator.scala:35)
	at scala.tools.nsc.doc.DocFactory.generate$1(DocFactory.scala:135)
	at scala.tools.nsc.doc.DocFactory.document(DocFactory.scala:138)
	at scala.tools.nsc.ScalaDoc.process(ScalaDoc.scala:47)
	at scala.tools.nsc.ScalaDoc$.main(ScalaDoc.scala:102)
	at scala.tools.nsc.ScalaDoc.main(ScalaDoc.scala)
```