### PR TITLE
Test building with all working versions of the JDK

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -42,9 +42,7 @@ jobs:
         run: |
           set -e
           sbt +clean coverage +test
-          sbt coverageReport coverageAggregate 
-          (find "$HOME/.sbt" -name "*.lock" -print0 | xargs -0 rm) || echo "No sbt lock files found in $HOME/.sbt"
-          (find "$HOME/.ivy2" -name "ivydata-*.properties" -print0 | xargs -0 rm) || echo "No ivy properties found in $HOME/.ivy2"
+          sbt coverageReport coverageAggregate
       - name: Code Coverage
         uses: codecov/codecov-action@v5.1.1
         with:

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -19,7 +19,10 @@ concurrency:
 jobs:
   test:
     name: Unit Tests
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java-version: [ 8, 11, 17, 21, 22 ]
     environment: github-actions
     steps:
       - name: Checkout
@@ -28,21 +31,13 @@ jobs:
           fetch-depth: 0
           lfs: true
       - name: Checkout LFS objects
-        run: git lfs checkout        
-      - name: Setup Scala
-        uses: olafurpg/setup-scala@v12
+        run: git lfs checkout
+      - uses: actions/setup-java@v4
         with:
-          java-version: adopt-openj9@1.8.0-292
-      - name: Cache .ivy2
-        uses: actions/cache@v4
-        with:
-          path: ~/.ivy2
-          key: ${{ runner.os }}-ivy2-${{ hashFiles('**/build.sbt') }}
-      - name: Cache .sbt
-        uses: actions/cache@v4
-        with:
-          path: ~/.sbt
-          key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.properties') }}
+          distribution: 'temurin'
+          java-version: ${{ matrix.java-version }}
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
       - name: Unit Tests
         run: |
           set -e
@@ -60,7 +55,7 @@ jobs:
   release:
     if: ${{ github.repository == 'fulcrumgenomics/fgbio' && github.ref == 'refs/heads/main' && github.event_name != 'workflow_call' }}
     needs: test
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     environment: github-actions
     env:
       SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
@@ -79,7 +74,7 @@ jobs:
   docs:
     name: Generate tool and metric markdown docs
     needs: test
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     if: ${{ github.event_name != 'workflow_call' && (github.event_name == 'pull_request' || (github.repository == 'fulcrumgenomics/fgbio' && github.ref == 'refs/heads/main')) }}
     steps:
       - name: Checkout

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [ 8, 11, 17, 21, 22 ]
+        jvm: [ "temurin:1.8.0-442", "temurin:1.11.0.27", "temurin:1.17.0.15", "temurin:1.21.0.7", "temurin:1.22.0.2"]
     environment: github-actions
     steps:
       - name: Checkout
@@ -32,12 +32,13 @@ jobs:
           lfs: true
       - name: Checkout LFS objects
         run: git lfs checkout
-      - uses: actions/setup-java@v4
+      - name: Setup cache
+        uses: coursier/cache-action@v6
+      - name: setup Scala
+        uses: coursier/setup-action@v1
         with:
-          distribution: 'temurin'
-          java-version: ${{ matrix.java-version }}
-          cache: sbt
-      - uses: sbt/setup-sbt@v1
+          apps: scala scalac scaladoc sbt
+          jvm: ${{ matrix.jvm }}
       - name: Unit Tests
         run: |
           set -e
@@ -62,10 +63,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Setup Scala
-        uses: olafurpg/setup-scala@v12
+      - name: Setup cache
+        uses: coursier/cache-action@v6
+      - name: setup Scala
+        uses: coursier/setup-action@v1
         with:
-          java-version: adopt-openj9@1.8.0-292
+          apps: scala scalac scaladoc sbt
+          jvm: "temurin:1.8.0-442"
       - name: Upload to Sonatype
         run: |
           sbt +publish

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 [![Build Status](https://github.com/fulcrumgenomics/fgbio/actions/workflows/unittests.yaml/badge.svg?branch=main)](https://github.com/fulcrumgenomics/fgbio/actions/workflows/unittests.yaml)
 [![codecov](https://codecov.io/gh/fulcrumgenomics/fgbio/branch/main/graph/badge.svg)](https://codecov.io/gh/fulcrumgenomics/fgbio)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.fulcrumgenomics/fgbio_2.13/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.fulcrumgenomics/fgbio_2.13)
-[![Bioconda](https://img.shields.io/conda/dn/bioconda/fgbio.svg?label=Bioconda)](http://bioconda.github.io/recipes/fgbio/README.html)
-[![Javadocs](http://javadoc.io/badge/com.fulcrumgenomics/fgbio_2.13.svg)](http://javadoc.io/doc/com.fulcrumgenomics/fgbio_2.13)
+[![Language](https://img.shields.io/badge/language-scala-c22d40.svg)](https://www.scala-lang.org/)
+[![Java Version](https://img.shields.io/badge/java-8,11,17,21,22-c22d40.svg)](https://github.com/AdoptOpenJDK/homebrew-openjdk)
 [![License](http://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/fulcrumgenomics/fgbio/blob/main/LICENSE)
-[![Language](http://img.shields.io/badge/language-scala-brightgreen.svg)](http://www.scala-lang.org/)
+
+[![Bioconda](https://img.shields.io/conda/dn/bioconda/fgbio.svg?label=Bioconda)](http://bioconda.github.io/recipes/fgbio/README.html)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.fulcrumgenomics/fgbio_2.13/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.fulcrumgenomics/fgbio_2.13)
+[![Javadocs](http://javadoc.io/badge/com.fulcrumgenomics/fgbio_2.13.svg)](http://javadoc.io/doc/com.fulcrumgenomics/fgbio_2.13)
 [![DOI](https://zenodo.org/badge/53011104.svg)](https://zenodo.org/doi/10.5281/zenodo.10456900)
 
 fgbio
@@ -13,7 +15,7 @@ fgbio
 A set of tools to analyze genomic data with a focus on Next Generation Sequencing.
 
 <p>
-<a href float="left"="https://fulcrumgenomics.com"><img src=".github/logos/fulcrumgenomics.svg" alt="Fulcrum Genomics" height="100"/></a>
+<a href="https://fulcrumgenomics.com"><img src=".github/logos/fulcrumgenomics.svg" alt="Fulcrum Genomics" height="100"/></a>
 </p>
 
 
@@ -154,9 +156,6 @@ fgbio is built using [sbt](http://www.scala-sbt.org/).
 Use ```sbt assembly``` to build an executable jar in ```target/scala-2.13/```.
 
 Tests may be run with ```sbt test```.
-
-Java SE 8 is required.
-
 
 ## Command line
 


### PR DESCRIPTION
We cannot successfully build with 23 or greater.

We still target version 8:

https://github.com/fulcrumgenomics/fgbio/blob/48751481b5a838a7da8c4c4cb6ac1f5b7fd00e2a/build.sbt#L92

Picard supports Java 17 at a minimum now, so should we consider trying to migrate up?