### PR TITLE
fix: do not recursively store the pr-preview directory in gh-pages

### DIFF
--- a/.github/actions/docs/action.yaml
+++ b/.github/actions/docs/action.yaml
@@ -26,12 +26,21 @@ runs:
     - name: Checkout gh-pages
       uses: actions/checkout@v4
       with:
-        fetch-depth: 0
-        lfs: true
         ref: gh-pages
+        fetch-depth: 1
         path: ${{ inputs.build-dir }}
+        # Note: it is import that we **do not** clone the pr-preview directory here since
+        # we don't need to include this sub-directory when releasing or previewing docs.  This
+        # speeds up the checkout time significantly, and stops the pr-preview directory from
+        # bloating up (otherwise we'll keep a recursive copy).
+        sparse-checkout-cone-mode: false
+        sparse-checkout: |
+          /*
+          !/pr-preview/
     # Note: we use sdkman to install java and scala as other actions do not provide support for
     # Java 8 and scaladoc
+    # Note: we could use coursier/setup-action, but we could not get it working with scaladoc
+    # (generated a ClassNotFoundException)
     - name: Setup sdkman
       shell: bash -l {0}
       run: |
@@ -43,7 +52,7 @@ runs:
       shell: bash -l {0}
       run: |
         sdk install java 8.312.07.1-amzn
-        sdk install scala 2.13.0
+        sdk install scala 2.13.14
         sdk install sbt 1.10.4
     - name: Cache .ivy2
       uses: actions/cache@v4
@@ -68,7 +77,7 @@ runs:
     - name: Build assembly JAR
       shell: bash -l {0}
       run: |
-        sbt +assembly
+        sbt assembly
     - name: Build tool docs
       shell: bash -l {0}
       env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,14 +114,14 @@ jobs:
             git config --global user.name "Github Actions"
             git config --global user.email "nobody@fulcrumgenomics.com"
             git commit --all --message "release: ${FGBIO_VERSION}" --author "Nobody <nobody@fulcrumgenomics.com>" || echo "nothing to commit"
-            git fetch origin
+            git fetch origin gh-pages
             git rebase -X ours origin/gh-pages
             git push --atomic --set-upstream origin gh-pages
             popd
           new_command_on_retry: |
             set -euo pipefail
             pushd ./build
-            git fetch origin
+            git fetch origin gh-pages
             git rebase --abort
             git rebase -X ours origin/gh-pages
             git push --atomic --set-upstream origin gh-pages

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -115,14 +115,14 @@ jobs:
             git config --global user.name "Github Actions"
             git config --global user.email "nobody@fulcrumgenomics.com"
             git commit --all --message "devel: ${{ steps.checkout.outputs.ref }}" --author "Nobody <nobody@fulcrumgenomics.com>" || echo "nothing to commit"
-            git fetch origin
+            git fetch origin gh-pages
             git rebase -X ours origin/gh-pages
             git push --atomic --set-upstream origin gh-pages
             popd
           new_command_on_retry: |
             set -euo pipefail
             pushd ./build
-            git fetch origin
+            git fetch origin gh-pages
             git rebase --abort
             git rebase -X ours origin/gh-pages
             git push --atomic --set-upstream origin gh-pages


### PR DESCRIPTION
Note: this _does not_ fix some of the metric generation errors.  See https://github.com/fulcrumgenomics/fgbio/pull/1053 instead.

The way we were building the docs meant that the pr-preview directory was being copied into each new preview, so we would have directories like pr-preview/pr-1047/pr-preview/pr-1047/...  This created very large (multi-gigabyte) directories in the gh-pages history.

This fetches only the latest commit when checking out gh-pages, as well as ignores the pr-preview sub-directory, to avoid the above problem.

We also update the scala install for the docs action to 2.13.14 to match the scala version in other actions.

We also remove `sbt +assembly` since we are no longer cross-compiling, and don't need to docs if we did.

Finally, when rebase prior to commiting the gh-pages updates, we update to only fetch the gh-pages, which is all we need.

Update 1:
- [x] As part of this PR, I am going to re-write the gh-pages history to excise the `pr-preview` directory, which should hopefully allow tests to pass, which were failing due to running out of disk space. 

Update 2:
- [x] Verified that there are no `pr-preview` sub-directories: https://github.com/fulcrumgenomics/fgbio/tree/gh-pages/pr-preview/pr-1053