### PR TITLE
Test building with known working versions of the JDK

### DIFF
--- a/.github/actions/docs/action.yaml
+++ b/.github/actions/docs/action.yaml
@@ -24,7 +24,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout gh-pages
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         ref: gh-pages
         fetch-depth: 1
@@ -55,12 +55,12 @@ runs:
         sdk install scala 2.13.14
         sdk install sbt 1.10.4
     - name: Cache .ivy2
-      uses: actions/cache@v4
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: ~/.ivy2
         key: ${{ runner.os }}-ivy2-${{ hashFiles('**/build.sbt') }}
     - name: Cache .sbt
-      uses: actions/cache@v4
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: ~/.sbt
         key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.properties') }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   on-main-branch-check:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs:
       on_main: ${{ steps.contains_tag.outputs.retval }}
     steps:
@@ -133,7 +133,7 @@ jobs:
           path: fgbio-${{ env.FGBIO_VERSION }}.jar
 
   make-changelog:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: release
     outputs:
       release_body: ${{ steps.git-cliff.outputs.content }}
@@ -154,7 +154,7 @@ jobs:
           GITHUB_REPO: ${{ github.repository }}
 
   make-github-release:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     environment: github-actions
     permissions:
       contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
         shell: bash
         run: git config --global remote.origin.followRemoteHEAD never
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -25,7 +25,7 @@ jobs:
         shell: bash
         run: git branch -a
 
-      - uses: rickstaa/action-contains-tag@v1
+      - uses: rickstaa/action-contains-tag@a9ff27d505ba2bf074a2ebb48b208e76d35ff308 # v1.2.10
         id: contains_tag
         with:
           reference: "main"
@@ -73,7 +73,7 @@ jobs:
         run: |
           echo "GPG_TTY=$(tty)" >> $GITHUB_ENV
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           # To work with the `pull_request` or any other non-`push` even with git-auto-commit
@@ -101,7 +101,7 @@ jobs:
         run: |
           sbt sonatypeRelease
       - name: Commit generated docs
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
           max_attempts: 5
           retry_on: error
@@ -127,7 +127,7 @@ jobs:
             git push --atomic --set-upstream origin gh-pages
             popd
       - name: Upload fgbio.jar
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: fgbio-jar
           path: fgbio-${{ env.FGBIO_VERSION }}.jar
@@ -139,13 +139,13 @@ jobs:
       release_body: ${{ steps.git-cliff.outputs.content }}
     steps:
       - name: Checkout the Repository at the Tagged Commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           ref: ${{ github.ref_name }}
 
       - name: Generate a Changelog
-        uses: orhun/git-cliff-action@v3
+        uses: orhun/git-cliff-action@4a4a951bc43fafe41cd2348d181853f52356bee7 # v4.4.2
         id: git-cliff
         with:
           config: pyproject.toml
@@ -162,7 +162,7 @@ jobs:
     needs: make-changelog
     steps:
       - name: Download fgbio.jar artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: fgbio-jar
       - name: Display structure of downloaded files
@@ -170,7 +170,7 @@ jobs:
         run: ls -R
       - name: Create a Release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
         with:
           name: ${{ github.ref_name }}
           body: ${{ needs.make-changelog.outputs.release_body }}

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -25,16 +25,16 @@ jobs:
         jvm: ["temurin:1.8.0-442", "temurin:1.11.0.27", "temurin:1.17.0.15", "temurin:1.21.0.7", "temurin:1.22.0.2"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           lfs: true
       - name: Checkout LFS objects
         run: git lfs checkout        
       - name: Setup cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
       - name: setup Scala
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@039f736548afa5411c1382f40a5bd9c2d30e0383 # v1.3.9
         with:
           apps: scala:2.13.14 scalac:2.13.14 scaladoc:2.13.14 sbt:1.10.1
           jvm: ${{ matrix.jvm }}
@@ -44,7 +44,7 @@ jobs:
           sbt clean coverage test
           sbt coverageReport coverageAggregate
       - name: Code Coverage
-        uses: codecov/codecov-action@v5.1.1
+        uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d # v5.4.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests # optional
@@ -65,11 +65,12 @@ jobs:
       SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
       SONATYPE_PASS: ${{ secrets.SONATYPE_PASS }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+      # TODO: The setup-scala action is deprecated and should be migrated to actions/setup-java or coursier/setup-action!
       - name: Setup Scala
-        uses: olafurpg/setup-scala@v12
+        uses: olafurpg/setup-scala@32ffa16635ff8f19cc21ea253a987f0fdf29844c # v14
         with:
           java-version: adopt-openj9@1.8.0-292
       - name: Upload to Sonatype
@@ -83,7 +84,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # To work with the `pull_request` or any other non-`push` even with git-auto-commit
           ref: ${{ github.head_ref }}
@@ -98,7 +99,7 @@ jobs:
         with:
           source-dir: ./build
       - name: Commit generated docs (main only)
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         #i.e. if: ${{ github.event_name != 'pull_request' }}
         if: ${{ github.repository == 'fulcrumgenomics/fgbio' && github.ref == 'refs/heads/main' }}
         with:

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Unit Tests
         run: |
           set -e
-          sbt +clean coverage +test
+          sbt clean coverage test
           sbt coverageReport coverageAggregate
       - name: Code Coverage
         uses: codecov/codecov-action@v5.1.1

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -19,8 +19,10 @@ concurrency:
 jobs:
   test:
     name: Unit Tests
-    runs-on: ubuntu-24.04
-    environment: github-actions
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        jvm: ["temurin:1.8.0-442", "temurin:1.11.0.27", "temurin:1.17.0.15", "temurin:1.21.0.7", "temurin:1.22.0.2"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,27 +31,18 @@ jobs:
           lfs: true
       - name: Checkout LFS objects
         run: git lfs checkout        
-      - name: Setup Scala
-        uses: olafurpg/setup-scala@v12
+      - name: Setup cache
+        uses: coursier/cache-action@v6
+      - name: setup Scala
+        uses: coursier/setup-action@v1
         with:
-          java-version: adopt-openj9@1.8.0-292
-      - name: Cache .ivy2
-        uses: actions/cache@v4
-        with:
-          path: ~/.ivy2
-          key: ${{ runner.os }}-ivy2-${{ hashFiles('**/build.sbt') }}
-      - name: Cache .sbt
-        uses: actions/cache@v4
-        with:
-          path: ~/.sbt
-          key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.properties') }}
+          apps: scala:2.13.14 scalac:2.13.14 scaladoc:2.13.14 sbt:1.10.1
+          jvm: ${{ matrix.jvm }}
       - name: Unit Tests
         run: |
           set -e
           sbt +clean coverage +test
-          sbt coverageReport coverageAggregate 
-          (find "$HOME/.sbt" -name "*.lock" -print0 | xargs -0 rm) || echo "No sbt lock files found in $HOME/.sbt"
-          (find "$HOME/.ivy2" -name "ivydata-*.properties" -print0 | xargs -0 rm) || echo "No ivy properties found in $HOME/.ivy2"
+          sbt coverageReport coverageAggregate
       - name: Code Coverage
         uses: codecov/codecov-action@v5.1.1
         with:
@@ -66,7 +59,7 @@ jobs:
   release:
     if: ${{ github.repository == 'fulcrumgenomics/fgbio' && github.ref == 'refs/heads/main' && github.event_name != 'workflow_call' }}
     needs: test
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     environment: github-actions
     env:
       SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
@@ -85,7 +78,7 @@ jobs:
   docs:
     name: Generate tool and metric markdown docs
     needs: test
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     if: ${{ github.event_name != 'workflow_call' && (github.event_name == 'pull_request' || (github.repository == 'fulcrumgenomics/fgbio' && github.ref == 'refs/heads/main')) }}
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 [![Build Status](https://github.com/fulcrumgenomics/fgbio/actions/workflows/unittests.yaml/badge.svg?branch=main)](https://github.com/fulcrumgenomics/fgbio/actions/workflows/unittests.yaml)
 [![codecov](https://codecov.io/gh/fulcrumgenomics/fgbio/branch/main/graph/badge.svg)](https://codecov.io/gh/fulcrumgenomics/fgbio)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.fulcrumgenomics/fgbio_2.13/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.fulcrumgenomics/fgbio_2.13)
-[![Bioconda](https://img.shields.io/conda/dn/bioconda/fgbio.svg?label=Bioconda)](http://bioconda.github.io/recipes/fgbio/README.html)
-[![Javadocs](http://javadoc.io/badge/com.fulcrumgenomics/fgbio_2.13.svg)](http://javadoc.io/doc/com.fulcrumgenomics/fgbio_2.13)
+[![Language](https://img.shields.io/badge/language-scala-c22d40.svg)](https://www.scala-lang.org/)
+[![Java Version](https://img.shields.io/badge/java-8,11,17,21,22-c22d40.svg)](https://github.com/AdoptOpenJDK/homebrew-openjdk)
 [![License](http://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/fulcrumgenomics/fgbio/blob/main/LICENSE)
-[![Language](http://img.shields.io/badge/language-scala-brightgreen.svg)](http://www.scala-lang.org/)
+
+[![Bioconda](https://img.shields.io/conda/dn/bioconda/fgbio.svg?label=Bioconda)](http://bioconda.github.io/recipes/fgbio/README.html)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.fulcrumgenomics/fgbio_2.13/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.fulcrumgenomics/fgbio_2.13)
+[![Javadocs](http://javadoc.io/badge/com.fulcrumgenomics/fgbio_2.13.svg)](http://javadoc.io/doc/com.fulcrumgenomics/fgbio_2.13)
 [![DOI](https://zenodo.org/badge/53011104.svg)](https://zenodo.org/doi/10.5281/zenodo.10456900)
 
 fgbio
@@ -13,7 +15,7 @@ fgbio
 A set of tools to analyze genomic data with a focus on Next Generation Sequencing.
 
 <p>
-<a href float="left"="https://fulcrumgenomics.com"><img src=".github/logos/fulcrumgenomics.svg" alt="Fulcrum Genomics" height="100"/></a>
+<a href="https://fulcrumgenomics.com"><img src=".github/logos/fulcrumgenomics.svg" alt="Fulcrum Genomics" height="100"/></a>
 </p>
 
 
@@ -69,7 +71,7 @@ There are many toolkits available for analyzing genomic data; fgbio does not aim
 
 ## Overview
 
-Fgbio is a set of command line tools to perform bioinformatic/genomic data analysis. 
+Fgbio is a set of command line tools to perform bioinformatic/genomic data analysis.
 The collection of tools within `fgbio` are used by our customers and others both for ad-hoc data analysis and within production pipelines.
 These tools typically operate on read-level data (ex. FASTQ, SAM, or BAM) or variant-level data (ex. VCF or BCF).
 They range from simple tools to filter reads in a BAM file, to tools to compute consensus reads from reads with the same molecular index/tag.
@@ -136,7 +138,7 @@ Below we highlight a few tools that you may find useful.
 [fgbio-maketwosamplemixturevcf-link]: https://fulcrumgenomics.github.io/fgbio/tools/latest/MakeTwoSampleMixtureVcf.html
 [fgbio-findswitchbackreads-link]: https://fulcrumgenomics.github.io/fgbio/tools/latest/FindSwitchbackReads.html
 
-## Building 
+## Building
 ### Cloning the Repository
 
 [Git LFS](https://git-lfs.github.com/) is used to store large files used in testing fgbio.  In order to compile and run tests it is necessary to [install git lfs](https://git-lfs.github.com/).  To retrieve the large files either:
@@ -154,9 +156,6 @@ fgbio is built using [sbt](http://www.scala-sbt.org/).
 Use ```sbt assembly``` to build an executable jar in ```target/scala-2.13/```.
 
 Tests may be run with ```sbt test```.
-
-Java SE 8 is required.
-
 
 ## Command line
 
@@ -229,4 +228,3 @@ Public sponsors include:
 </p>
 
 The full list of sponsors supporting `fgbio` is available in the [sponsor](https://github.com/sponsors/fulcrumgenomics) page.
-

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://github.com/fulcrumgenomics/fgbio/actions/workflows/unittests.yaml/badge.svg?branch=main)](https://github.com/fulcrumgenomics/fgbio/actions/workflows/unittests.yaml)
 [![codecov](https://codecov.io/gh/fulcrumgenomics/fgbio/branch/main/graph/badge.svg)](https://codecov.io/gh/fulcrumgenomics/fgbio)
 [![Language](https://img.shields.io/badge/language-scala-c22d40.svg)](https://www.scala-lang.org/)
-[![Java Version](https://img.shields.io/badge/java-8,11,17,21,22-c22d40.svg)](https://github.com/AdoptOpenJDK/homebrew-openjdk)
+[![Java Version](https://img.shields.io/badge/java-8,11,17,21,22-a77805.svg)](https://github.com/AdoptOpenJDK/homebrew-openjdk)
 [![License](http://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/fulcrumgenomics/fgbio/blob/main/LICENSE)
 
 [![Bioconda](https://img.shields.io/conda/dn/bioconda/fgbio.svg?label=Bioconda)](http://bioconda.github.io/recipes/fgbio/README.html)


### PR DESCRIPTION
This PR runs all _**unit tests**_ using a matrix of JDKs that are known to work for building this project. I confirmed that sbt is correctly picking up the set Java distribution in each of the tests. E.g. here is the log line for the [Java 22 test](https://github.com/fulcrumgenomics/fgbio/actions/runs/14739164674/job/41373013950):

```console
[info] welcome to sbt 1.10.4 (Eclipse Adoptium Java 22.0.2)
```