### PR TITLE
chore: docstring for AlignmentScorer.scoreGap

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/alignment/Aligner.scala
+++ b/src/main/scala/com/fulcrumgenomics/alignment/Aligner.scala
@@ -131,7 +131,7 @@ object Aligner {
       *
       * scoreGap(query, target, qOffset=4, tOffset=3, gapIsinQuery=false, extend=false)
       * scoreGap(query, target, qOffset=5, tOffset=3, gapIsinQuery=false, extend=true)
-      * scoreGap(query, target, qOffset=9, tOffset=8, gapIsinQuery=true, extend=true)
+      * scoreGap(query, target, qOffset=9, tOffset=8, gapIsinQuery=true, extend=false)
       *
       * Offsets of -1, query.length and target.length may be passed to indicate that the gap is occurring
       * before the start of one of the sequences, or after the end of the query or target sequence respectively.


### PR DESCRIPTION
The example in the docstring for `scoreGap` is:

```scala
      * qoffset: 0123456789 0123
      * query:   ACGTGCATTC-AACA
      * aln:     ||||--||||-AACA
      * target:  ACGT--ATTCGAACA
      * toffset: 0123  456789012
```

The third call to `scoreGap` in the example should have `extend=false` as it's a new gap in the query.

```scala
      * scoreGap(query, target, qOffset=4, tOffset=3, gapIsinQuery=false, extend=false)
      * scoreGap(query, target, qOffset=5, tOffset=3, gapIsinQuery=false, extend=true)
      * scoreGap(query, target, qOffset=9, tOffset=8, gapIsinQuery=true, extend=false)
```