### PR TITLE
Fix GroupReadsByUmi to treat reads with differing pair-orientations separately (except for strategy=paired)

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
@@ -158,6 +158,9 @@ object GroupReadsByUmi {
     /** Returns a canonical form of the UMI that is the same for all reads with the same UMI. */
     def canonicalize(u: Umi): Umi = u
 
+    /** If true, templates at the same coordinates will be split up by R1+R2 orientation prior to grouping. */
+    def splitTemplatesByPairOrientation: Boolean = true
+
     /** Default implementation of a method to retrieve the next ID based on a counter. */
     protected def nextId: MoleculeId = this.counter.getAndIncrement().toString
 
@@ -381,6 +384,9 @@ object GroupReadsByUmi {
       val (a, b) = split(u)
       if (a < b) u else s"${b}-${a}"
     }
+
+    /** If true, templates at the same coordinates will be split up by R1+R2 orientation prior to grouping. */
+    override def splitTemplatesByPairOrientation: Boolean = false
 
     /** Splits the paired UMI into its two parts. */
     @inline private def split(umi: Umi): (Umi, Umi) = {
@@ -798,18 +804,27 @@ class GroupReadsByUmi
     */
   def assignUmiGroups(templates: Seq[Template]): Unit = {
     val startMs = System.currentTimeMillis
-    val umis    = truncateUmis(templates.map { t => umiForRead(t) })
-    val rawToId = this.assigner.assign(umis)
 
-    templates.iterator.zip(umis.iterator).foreach { case (template, umi) =>
-      val id  = rawToId(umi)
-      template.primaryReads.foreach(r => r(this.assignTag) = id)
+    // Split reads back out so we don't accidentally group F1R2 pairs with F2R1 pairs _unless_ the assigner
+    // wants it that way (e.g. the paired assigner)
+    val subgroups = if (!this.assigner.splitTemplatesByPairOrientation) Seq(templates) else {
+      templates.groupBy { t => (t.r1.forall(_.positiveStrand), t.r2.forall(_.positiveStrand)) }.values
     }
+
+    subgroups.foreach { ts =>
+        val umis    = truncateUmis(ts.map { t => umiForRead(t) })
+        val rawToId = this.assigner.assign(umis)
+
+        ts.iterator.zip(umis.iterator).foreach { case (template, umi) =>
+          val id  = rawToId(umi)
+          template.primaryReads.foreach(r => r(this.assignTag) = id)
+        }
+      }
 
     val endMs = System.currentTimeMillis()
     val durationMs = endMs - startMs
     if (durationMs >= 2500) {
-      logger.debug(f"Grouped ${rawToId.size}%,d UMIs from ${templates.size}%,d templates in ${durationMs}%,d ms." )
+      logger.debug(f"Grouped UMIs from ${templates.size}%,d templates in ${durationMs}%,d ms." )
     }
   }
 

--- a/src/test/scala/com/fulcrumgenomics/umi/GroupReadsByUmiTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/GroupReadsByUmiTest.scala
@@ -484,13 +484,15 @@ class GroupReadsByUmiTest extends UnitSpec with OptionValues with PrivateMethodT
     builder.addPair(name="rr",   start1=  1, start2=201, strand1=Minus, strand2=Minus, attrs=Map("RX" -> "ACGT-TTGA"))
     builder.addPair(name="r1f2", start1=100, start2=300, strand1=Minus, strand2=Plus,  attrs=Map("RX" -> "ACGT-TTGA"))
     builder.addPair(name="r2f1", start1=300, start2=100, strand1=Plus,  strand2=Minus, attrs=Map("RX" -> "ACGT-TTGA"))
+    builder.addFrag(name="Frag", start=100, strand=Minus, attrs=Map("RX" -> "ACGT-TTGA"))
+    builder.addFrag(name="fRag", start=1,   strand=Plus,  attrs=Map("RX" -> "ACGT-TTGA"))
 
     val in   = builder.toTempFile()
     val out  = Files.createTempFile("umi_grouped.", ".sam")
     new GroupReadsByUmi(input=in, output=out, familySizeHistogram=None, rawTag="RX", assignTag="MI", strategy=Strategy.Adjacency, edits=1).execute()
 
     val recs = readBamRecs(out)
-    recs.map(r => r[String]("MI")).distinct.size shouldBe 6  // each pair is a separate MI
+    recs.map(r => r[String]("MI")).distinct.size shouldBe 8  // each template is a separate MI
   }
 
   Seq(


### PR DESCRIPTION
When running with any of the non-paired/duplex strategies, GroupReadsByUmi was only comparing "outer coordinates and UMI" when matching up reads potentially from the same molecule.  This meant that it was considering two templates, with the same insert, but where one was F1R2 (Forward/Reverse inward facing pair with read 1 on the forward strand and read 2 on the reverse strand) and F2R1 (same but swap which read is which) as being from the same source molecule.  Since all preps we are aware of cannot give rise to this (two templates on opposite strands with the same UMI(s) in the same order) - this changes to separate reads out by R1 strand and R2 strand for grouping.