### PR TITLE
Add min AD and handle haploid calls for DownsampleVcf

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,3 @@ addSbtPlugin("org.scoverage"     % "sbt-scoverage" % "1.6.1")
 addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"  % "3.12.2")
 addSbtPlugin("com.github.sbt"    % "sbt-pgp"       % "2.3.1")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.0")
-
-ThisBuild / libraryDependencySchemes ++= Seq(
-  "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
-)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,3 +10,6 @@ addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"  % "3.12.2")
 addSbtPlugin("com.github.sbt"    % "sbt-pgp"       % "2.3.1")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.0")
 
+ThisBuild / libraryDependencySchemes ++= Seq(
+  "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+)

--- a/src/main/scala/com/fulcrumgenomics/vcf/DownsampleVcf.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/DownsampleVcf.scala
@@ -310,13 +310,10 @@ object DownsampleVcf extends LazyLogging {
     * If multiple PLs equal zero then return None (NOCALL)
     */
     private def mostLikelyGenotype: Option[Int] = {
-      val minIndexes = pls.zipWithIndex.filter(pair => pair._1 == 0)
-      minIndexes match {
-        case Nil => throw new IllegalArgumentException("expected the most likely PL to have a value of 0.0")
-        case _ +: Nil => {
-          Some(minIndexes.head._2)
-        }
-        case _ => None  // if multiple genotypes are most likely, don't make a call
+      pls.zipWithIndex.collect { case (0, index) => index } match {
+        case Seq(singleIndex) => Some(singleIndex)
+        case Seq() => throw new IllegalArgumentException("expected the most likely PL to have a value of 0.0")
+        case _ => None
       }
     }
   

--- a/src/main/scala/com/fulcrumgenomics/vcf/DownsampleVcf.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/DownsampleVcf.scala
@@ -120,7 +120,7 @@ object DownsampleVcf extends LazyLogging {
     }
   }
 
-  trait HasLikelihoods {
+  sealed trait HasLikelihoods {
     def pls: IndexedSeq[Int]
 
     def mostLikelyCall(alleles: Seq[Allele]): IndexedSeq[Allele]

--- a/src/main/scala/com/fulcrumgenomics/vcf/DownsampleVcf.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/DownsampleVcf.scala
@@ -304,7 +304,7 @@ object DownsampleVcf extends LazyLogging {
   
     def mostLikelyCall(alleles: Seq[Allele]): IndexedSeq[Allele] = {
       mostLikelyGenotype match {
-        case None => IndexedSeq(NoCallAllele)
+        case None    => IndexedSeq(NoCallAllele)
         case Some(a) => IndexedSeq(alleles(a))
       }
     }

--- a/src/main/scala/com/fulcrumgenomics/vcf/DownsampleVcf.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/DownsampleVcf.scala
@@ -409,8 +409,14 @@ class DownsampleVcf
     val progress = ProgressLogger(logger, noun="variants written")
     val random = new Random(seed)
     winnowed.foreach { v =>
-      val ds = downsampleAndRegenotype(v, proportions=proportions, random=random, epsilon=epsilon,
-                                       minAdHomvar=minAdHomvar, minAdHomref=minAdHomref)
+      val ds = downsampleAndRegenotype(
+          gt          = v,
+          proportions = proportions,
+          random      = random,
+          epsilon     = epsilon,
+          minAdHomvar = minAdHomvar,
+          minAdHomref = minAdHomref
+       )
       if (writeNoCall || !ds.gts.forall(g => g.isNoCall)) {
         outputVcf += ds
         progress.record(ds)

--- a/src/main/scala/com/fulcrumgenomics/vcf/DownsampleVcf.scala
+++ b/src/main/scala/com/fulcrumgenomics/vcf/DownsampleVcf.scala
@@ -410,7 +410,7 @@ class DownsampleVcf
     val random = new Random(seed)
     winnowed.foreach { v =>
       val ds = downsampleAndRegenotype(
-          gt          = v,
+          variant     = v,
           proportions = proportions,
           random      = random,
           epsilon     = epsilon,


### PR DESCRIPTION
Three commits
1. **Add minimum allele depths for downsampling**: adds minimum allele depth for HOMVAR and HOMREF calls (3 and 1 respectively) and sets called GT to NOCALL if those depths are not met. Without this change, you could frequently see downsampled VCFs that had called HOMVAR with AD=1, an unreliable call. I set the defaults to what felt like minimums I'd use if I wanted to be aggressive but sane about making calls. Perhaps those are worth a second look.
2. **Allow haploid GTs**: Essential for preserving calls on sex chromosomes.
3. **Workaround bug in sbt compile**: Without this I got failures building the project due to version conflicts related to `scala-xml` (thanks to @nh13, see: See https://github.com/scala/bug/issues/12632)