### PR TITLE
Update the CLI docs of CorrectUmis to be more functionally correct

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/CorrectUmis.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CorrectUmis.scala
@@ -129,7 +129,7 @@ class CorrectUmis
  @arg(flag='r', doc="Reject BAM file to save unassigned reads.") val rejects: Option[PathToBam] = None,
  @arg(flag='M', doc="Metrics file to write.") val metrics: Option[FilePath] = None,
  @arg(flag='m', doc="Maximum number of mismatches between a UMI and an expected UMI.") val maxMismatches: Int,
- @arg(flag='d', name="minDistance", doc="Minimum difference (of mismatch distance) to next-best UMI.") val minDistanceDiff: Int,
+ @arg(flag='d', name="min-distance", doc="Minimum difference (of mismatch distance) to next-best UMI.") val minDistanceDiff: Int,
  @arg(flag='u', doc="Expected UMI sequences.", minElements=0) val umis: Seq[String] = Seq.empty,
  @arg(flag='U', doc="File of UMI sequences, one per line.", minElements=0) val umiFiles: Seq[FilePath] = Seq.empty,
  @arg(flag='t', doc="Tag in which UMIs are stored.") val umiTag: String = ConsensusTags.UmiBases,

--- a/src/main/scala/com/fulcrumgenomics/umi/CorrectUmis.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CorrectUmis.scala
@@ -102,7 +102,7 @@ object CorrectUmis {
     |
     |  1. _--max-mismatches_ controls how many mismatches (no-calls are counted as mismatches) are tolerated
     |         between a UMI as read and a fixed UMI.
-    |  2. _--min-distance_ controls how many more mismatches the next best hit must have
+    |  2. _--min-distance_ controls how many *more* mismatches the next best hit must have
     |
     |For example, with two fixed UMIs `AAAAA` and `CCCCC` and `--max-mismatches=3` and `--min-distance=2` the
     |following would happen:
@@ -124,18 +124,18 @@ object CorrectUmis {
     |using a cache, set the value to `0`.
   """)
 class CorrectUmis
-( @arg(flag='i', doc="Input SAM or BAM file.")  val input: PathToBam,
-  @arg(flag='o', doc="Output SAM or BAM file.") val output: PathToBam,
-  @arg(flag='r', doc="Reject BAM file to save unassigned reads.") val rejects: Option[PathToBam] = None,
-  @arg(flag='M', doc="Metrics file to write.") val metrics: Option[FilePath] = None,
-  @arg(flag='m', doc="Maximum number of mismatches between a UMI and an expected UMI.") val maxMismatches: Int,
-  @arg(flag='d', doc="Minimum distance (in mismatches) to next best UMI.") val minDistance: Int,
-  @arg(flag='u', doc="Expected UMI sequences.", minElements=0) val umis: Seq[String] = Seq.empty,
-  @arg(flag='U', doc="File of UMI sequences, one per line.", minElements=0) val umiFiles: Seq[FilePath] = Seq.empty,
-  @arg(flag='t', doc="Tag in which UMIs are stored.") val umiTag: String = ConsensusTags.UmiBases,
-  @arg(flag='x', doc="Don't store original UMIs upon correction.") val dontStoreOriginalUmis: Boolean = false,
-  @arg(doc="The number of uncorrected UMIs to cache; zero will disable the cache.") val cacheSize: Int = 100000,
-  @arg(doc="The minimum ratio of kept UMIs to accept. A ratio below this will cause a failure (but all files will still be written).") val minCorrected: Option[Double] = None
+(@arg(flag='i', doc="Input SAM or BAM file.")  val input: PathToBam,
+ @arg(flag='o', doc="Output SAM or BAM file.") val output: PathToBam,
+ @arg(flag='r', doc="Reject BAM file to save unassigned reads.") val rejects: Option[PathToBam] = None,
+ @arg(flag='M', doc="Metrics file to write.") val metrics: Option[FilePath] = None,
+ @arg(flag='m', doc="Maximum number of mismatches between a UMI and an expected UMI.") val maxMismatches: Int,
+ @arg(flag='d', name="minDistance", doc="Minimum difference (of mismatch distance) to next-best UMI.") val minDistanceDiff: Int,
+ @arg(flag='u', doc="Expected UMI sequences.", minElements=0) val umis: Seq[String] = Seq.empty,
+ @arg(flag='U', doc="File of UMI sequences, one per line.", minElements=0) val umiFiles: Seq[FilePath] = Seq.empty,
+ @arg(flag='t', doc="Tag in which UMIs are stored.") val umiTag: String = ConsensusTags.UmiBases,
+ @arg(flag='x', doc="Don't store original UMIs upon correction.") val dontStoreOriginalUmis: Boolean = false,
+ @arg(doc="The number of uncorrected UMIs to cache; zero will disable the cache.") val cacheSize: Int = 100000,
+ @arg(doc="The minimum ratio of kept UMIs to accept. A ratio below this will cause a failure (but all files will still be written).") val minCorrected: Option[Double] = None
 ) extends FgBioTool with LazyLogging {
 
   validate(umis.nonEmpty || umiFiles.nonEmpty, "At least one UMI or UMI file must be provided.")
@@ -161,8 +161,8 @@ class CorrectUmis
     }
 
     // Warn if any of the UMIs are too close together
-    CorrectUmis.findUmiPairsWithinDistance(umiSequences.toSeq, minDistance-1).foreach { case (umi1, umi2, distance) =>
-        logger.warning(s"Umis $umi1 and $umi2 are $distance edits apart which is less than the min distance: $minDistance")
+    CorrectUmis.findUmiPairsWithinDistance(umiSequences.toSeq, minDistanceDiff-1).foreach { case (umi1, umi2, distance) =>
+        logger.warning(s"Umis $umi1 and $umi2 are $distance edits apart which is less than the min distance diff: $minDistanceDiff")
     }
 
     // Construct the UMI metrics objects
@@ -280,7 +280,7 @@ class CorrectUmis
       case None         =>
         val mismatches = umis.map(umi => Sequences.countMismatches(bases, umi))
         val min        = mismatches.min
-        val matched    = (min <= maxMismatches) && (mismatches.count(m => m < min + this.minDistance) == 1)
+        val matched    = (min <= maxMismatches) && (mismatches.count(m => m < min + this.minDistanceDiff) == 1)
         val umiMatch   = UmiMatch(matched, umis(mismatches.indexOf(min)), min)
         if (cacheSize > 0) cache.put(bases, umiMatch)
         umiMatch

--- a/src/test/scala/com/fulcrumgenomics/umi/CorrectUmisTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/CorrectUmisTest.scala
@@ -35,7 +35,7 @@ class CorrectUmisTest extends UnitSpec {
   private val NoBam = makeTempFile("correct_umis.", ".bam")
 
   "CorrectUmis.findBestMatch" should "find perfect matches" in {
-    val corrector = new CorrectUmis(input = NoBam, output = NoBam, maxMismatches = 2, minDistance = 2, umis = FixedUmis)
+    val corrector = new CorrectUmis(input = NoBam, output = NoBam, maxMismatches = 2, minDistanceDiff = 2, umis = FixedUmis)
     val hit1 = corrector.findBestMatch("AAAAAA", FixedUmisArray)
     hit1.matched shouldBe true
     hit1.mismatches shouldBe 0
@@ -58,7 +58,7 @@ class CorrectUmisTest extends UnitSpec {
   }
 
   it should "match UMIs with up to the maximum allowed mismatches" in {
-    val corrector = new CorrectUmis(input = NoBam, output = NoBam, maxMismatches = 2, minDistance = 2, umis = FixedUmis)
+    val corrector = new CorrectUmis(input = NoBam, output = NoBam, maxMismatches = 2, minDistanceDiff = 2, umis = FixedUmis)
     corrector.findBestMatch("AAAAAA", FixedUmisArray) shouldBe UmiMatch(matched = true, "AAAAAA", 0)
     corrector.findBestMatch("AAAAAT", FixedUmisArray) shouldBe UmiMatch(matched = true, "AAAAAA", 1)
     corrector.findBestMatch("AAAACT", FixedUmisArray) shouldBe UmiMatch(matched = true, "AAAAAA", 2)
@@ -66,12 +66,12 @@ class CorrectUmisTest extends UnitSpec {
   }
 
   it should "not match with mismatches when two UMIs are too similar (e.g. poorly picked UMIs)" in {
-    val corrector = new CorrectUmis(input = NoBam, output = NoBam, maxMismatches = 2, minDistance = 2, umis = Seq("AAAG", "AAAT"))
+    val corrector = new CorrectUmis(input = NoBam, output = NoBam, maxMismatches = 2, minDistanceDiff = 2, umis = Seq("AAAG", "AAAT"))
     corrector.findBestMatch("AAAG", Array("AAAG", "AAAT")) shouldBe UmiMatch(matched = false, "AAAG", 0)
   }
 
   it should "match with lots of mismatches, but only if the next best UMI is far enough away" in {
-    val corrector = new CorrectUmis(input = NoBam, output = NoBam, maxMismatches = 3, minDistance = 2, umis = FixedUmis)
+    val corrector = new CorrectUmis(input = NoBam, output = NoBam, maxMismatches = 3, minDistanceDiff = 2, umis = FixedUmis)
     corrector.findBestMatch("AAAAAA", FixedUmisArray) shouldBe UmiMatch(matched = true, "AAAAAA", 0)
     corrector.findBestMatch("AAACGT", FixedUmisArray) shouldBe UmiMatch(matched = true, "AAAAAA", 3)
     corrector.findBestMatch("AAACGT", FixedUmisArray) shouldBe UmiMatch(matched = true, "AAAAAA", 3)
@@ -96,7 +96,7 @@ class CorrectUmisTest extends UnitSpec {
     val corrected = makeTempFile("corrected.", ".bam")
     val rejects = makeTempFile("rejects.", ".bam")
 
-    val corrector = new CorrectUmis(input = input, output = corrected, rejects = Some(rejects), maxMismatches = 2, minDistance = 2, umis = FixedUmis)
+    val corrector = new CorrectUmis(input = input, output = corrected, rejects = Some(rejects), maxMismatches = 2, minDistanceDiff = 2, umis = FixedUmis)
     val logLines = executeFgbioTool(corrector)
     logLines.exists(line => line.contains("Error")) shouldBe true
     readBamRecs(corrected) shouldBe empty
@@ -105,7 +105,7 @@ class CorrectUmisTest extends UnitSpec {
 
   it should "throw an exception if all the fixed umis are not the same length " in {
     an[ValidationException] shouldBe thrownBy {
-      new CorrectUmis(input = NoBam, output = NoBam, maxMismatches = 2, minDistance = 2, umis = Seq("AAAAAA", "CCC")).execute()
+      new CorrectUmis(input = NoBam, output = NoBam, maxMismatches = 2, minDistanceDiff = 2, umis = Seq("AAAAAA", "CCC")).execute()
     }
   }
 
@@ -116,7 +116,7 @@ class CorrectUmisTest extends UnitSpec {
     val corrected = makeTempFile("corrected.", ".bam")
     val rejects = makeTempFile("rejects.", ".bam")
 
-    val corrector = new CorrectUmis(input = input, output = corrected, rejects = Some(rejects), maxMismatches = 2, minDistance = 2, umis = FixedUmis)
+    val corrector = new CorrectUmis(input = input, output = corrected, rejects = Some(rejects), maxMismatches = 2, minDistanceDiff = 2, umis = FixedUmis)
     val logLines = executeFgbioTool(corrector)
     logLines.exists(line => line.contains("Error")) shouldBe true
     readBamRecs(corrected) shouldBe empty
@@ -141,7 +141,7 @@ class CorrectUmisTest extends UnitSpec {
     val rejects   = makeTempFile("rejects.", ".bam")
     val metrics   = makeTempFile("metrics.", ".txt")
 
-    val corrector = new CorrectUmis(input=input, output=corrected, rejects=Some(rejects), metrics=Some(metrics), maxMismatches=3, minDistance=2, umis=FixedUmis)
+    val corrector = new CorrectUmis(input=input, output=corrected, rejects=Some(rejects), metrics=Some(metrics), maxMismatches=3, minDistanceDiff=2, umis=FixedUmis)
     val logLines = executeFgbioTool(corrector)
     logLines.exists(line => line.contains("Error")) shouldBe false // No errors this time
 
@@ -169,7 +169,7 @@ class CorrectUmisTest extends UnitSpec {
     val rejects   = makeTempFile("rejects.", ".bam")
     val metrics   = makeTempFile("metrics.", ".txt")
 
-    val corrector = new CorrectUmis(input=input, output=corrected, rejects=Some(rejects), metrics=Some(metrics), maxMismatches=3, minDistance=2, umis=FixedUmis)
+    val corrector = new CorrectUmis(input=input, output=corrected, rejects=Some(rejects), metrics=Some(metrics), maxMismatches=3, minDistanceDiff=2, umis=FixedUmis)
     val logLines = executeFgbioTool(corrector)
     logLines.exists(line => line.contains("Error")) shouldBe false // No errors this time
 
@@ -201,8 +201,8 @@ class CorrectUmisTest extends UnitSpec {
 
     Io.writeLines(umiFile, FixedUmis)
 
-    new CorrectUmis(input=input, output=corrected, rejects=Some(rejects), metrics=Some(metrics1), maxMismatches=3, minDistance=2, umis=FixedUmis).execute()
-    new CorrectUmis(input=input, output=corrected, rejects=Some(rejects), metrics=Some(metrics2), maxMismatches=3, minDistance=2, umiFiles=Seq(umiFile)).execute()
+    new CorrectUmis(input=input, output=corrected, rejects=Some(rejects), metrics=Some(metrics1), maxMismatches=3, minDistanceDiff=2, umis=FixedUmis).execute()
+    new CorrectUmis(input=input, output=corrected, rejects=Some(rejects), metrics=Some(metrics2), maxMismatches=3, minDistanceDiff=2, umiFiles=Seq(umiFile)).execute()
 
     val m1 = Metric.read[UmiCorrectionMetrics](metrics1)
     val m2 = Metric.read[UmiCorrectionMetrics](metrics2)
@@ -219,7 +219,7 @@ class CorrectUmisTest extends UnitSpec {
     val output = makeTempFile("corrected.", ".bam")
 
     // Should store original UMI on corrected records
-    new CorrectUmis(input=builder.toTempFile(), output=output, umis=expectedUmis, maxMismatches=2, minDistance=2).execute()
+    new CorrectUmis(input=builder.toTempFile(), output=output, umis=expectedUmis, maxMismatches=2, minDistanceDiff=2).execute()
     readBamRecs(output).foreach { rec =>
       if (rec.name == "exact")       rec.get(ConsensusTags.OriginalUmiBases) shouldBe None
       if (rec.name == "correctable") rec.get(ConsensusTags.OriginalUmiBases) shouldBe Some("AAAAGA")
@@ -227,7 +227,7 @@ class CorrectUmisTest extends UnitSpec {
     }
 
     // Should not store original UMIs on any records
-    new CorrectUmis(input=builder.toTempFile(), output=output, umis=expectedUmis, maxMismatches=2, minDistance=2, dontStoreOriginalUmis=true).execute()
+    new CorrectUmis(input=builder.toTempFile(), output=output, umis=expectedUmis, maxMismatches=2, minDistanceDiff=2, dontStoreOriginalUmis=true).execute()
     readBamRecs(output).foreach { rec =>
       rec.get(ConsensusTags.OriginalUmiBases) shouldBe None
     }


### PR DESCRIPTION
- Changes the name of the variable `minDistance` to `minDistanceDiff` (while leaving the name of the argument the same for backwards compatibility...)
- Slight modification of the documentation to clarify that the value is the _difference_ in distance, not the distance itself.