### PR TITLE
Remove primary name if also found in alternate names in CollectAlternateContigNames

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/fasta/CollectAlternateContigNames.scala
+++ b/src/main/scala/com/fulcrumgenomics/fasta/CollectAlternateContigNames.scala
@@ -184,7 +184,7 @@ class CollectAlternateContigNames
               None
             case alternate => Some(alternate)
           }
-      }.distinct
+      }.distinct.filter(_ != name)
       if (sequenceRoles.nonEmpty && !this.sequenceRoles.contains(role)) {
         skipReasons += SkipReason(name=name, role=role, msg=s"Skipping contig name '$name' with mismatching sequencing role: $role.")
       }

--- a/src/test/scala/com/fulcrumgenomics/fasta/CollectAlternateContigNamesTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/fasta/CollectAlternateContigNamesTest.scala
@@ -74,6 +74,23 @@ class CollectAlternateContigNamesTest extends UnitSpec {
     dict.last.aliases should contain theSameElementsInOrderAs Seq("chrM")
   }
 
+  it should "handle cases where the primary and one of the alternates contain the same value for a sequence" in {
+    val output = makeTempFile("test.", ".dict")
+    val tool = new CollectAlternateContigNames(
+      input         = reportHg38,
+      output        = output,
+      primary       = Column.SequenceName,
+      alternates    = Seq(Column.AssignedMolecule, Column.UcscName),
+      sequenceRoles = Seq(AssembledMolecule),
+    )
+    executeFgbioTool(tool)
+
+    val dict = SequenceDictionary(output)
+    dict should have length 25
+    dict.head.name shouldBe "1"
+    dict.head.aliases should contain theSameElementsInOrderAs Seq("chr1")
+  }
+
   it should "read the assigned-molecules for alternates in GRCh38.p12" in {
     val output = makeTempFile("test.", ".dict")
     val tool = new CollectAlternateContigNames(


### PR DESCRIPTION
I was trying to use CollectAlternateContigNames on [this assembly report](https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/018/350/175/GCF_018350175.1_F.catus_Fca126_mat1.0/GCF_018350175.1_F.catus_Fca126_mat1.0_assembly_report.txt).  It was failing, because the last line has the sequence name `MT` and also assigned-molecule as `MT` and that was causing redundancy in the generated sequence dictionary.