### PR TITLE
Added some extra stats for the codec caller, and added a --stats stats.txt output file.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/CallCodecConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CallCodecConsensusReads.scala
@@ -84,6 +84,7 @@ class CallCodecConsensusReads
 (@arg(flag='i', doc="The input SAM or BAM file.") val input: PathToBam,
  @arg(flag='o', doc="Output SAM or BAM file to write consensus reads.") val output: PathToBam,
  @arg(flag='r', doc="Optional output SAM or BAM file to write reads not used.") val rejects: Option[PathToBam] = None,
+ @arg(flag='s', doc="Optional output text file of key consensus calling statistics.") val stats: Option[FilePath] = None,
  @arg(flag='p', doc="The prefix all consensus read names") val readNamePrefix: Option[String] = None,
  @arg(flag='R', doc="The new read group ID for all the consensus reads.") val readGroupId: String = "A",
  @arg(flag='1', doc="The Phred-scaled error rate for an error prior to the UMIs being integrated.") val errorRatePreUmi: PhredScore = DefaultErrorRatePreUmi,
@@ -150,6 +151,13 @@ class CallCodecConsensusReads
     in.safelyClose()
     out.close()
     rejectsWriter.foreach(_.close())
+
     caller.logStatistics(logger)
+    stats.foreach { path =>
+      val lines = Seq("statistic\tvalue") ++ caller.statistics.map {
+        case (key, value) => s"${key}\t${value}"
+      }
+      Io.writeLines(path, lines)
+    }
   }
 }

--- a/src/main/scala/com/fulcrumgenomics/umi/CodecConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CodecConsensusCaller.scala
@@ -32,6 +32,8 @@ import com.fulcrumgenomics.umi.UmiConsensusCaller.{ReadType, SourceRead}
 import com.fulcrumgenomics.util.NumericTypes.PhredScore
 import com.fulcrumgenomics.util.Sequences
 
+import scala.collection.immutable.ListMap
+
 /**
   * Consensus caller for CODEC sequencing[1].  In CODEC each read-pair has an R1 which is generated from one
   * strand of the original duplex and an R2 which is generated from the opposite strand of the original duplex.
@@ -110,10 +112,14 @@ class CodecConsensusCaller(readNamePrefix: String,
 ) {
   require(this.minReadsPerStrand >= 1, "minReadsPerStrand must be at least 1.")
 
-  private val FilterDuplexTooShort = s"Top/Bottom Strand Overlap < ${minDuplexLength} bases."
-  private val FilterIndelError = "Indel error between strands in duplex overlap."
-  private val FilterHighDuplexDisagreement = "Duplex had too many disagreements between strands."
+  private val FilterDuplexTooShort = s"Top/Bottom strand overlap too short"
+  private val FilterIndelError = "Indel error between strands in duplex overlap"
+  private val FilterHighDuplexDisagreement = "Too many duplex disagreements"
   private val clipper = new SamRecordClipper(ClippingMode.Hard, autoClipAttributes = false)
+
+  private var totalConsensusBases: Long = 0
+  private var totalDuplexBases: Long = 0
+  private var duplexErrorBases: Long = 0
 
   /** Returns the MI tag as is because in CODEC there is no /A or /B unlike classic duplex-seq */
   override protected[umi] def sourceMoleculeId(rec: SamRecord): String = rec[String](ConsensusTags.MolecularId)
@@ -216,30 +222,27 @@ class CodecConsensusCaller(readNamePrefix: String,
               val paddedR1 = r1Consensus.padded(newLength = consensusLength, left = longestR1Alignment.negativeStrand, qual = 0)
               val paddedR2 = r2Consensus.padded(newLength = consensusLength, left = longestR2Alignment.negativeStrand, qual = 0)
 
-              // Calculate number and rate of duplex errors ... but don't really if the thresholds won't need them
-              val (duplexErrors, duplexErrorRate) = {
-                if (this.maxDuplexDisagreementRate >= 1 && this.maxDuplexDisagreements >= overlapLength) (0, 0.0)
-                else {
-                  val (duplexBases, duplexErrors) = computeDuplexCounts(paddedR1, paddedR2)
-                  val duplexErrorRate = if (duplexBases > 0) duplexErrors.toDouble / duplexBases.toDouble else 0
-                  (duplexErrors, duplexErrorRate)
-                }
-              }
+              // Calculate number and rate of duplex errors
+              val (duplexBases, duplexErrors) = computeDuplexCounts(paddedR1, paddedR2)
+              val duplexErrorRate = if (duplexBases > 0) duplexErrors.toDouble / duplexBases.toDouble else 0
 
               if (duplexErrors > this.maxDuplexDisagreements || duplexErrorRate > this.maxDuplexDisagreementRate) {
                 rejectRecords((r1s.view ++ r2s.view).flatMap(_.sam), FilterHighDuplexDisagreement)
                 Nil
               }
               else {
-                val consensus = duplexConsensus(Some(paddedR1), Some(paddedR2), sourceReads = None)
-                if (longestR1Alignment.negativeStrand) consensus.foreach(_.revcomp())
-                consensus.foreach(maskCodecConsensusQuals)
+                duplexConsensus(Some(paddedR1), Some(paddedR2), sourceReads = None).map { c =>
+                  // Update statistics
+                  this.totalConsensusBases += c.length
+                  this.totalDuplexBases += duplexBases
+                  this.duplexErrorBases += duplexErrors
 
-                val umis = recs.iterator.map(r => r[String](ConsensusTags.UmiBases)).toSeq
-                consensus
-                  .iterator
-                  .map(c => createSamRecord(c, ReadType.Fragment, umis))
-                  .toSeq
+                  // Generate the output SamRecord
+                  if (longestR1Alignment.negativeStrand) c.revcomp()
+                  maskCodecConsensusQuals(c)
+                  val umis = recs.iterator.map(r => r[String](ConsensusTags.UmiBases)).toSeq
+                  createSamRecord(c, ReadType.Fragment, umis)
+                }.toSeq
               }
           }
         }
@@ -334,5 +337,27 @@ class CodecConsensusCaller(readNamePrefix: String,
     }
 
     (duplexBases, duplexErrors)
+  }
+
+  /** Adds the given caller's statistics (counts) to this caller. */
+  override def addStatistics(caller: UmiConsensusCaller[DuplexConsensusRead]): Unit = {
+    super.addStatistics(caller)
+    caller match {
+      case sub: CodecConsensusCaller =>
+        this.totalConsensusBases += sub.totalConsensusBases
+        this.totalDuplexBases += sub.totalDuplexBases
+        this.duplexErrorBases += sub.duplexErrorBases
+    }
+  }
+
+  /** Generates a map of statistics collected by the caller. */
+  override def statistics: ListMap[FilenameSuffix, Any] = {
+    val duplexErrorRate = if (this.totalDuplexBases == 0) 0 else this.duplexErrorBases / this.totalDuplexBases.toDouble
+
+    super.statistics +
+      ("Consensus Bases Emitted" -> this.totalConsensusBases) +
+      ("Duplex Consensus Bases Emitted" -> this.totalDuplexBases) +
+      ("Duplex Strand Disagreements" -> this.duplexErrorBases) +
+      ("Duplex Disagreement Rate" -> duplexErrorRate)
   }
 }

--- a/src/main/scala/com/fulcrumgenomics/umi/DuplexConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/DuplexConsensusCaller.scala
@@ -47,10 +47,12 @@ object DuplexConsensusCaller {
   val NoCallQual: PhredScore = PhredScore.MinValue
 
   /** Additional filter strings used when rejecting reads. */
-  val FilterMinReads    = "Not Enough Reads (Either Total, AB, or BA)"
-  val FilterFragments   = "Being Fragment/Non-Paired Reads"
+  val FilterMinReads    = "Minimum Read Limit(s) Not Met"
+  val FilterFragments   = "Fragment/Non-Paired Reads"
   val FilterSsConsensus = "Only Generating One Strand Consensus"
   val FilterCollision   = "Potential collision between independent duplex molecules"
+
+  private val DuplexFilterStrings = Seq(FilterMinReads, FilterFragments, FilterSsConsensus, FilterCollision)
 
   /**
     * Stores information about a consensus read.  Bases, arrays, and the two single
@@ -127,7 +129,7 @@ class DuplexConsensusCaller(override val readNamePrefix: String,
                            ) extends UmiConsensusCaller[DuplexConsensusRead] with LazyLogging {
 
   private val Seq(minTotalReads, minXyReads, minYxReads) = this.minReads.padTo(3, this.minReads.last)
-
+  DuplexFilterStrings.foreach(rejectRecords(_))
   // For depth thresholds it's required that ba <= ab <= cc
   require(minXyReads <= minTotalReads, "min-reads values must be specified high to low.")
   require(minYxReads <= minXyReads, "min-reads values must be specified high to low.")

--- a/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
@@ -64,6 +64,8 @@ object UmiConsensusCaller {
   /** Filter reason for when reads are rejected due creation of orphaned consensus (i.e. R1 or R2 failed). */
   val FilterOrphan = "Orphan Consensus Created"
 
+  val FilterStrings: Seq[String] = Seq(FilterInsufficientSupport, FilterMinorityAlignment, FilterLowQuality, FilterOrphan)
+
   /** A trait that consensus reads must implement. */
   trait SimpleRead {
     /** The ID of the molecule that generated the consensus read. */

--- a/src/main/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/VanillaUmiConsensusCaller.scala
@@ -159,6 +159,9 @@ class VanillaUmiConsensusCaller(override val readNamePrefix: String,
                                 override val rejectsWriter: Option[SamWriter] = None
                                ) extends UmiConsensusCaller[VanillaConsensusRead] with LazyLogging {
 
+  UmiConsensusCaller.FilterStrings.foreach(rejectRecords(_))
+
+
   private val NotEnoughReadsQual: PhredScore = 0.toByte // Score output when masking to N due to insufficient input reads
   private val TooLowQualityQual: PhredScore = 2.toByte  // Score output when masking to N due to too low consensus quality
 

--- a/src/test/scala/com/fulcrumgenomics/umi/CallCodecConsensusReadsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/CallCodecConsensusReadsTest.scala
@@ -26,6 +26,7 @@ package com.fulcrumgenomics.umi
 
 import com.fulcrumgenomics.bam.api.{SamOrder, SamSource}
 import com.fulcrumgenomics.testing.{SamBuilder, UnitSpec}
+import com.fulcrumgenomics.util.Io
 
 import java.nio.file.Paths
 
@@ -83,5 +84,40 @@ class CallCodecConsensusReadsTest extends UnitSpec {
     val reader = SamSource(out)
     val recs = reader.toSeq
     recs should have size 1
+  }
+
+  it should "emit statistics and a reject BAM" in {
+    val builder = new SamBuilder(readLength=30, sort=Some(SamOrder.TemplateCoordinate))
+    builder.addPair( // Should form a consensus
+      start1=100, start2=100, bases1="AC" * 15, bases2="AC" * 15, attrs=Map(("RX", "ACC-TGA"), ("MI", "hi"))
+    )
+    builder.addPair( // Too far apart to form a consensus
+      name="x", start1=200, start2=500, bases1="AC" * 15, bases2="AC" * 15, attrs=Map(("RX", "ACC-TGA"), ("MI", "bye"))
+    )
+    val in  = builder.toTempFile()
+
+    val out = makeTempFile("codec.", ".bam")
+    val rej = makeTempFile("rejects.", ".bam")
+    val statsPath = makeTempFile("stats.", ".txt")
+    val caller = new CallCodecConsensusReads(input=in, output=out, readGroupId="ZZ", rejects=Some(rej), stats=Some(statsPath))
+    caller.execute()
+
+    val recs = readBamRecs(out)
+    recs should have size 1
+
+    val rejectedRecs = readBamRecs(rej)
+    rejectedRecs should have size 2
+    rejectedRecs.foreach(_.name shouldBe "x")
+
+    val stats: Map[String, String] = Io.readLines(statsPath).drop(1)
+      .map { line =>
+        val tabIdx = line.indexOf('\t')
+        (line.substring(0, tabIdx), line.substring(tabIdx + 1))
+      }
+      .toMap
+
+    val key = stats.keys.find(_.contains("overlap too short")).getOrElse(fail("Couldn't find key in stats."))
+    val count = stats(key).toInt
+    count shouldBe 2
   }
 }


### PR DESCRIPTION
Example output from a small dataset (column -t'd for ease of reading):

```
statistic                                                          value
Total Raw Reads Considered                                         9471158
Total Raw Reads Rejected                                           439587
Fraction Of Raw Reads Used                                         0.9535867736553439
Rejected Raw Reads: Being Fragment/Non-Paired Reads                0
Rejected Raw Reads: Not Enough Reads (Either Total, AB, or BA)     0
Rejected Raw Reads: Indel error between strands in duplex overlap  132399
Rejected Raw Reads: Top/Bottom strand overlap too short            283566
Rejected Raw Reads: Mismatching Cigars                             22265
Rejected Raw Reads: Temporary Issue: Fix Clipping Issue            1357
Consensus Reads Emitted                                            1382601
Consensus Bases Emitted                                            203872568
Duplex Consensus Bases Emitted                                     125709179
Duplex Strand Disagreements                                        1508704
Duplex Disagreement Rate                                           0.012001542067186677
```