### PR TITLE
Use Metric to output consensus caller stats with a bit more structure to the table

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/CallCodecConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CallCodecConsensusReads.scala
@@ -109,6 +109,7 @@ class CallCodecConsensusReads
   Io.assertReadable(input)
   Io.assertCanWriteFile(output)
   rejects.foreach(Io.assertCanWriteFile(_))
+  stats.foreach(Io.assertCanWriteFile(_))
   validate(errorRatePreUmi  > 0, "Phred-scaled error rate pre UMI must be > 0")
   validate(errorRatePostUmi > 0, "Phred-scaled error rate post UMI must be > 0")
   validate(minReadPairs >= 1, "min-read-pairs must be >= 1")

--- a/src/main/scala/com/fulcrumgenomics/umi/CallCodecConsensusReads.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CallCodecConsensusReads.scala
@@ -32,7 +32,7 @@ import com.fulcrumgenomics.commons.util.LazyLogging
 import com.fulcrumgenomics.sopt._
 import com.fulcrumgenomics.umi.VanillaUmiConsensusCallerOptions._
 import com.fulcrumgenomics.util.NumericTypes.PhredScore
-import com.fulcrumgenomics.util.ProgressLogger
+import com.fulcrumgenomics.util.{Metric, ProgressLogger}
 
 @clp(description =
   """
@@ -153,11 +153,6 @@ class CallCodecConsensusReads
     rejectsWriter.foreach(_.close())
 
     caller.logStatistics(logger)
-    stats.foreach { path =>
-      val lines = Seq("statistic\tvalue") ++ caller.statistics.map {
-        case (key, value) => s"${key}\t${value}"
-      }
-      Io.writeLines(path, lines)
-    }
+    stats.foreach { path => Metric.write(path, caller.statistics) }
   }
 }


### PR DESCRIPTION
Also added the `--stats` optional output to the other consensus callers because once I was done, it was easy to do.