### PR TITLE
Fixup publishing of invalid POM caused by duplicate URL entries.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -141,8 +141,7 @@ lazy val commonSettings = Seq(
   resolvers            += "broad-snapshots" at "https://broadinstitute.jfrog.io/artifactory/libs-snapshot/",
   shellPrompt          := { state => "%s| %s> ".format(GitCommand.prompt.apply(state), version.value) },
   updateOptions        := updateOptions.value.withCachedResolution(true),
-  pomExtra             := <url>https://github.com/fulcrumgenomics/fgbio</url>
-    <licenses>
+  pomExtra             := <licenses>
       <license>
         <name>MIT License</name>
         <url>https://www.opensource.org/licenses/mit-license.html</url>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.2
+sbt.version=1.11.4


### PR DESCRIPTION
At some point `sbt` started automatically inserting the `<url>` element into the POM, and so having it in the `pomExtras` caused validation failures.