### PR TITLE
Make it so FastqToBam can stream input

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -138,6 +138,7 @@ lazy val commonSettings = Seq(
   resolvers            += Resolver.sonatypeCentralSnapshots,
   resolvers            += Resolver.sonatypeCentralRepo("releases"),
   resolvers            += Resolver.mavenLocal,
+  resolvers            += Resolver.mavenCentral,
   resolvers            += "broad-snapshots" at "https://broadinstitute.jfrog.io/artifactory/libs-snapshot/",
   shellPrompt          := { state => "%s| %s> ".format(GitCommand.prompt.apply(state), version.value) },
   updateOptions        := updateOptions.value.withCachedResolution(true),
@@ -199,6 +200,7 @@ lazy val root = Project(id="fgbio", base=file("."))
       "org.apache.commons"        %  "commons-math3"  % "3.6.1",
       "com.beachape"              %% "enumeratum"     % "1.7.0",
       "com.intel.gkl"             %  "gkl"            % "0.8.10",
+      "io.cvbio.collection"       %% "fullypeekable"  % "1.0.0",
 
       //---------- Test libraries -------------------//
       "org.scalatest"             %% "scalatest"     % "3.1.3"  % "test->*" excludeAll ExclusionRule(organization="org.junit", name="junit")

--- a/src/main/scala/com/fulcrumgenomics/fastq/FastqSource.scala
+++ b/src/main/scala/com/fulcrumgenomics/fastq/FastqSource.scala
@@ -51,14 +51,15 @@ object FastqSource {
   /** Creates a new fastq source from a Path. */
   def apply(path: PathToFastq): FastqSource = apply(Io.readLines(path))
 
-  /** Returns an iterator over multiple fastq files that ensures:
+  /** Returns an iterator over multiple FASTQ iterators that ensures:
+    *
     *   1. Either all sources or no sources have more records
     *   2. That the next records from each of the sources have the same read name
     *
-    * @param sources a Seq of one or more FastqSource objects
+    * @param sources a Seq of one or more FASTQ record iterators
     * @return an Iterator that returns a Seq of FastqRecord, one per source
     */
-  def zipped(sources: Seq[FastqSource]): Iterator[Seq[FastqRecord]] = new Iterator[Seq[FastqRecord]] {
+  def zipped(sources: Seq[Iterator[FastqRecord]]): Iterator[Seq[FastqRecord]] = new Iterator[Seq[FastqRecord]] {
     require(sources.nonEmpty, "No sources provided")
 
     def hasNext: Boolean = sources.exists(_.hasNext)
@@ -68,7 +69,7 @@ object FastqSource {
       require(sources.forall(_.hasNext) == sources.head.hasNext, "Sources are out of sync.")
       val records = sources.map(_.next())
       // Check that the FASTQ records all have the same name
-      require(records.forall(_.name == records.head.name), "Fastqs are out of sync, found read names: " + records.map(_.name).mkString(", "))
+      require(records.forall(_.name == records.head.name), "FASTQs are out of sync, found read names: " + records.map(_.name).mkString(", "))
       records
     }
   }


### PR DESCRIPTION
I'd like to stream with `FastqToBam` so I don't have to generate temporary FASTQ files before format conversion.

Currently, `FastqToBam` opens all input files, samples them to determine the quality encoding, and closes them before re-opening them for actual iteration. If we add a fully peekable iterator over the FASTQ streams, then we can peek forward as many records as we need for quality encoding detection and then re-use the iterators for doing the actual work.

I happened to have a fully peekable iterator in my personal portfolio, but if that dependency is unwanted, I can copy-paste the code file over the fgbio project.