### PR TITLE
WIP: feat: support dual barcoding with Agilent's SureSelect XT HS2

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/GroupReadsByUmi.scala
@@ -866,7 +866,7 @@ class GroupReadsByUmi
         val umis = umi.split("-", -1) // Split and ensure we return empty strings for missing UMIs.
         require(umis.length == 2, s"Paired strategy used but umi did not contain 2 segments delimited by a '-': $umi")
         if (ignorePairedUmiOrder) {
-          val _umis = if (umi(0) <= umi(1)) umis else umis.reverse
+          val _umis = if (umis(0) <= umis(1)) umis else umis.reverse
           if (r1Lower) paired.lowerReadUmiPrefix + ":" + _umis(0) + "-" + paired.higherReadUmiPrefix + ":" + _umis(1)
           else         paired.higherReadUmiPrefix + ":" + _umis(1) + "-" + paired.lowerReadUmiPrefix + ":" + _umis(0)
         } else {


### PR DESCRIPTION
Closes: #1099

For this dual barcoding scheme, it is assumed that the order of the barcodes relative to R1 or R2 does not matter.  This means that CTG-ATG on the A strand originates from the same source molecule as ATG-CTG on the A strand.

We add the --ignore-paired-umi-order option to support this. Practically speaking, this option sorts the two UMI segements lexicographically, and applies them such that they earlier segment is first on the A strand (e.g. ATG), and later segment is on the B strand (CTG), regardless of the order they appear in the RX tag (i.e. when originally parsed).

Alternatively, I could add an option to the various UMI extraction tools to sort the UMIs in the `MI` tag.  This modifies fewer tools.

TODO:
- [x] add unit tests