### PR TITLE
Support cell barcodes in ReadStructure and FastqToBam

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/fastq/DemuxFastqs.scala
+++ b/src/main/scala/com/fulcrumgenomics/fastq/DemuxFastqs.scala
@@ -377,6 +377,10 @@ class DemuxFastqs
  val omitControlReads: Boolean = false,
  @arg(doc="Mask bases with a quality score below the specified threshold as Ns") val maskBasesBelowQuality: Int = 0,
 ) extends FgBioTool with LazyLogging {
+  validate(
+    !readStructures.exists(_.cellBarcodeSegments.nonEmpty),
+    "DemuxFastqs does not support cell barcodes in read structures!",
+  )
 
   private val fastqStandards: FastqStandards = {
     FastqStandards(

--- a/src/main/scala/com/fulcrumgenomics/fastq/FastqToBam.scala
+++ b/src/main/scala/com/fulcrumgenomics/fastq/FastqToBam.scala
@@ -43,8 +43,8 @@ import java.util
   """
     |Generates an unmapped BAM (or SAM or CRAM) file from fastq files.  Takes in one or more fastq files (optionally
     |gzipped), each representing a different sequencing read (e.g. R1, R2, I1 or I2) and can use a set of read
-    |structures to allocate bases in those reads to template reads, sample indices, unique molecular indices, or to
-    |designate bases to be skipped over.
+    |structures to allocate bases in those reads to template reads, sample indices, unique molecular indices, cell
+    |barcodes, or to designate bases to be skipped over.
     |
     |Read structures are made up of `<number><operator>` pairs much like the CIGAR string in BAM files. Four kinds of
     |operators are recognized:
@@ -52,10 +52,11 @@ import java.util
     |1. `T` identifies a template read
     |2. `B` identifies a sample barcode read
     |3. `M` identifies a unique molecular index read
-    |4. `S` identifies a set of bases that should be skipped or ignored
+    |4. `C` identifies a cell barcode read
+    |5. `S` identifies a set of bases that should be skipped or ignored
     |
     |The last `<number><operator>` pair may be specified using a `+` sign instead of number to denote "all remaining
-    |bases". This is useful if, e.g., fastqs have been trimmed and contain reads of varying length.  For example
+    |bases". This is useful if, e.g., FASTQs have been trimmed and contain reads of varying length.  For example
     |to convert a paired-end run with an index read and where the first 5 bases of R1 are a UMI and the second
     |five bases are monotemplate you might specify:
     |
@@ -93,6 +94,8 @@ class FastqToBam
   @arg(flag='s', doc="If true, queryname sort the BAM file, otherwise preserve input order.")  val sort: Boolean = false,
   @arg(flag='u', doc="Tag in which to store molecular barcodes/UMIs.")                         val umiTag: String = ConsensusTags.UmiBases,
   @arg(flag='q', doc="Tag in which to store molecular barcode/UMI qualities.")                 val umiQualTag: Option[String] = None,
+  @arg(flag='c', doc="Tag in which to store the cellular barcodes.")                           val cellTag: String = "CB",
+  @arg(flag='C', doc="Tag in which to store the cellular barcodes qualities.")                 val cellQualTag: Option[String] = None,
   @arg(flag='Q', doc="Store the sample barcode qualities in the QT Tag.")                      val storeSampleBarcodeQualities: Boolean = false,
   @arg(flag='n', doc="Extract UMI(s) from read names and prepend to UMIs from reads.")         val extractUmisFromReadNames: Boolean = false,
   @arg(          doc="Read group ID to use in the file header.")                               val readGroupId: String = "A",
@@ -172,6 +175,8 @@ class FastqToBam
     // Make the SamRecords inside a try so we can provide more informative error messages
     try {
       val subs = fqs.iterator.zip(structures.iterator).flatMap { case(fq, rs) => rs.extract(fq.bases, fq.quals) }.toIndexedSeq
+      val cellBarcode   = subs.iterator.filter(_.kind == CellBarcode).map(_.bases).mkString("-")
+      val cellQuals     = subs.iterator.filter(_.kind == CellBarcode).map(_.quals).mkString(" ")
       val sampleBarcode = subs.iterator.filter(_.kind == SampleBarcode).map(_.bases).mkString("-")
       val sampleQuals   = subs.iterator.filter(_.kind == SampleBarcode).map(_.quals).mkString(" ")
       val umi           = subs.iterator.filter(_.kind == MolecularBarcode).map(_.bases).mkString("-")
@@ -197,6 +202,8 @@ class FastqToBam
           if (index == 0) rec.firstOfPair = true else rec.secondOfPair = true
         }
 
+        if (cellBarcode.nonEmpty) rec(cellTag) = cellBarcode
+        if (cellQuals.nonEmpty) cellQualTag.foreach(tag => rec(tag) = cellQuals)
         if (sampleBarcode.nonEmpty) rec("BC") = sampleBarcode
         if (storeSampleBarcodeQualities && sampleQuals.nonEmpty) rec("QT") = sampleQuals
 

--- a/src/main/scala/com/fulcrumgenomics/util/ReadStructure.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/ReadStructure.scala
@@ -178,6 +178,7 @@ class ReadStructure private(val segments: Seq[ReadSegment]) extends immutable.Se
   def templateSegments:         Seq[ReadSegment] = segments(SegmentType.Template)
   def sampleBarcodeSegments:    Seq[ReadSegment] = segments(SegmentType.SampleBarcode)
   def molecularBarcodeSegments: Seq[ReadSegment] = segments(SegmentType.MolecularBarcode)
+  def cellBarcodeSegments:      Seq[ReadSegment] = segments(SegmentType.CellBarcode)
   def skipSegments:             Seq[ReadSegment] = segments(SegmentType.Skip)
 }
 
@@ -187,23 +188,25 @@ object SegmentType {
   case object Template extends SegmentType('T')
   case object SampleBarcode extends SegmentType('B')
   case object MolecularBarcode extends SegmentType('M')
+  case object CellBarcode extends SegmentType('C')
   case object Skip extends SegmentType('S')
 
   /** All the possible types. */
-  val values: Seq[SegmentType] = Seq(Template, SampleBarcode, MolecularBarcode, Skip)
+  val values: Seq[SegmentType] = Seq(Template, SampleBarcode, MolecularBarcode, CellBarcode, Skip)
 
   /** Returns the [[SegmentType]] for the given code/letter. */
   def apply(code: Char): SegmentType = code match {
     case 'T' => Template
     case 'B' => SampleBarcode
     case 'M' => MolecularBarcode
+    case 'C' => CellBarcode
     case 'S' => Skip
     case _   => throw new IllegalArgumentException(s"Invalid read segment type: $code")
   }
 }
 
 object ReadSegment {
-  val Types = Seq('T', 'B', 'M', 'S')
+  val Types: Seq[Char] = Seq('T', 'B', 'M', 'C', 'S') // TODO: this is never used, can we delete it?
 
   /** Creates a new ReadSegment with undefined length (i.e. length=0 or more). */
   def apply(offset: Int, c: Char): ReadSegment = new ReadSegment(offset, None, kind=SegmentType(c))

--- a/src/test/scala/com/fulcrumgenomics/fastq/FastqToBamTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/fastq/FastqToBamTest.scala
@@ -383,6 +383,22 @@ class FastqToBamTest extends UnitSpec {
     recs(1).apply[String]("RX") shouldBe "TTGA-TAAT-TA-AA"
   }
 
+  it should "extract cell barcodes in read sequences" in {
+    val r1 = fq(
+      FastqRecord("q1:2:3:4:5:6:7:ACGT+CGTA", "GGNCCGAAAAAAA", "============="),
+      FastqRecord("q2:2:3:4:5:6:7:TTGA+TAAT", "TANAACAAAAAAA", "============="),
+    )
+    val rs  = ReadStructure("2C1S2C+T")
+    val bam = makeTempFile("fastqToBamTest.", ".bam")
+    new FastqToBam(input=Seq(r1), readStructures=Seq(rs), output=bam, sample="s", library="l", cellQualTag = Some("CY")).execute()
+    val recs = readBamRecs(bam)
+    recs should have size 2
+    recs(0).apply[String]("CB") shouldBe "GG-CC"
+    recs(0).apply[String]("CY") shouldBe "== =="
+    recs(1).apply[String]("CB") shouldBe "TA-AA"
+    recs(1).apply[String]("CY") shouldBe "== =="
+  }
+
   it should "fail when read names don't match up" in {
     val r1 = fq(FastqRecord("q1", "AAAAAAAAAA", "=========="))
     val r2 = fq(FastqRecord("x1", "CCCCCCCCCC", "##########"))


### PR DESCRIPTION
## Introduction

I'd like to support extracting cell barcodes with `FastqToBam`.

This requires that the `ReadStructure` specification has support for a cell barcode identifier. I propose we add the `C` operator to the read structure specification. Once we have a `C` operator we can extract cell barcodes from a read and their quality sequences too.

The [SAM spec.](https://samtools.github.io/hts-specs/SAMtags.pdf) recommends we store cell barcode information similarly to molecular indices: hypen-separated for the cell barcode sequences and space-separated for the associated qualities. The recommended tags for cell barcode info is as follows:

- `CB`: cell identifier
- `CR`: cell barcode sequence bases (uncorrected)
- `CY`: Phred qualities of the cell barcode sequence

Along with this PR, I propose we make these changes to the Wiki on [`ReadStructure`](https://github.com/fulcrumgenomics/fgbio/wiki/Read-Structures):

```diff
20c20
< * `FastqToBam` in fgbio to convert from fastq to BAM while preserving sample barcode and UMI information
---
> * `FastqToBam` in fgbio to convert from fastq to BAM while preserving sample barcode, cell barcode, and UMI information
28a29
> * `C` or Cell Barcode: the bases in the segment are a cell bar index sequence used to identify the cell being sequenced
51a53,55
> * A 2x150bp single-cell sequencing run with two cell-specific barcodes separated by a skipped linker and a UMI:
>   * `5C30S5C3S8M99T8B150T`
>   * [`5C30S5C3S8M+T`, `8B`, `+T`]
62c66
< <operator>           ::= "T" | "B" | "M" | "S"
---
> <operator>           ::= "T" | "B" | "M" | "C" | "S"
```

And this change to the read structure validator:

- https://github.com/fulcrumgenomics/fgbio/compare/gh-pages...cv_cell_barcodes_js

## Out of Scope

At this time I did not feel that supporting cell barcodes in `DemuxFastqs` was worth the effort since we'd rather users adopt `fqtk`. So when a cell barcode is encountered, a validation exception is raised. I also did not add cell barcode specific functionality to `ExtractUmisFromBam` since I don't think that's necessary for the function of the tool.

I also intend to skip Picard's [`IlluminaBaseCallsToSam`](https://gatk.broadinstitute.org/hc/en-us/articles/360037225472-IlluminaBasecallsToSam-Picard) and [`IlluminaBaseCallsToFastq`](https://gatk.broadinstitute.org/hc/en-us/articles/360037051752-IlluminaBasecallsToFastq-Picard) because of [numerous issues](https://github.com/broadinstitute/picard/issues?q=is%3Aissue%20state%3Aopen%20(IlluminaBaseCallsToSam%20OR%20IlluminaBaseCallsToFastq)), many of which I've experienced such that I would no longer recommend those tools be used in the era of NovaSeq.

## Next Steps

If this PR is merged and we update the wiki and Javascript validator, then I'd go and make changes to the rest of the ecosystem to ensure better support for cell barcodes in read structures:

- [ ] Python [`ReadStructure`](https://github.com/fulcrumgenomics/fgpyo/blob/39a7f58bcbe6eac7bd9ee667c889a8e558b8b237/fgpyo/read_structure.py#L193) in `fgpyo`
- [ ] Rust [`SegmentType`](https://github.com/fulcrumgenomics/read-structure/blob/295aa041621cd8d95ef88af4d30c03b5d2bb4348/src/segment_type.rs#L18) in `read-structure`
- [ ] Newer Rust demultiplexer [`fqtk`](https://github.com/fulcrumgenomics/fqtk)
- [ ] _**Others?**_