### PR TITLE
Ensure file toRealPath() does not raise for file descriptors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -193,11 +193,11 @@ lazy val root = Project(id="fgbio", base=file("."))
       "org.scala-lang"            %  "scala-reflect"  % scalaVersion.value,
       "org.scala-lang"            %  "scala-compiler" % scalaVersion.value,
       "org.scala-lang.modules"    %% "scala-xml"      % "2.1.0",
-      "com.fulcrumgenomics"       %% "commons"        % "1.7.0",
+      "com.fulcrumgenomics"       %% "commons"        % "1.7.1",
       "com.fulcrumgenomics"       %% "sopt"           % "1.1.0",
       "com.github.samtools"       %  "htsjdk"         % "3.0.5" excludeAll(htsjdkExcludes: _*),
       "org.apache.commons"        %  "commons-math3"  % "3.6.1",
-      "com.beachape"              %% "enumeratum"     % "1.7.1",
+      "com.beachape"              %% "enumeratum"     % "1.7.0",
       "com.intel.gkl"             %  "gkl"            % "0.8.10",
 
       //---------- Test libraries -------------------//


### PR DESCRIPTION
It would be nice to use an official release of commons, but in the meantime I'm opening this PR to track a feature I'd like fgbio to have. Specifically, the ability to use bash process substitution for file handles:

```bash
tool --input <( ... )
```