### PR TITLE
fix: remove explicit ref from docs job checkout to support fork PRs

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -124,9 +124,6 @@ jobs:
       - name: Checkout
         id: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          # To work with the `pull_request` or any other non-`push` even with git-auto-commit
-          ref: ${{ github.head_ref }}
       - name: Generate the docs
         uses: ./.github/actions/docs/
         with:


### PR DESCRIPTION
Fixes the issue in #1125 where the markdown doc generation failed: https://github.com/fulcrumgenomics/fgbio/actions/runs/20318274458/job/58367927183?pr=1125

This was due to github.head_ref checkout out the right branch name but the wrong repo (not the fork).