### PR TITLE
feat: add deterministic tie-breaking to filterToMostCommonAlignment

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
@@ -420,7 +420,8 @@ trait UmiConsensusCaller[ConsensusRead <: SimpleRead] {
       Seq.empty
     }
     else {
-      val bestGroup = groups.maxBy(_.size)
+      // Select group with largest size; use smallest CIGAR as tie-breaker for determinism
+      val bestGroup = groups.maxBy(g => (g.size, g.cigar))(Ordering.Tuple2(Ordering.Int, Cigar.cigarOrdering.reverse))
       // BitSet tracking which original indices are kept - allows O(n) reconstruction in original order
       val keptIndices = new mutable.BitSet(recsIndexed.length)
       forloop (from=0, until=sortedIndices.length) { si =>


### PR DESCRIPTION
## Summary
- Adds deterministic tie-breaking when multiple alignment groups have equal sizes in `filterToMostCommonAlignment`
- Uses element-by-element CIGAR comparison as secondary sort key (smaller CIGAR wins)
- Comparison order: element length, then operator type (M, I, D, N, S, H, P, EQ, X), then total elements

## Test plan
- [x] Added test verifying deterministic selection regardless of input order
- [x] Existing tests pass