### PR TITLE
Ensure file descriptors work with CLI tools that call toInputStream

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -193,7 +193,7 @@ lazy val root = Project(id="fgbio", base=file("."))
       "org.scala-lang"            %  "scala-reflect"  % scalaVersion.value,
       "org.scala-lang"            %  "scala-compiler" % scalaVersion.value,
       "org.scala-lang.modules"    %% "scala-xml"      % "2.1.0",
-      "com.fulcrumgenomics"       %% "commons"        % "1.9.0-93d97fa-SNAPSHOT",
+      "com.fulcrumgenomics"       %% "commons"        % "1.9.0",
       "com.fulcrumgenomics"       %% "sopt"           % "1.2.0",
       "com.github.samtools"       %  "htsjdk"         % "3.0.5" excludeAll(htsjdkExcludes: _*),
       "org.apache.commons"        %  "commons-math3"  % "3.6.1",


### PR DESCRIPTION
Opening as draft until we have an actual release of commons.