### PR TITLE
fix: grant write permission to docs job for gh-pages preview

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -116,6 +116,8 @@ jobs:
     name: Generate tool and metric markdown docs
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: ${{ github.event_name != 'workflow_call' && (github.event_name == 'pull_request' || (github.repository == 'fulcrumgenomics/fgbio' && github.ref == 'refs/heads/main')) }}
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- The `docs` job's gh-pages preview step (`rossjrw/pr-preview-action`) fails with HTTP 401 because the `GITHUB_TOKEN` lacks write access to push to the `gh-pages` branch
- Adds `permissions: contents: write` to the `docs` job so the token can push the preview deployment
- This has been failing on PR builds (e.g. #1125, #1137)

## Test plan
- [x] Verify this PR's own "Generate tool and metric markdown docs" job passes