### PR TITLE
fix: grant pull-requests write permission to docs job for PR preview comments

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -118,6 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     if: ${{ github.event_name != 'workflow_call' && (github.event_name == 'pull_request' || (github.repository == 'fulcrumgenomics/fgbio' && github.ref == 'refs/heads/main')) }}
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- The `pr-preview-action` uses `marocchino/sticky-pull-request-comment` to post a preview link on PRs, which requires `pull-requests: write` permission
- #1138 added `contents: write` for the gh-pages push but missed this permission, causing `Resource not accessible by integration` errors on every PR

## Test plan
- [x] This PR itself will validate the fix — the "Generate tool and metric markdown docs" check should pass and post the preview comment