### PR TITLE
docs: specify order of clipping operations in ClipBam docs

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/bam/ClipBam.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/ClipBam.scala
@@ -69,7 +69,7 @@ import htsjdk.samtools.SamPairUtil
     |from `Soft` to either `SoftWithMask` or `Hard`, and `SoftWithMask` to `Hard`. In all other cases, clipping remains
     |the same prior to applying any other clipping criteria.
     |
-    |The order of operations for clipping are:
+    |The order of operations for clipping is:
     |
     |1. Upgrade of clipping if `--upgrade-clipping` is specified
     |2. Any fixed 5-prime or 3-prime clippings for R1 and/or R2


### PR DESCRIPTION
Good idea to document this order (since order does matter) from this issue:

- https://github.com/fulcrumgenomics/fgbio/issues/1141#issuecomment-3994311318