### PR TITLE
#960: bump htsjdk to 4.2.0, sbt-cov to 2.4.4, fix sbt issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Contributions are welcome and encouraged.
 We will do our best to provide an initial response to any pull request or issue within one-week.
 For urgent matters, please contact us directly.
 
-See [Contributing](Contributing.md) for more details.
+See [Contributing](CONTRIBUTING.md) for more details.
 
 ## Authors
 

--- a/build.sbt
+++ b/build.sbt
@@ -236,7 +236,7 @@ val customMergeStrategy: String => MergeStrategy = {
         MergeStrategy.filterDistinctLines
       case ("spring.schemas" :: Nil) | ("spring.handlers" :: Nil) =>
         MergeStrategy.filterDistinctLines
-      case ("versions" :: "9" :: "module-info.class" :: Nil) =>
+      case ("versions" :: _ :: "module-info.class" :: Nil) =>
         MergeStrategy.discard
       case _ => MergeStrategy.deduplicate
     }

--- a/build.sbt
+++ b/build.sbt
@@ -195,7 +195,7 @@ lazy val root = Project(id="fgbio", base=file("."))
       "org.scala-lang.modules"    %% "scala-xml"      % "2.1.0",
       "com.fulcrumgenomics"       %% "commons"        % "1.9.0",
       "com.fulcrumgenomics"       %% "sopt"           % "1.2.0",
-      "com.github.samtools"       %  "htsjdk"         % "3.0.5" excludeAll(htsjdkExcludes: _*),
+      "com.github.samtools"       %  "htsjdk"         % "4.2.0" excludeAll(htsjdkExcludes: _*),
       "org.apache.commons"        %  "commons-math3"  % "3.6.1",
       "com.beachape"              %% "enumeratum"     % "1.7.0",
       "com.intel.gkl"             %  "gkl"            % "0.8.10",
@@ -236,9 +236,11 @@ val customMergeStrategy: String => MergeStrategy = {
         MergeStrategy.filterDistinctLines
       case ("spring.schemas" :: Nil) | ("spring.handlers" :: Nil) =>
         MergeStrategy.filterDistinctLines
+      case ("versions" :: "9" :: "module-info.class" :: Nil) =>
+        MergeStrategy.discard
       case _ => MergeStrategy.deduplicate
     }
-  case "asm-license.txt" | "overview.html" =>
+  case "asm-license.txt" | "overview.html "| "module-info.class"  =>
     MergeStrategy.discard
   case "logback.xml" =>
     MergeStrategy.first

--- a/build.sbt
+++ b/build.sbt
@@ -240,7 +240,7 @@ val customMergeStrategy: String => MergeStrategy = {
         MergeStrategy.discard
       case _ => MergeStrategy.deduplicate
     }
-  case "asm-license.txt" | "overview.html "| "module-info.class"  =>
+  case "asm-license.txt" | "overview.html" | "module-info.class"  =>
     MergeStrategy.discard
   case "logback.xml" =>
     MergeStrategy.first

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,6 +5,6 @@ addDependencyTreePlugin
 addSbtPlugin("com.typesafe.sbt"  % "sbt-git"       % "1.0.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release"   % "1.0.10")
 addSbtPlugin("com.eed3si9n"      % "sbt-assembly"  % "1.2.0")
-addSbtPlugin("org.scoverage"     % "sbt-scoverage" % "1.6.1")
+addSbtPlugin("org.scoverage"     % "sbt-scoverage" % "2.4.4")
 addSbtPlugin("com.github.sbt"    % "sbt-pgp"       % "2.3.1")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.0")


### PR DESCRIPTION
This bumps htsjdk from 3.0.5. to 4.2.0 (to fix #960); there are no compile errors and all tests pass.

It also fixes a broken link in the README.

## Other changes (to fix the build)

- Running 'sbt assembly' runs into an issue because sbt-scoverage 1.6.1 requires another scala-xml version (so this bumps the sbt-coverage version to 2.4.4).

- Running 'sbt assembly' also runs into trouble with duplicate 'module-info.class' files inside the dependencies, so this updates the merge strategy to discard those files.