### PR TITLE
feat!: allow non-terminal + segment in read structures

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/fastq/DemuxFastqs.scala
+++ b/src/main/scala/com/fulcrumgenomics/fastq/DemuxFastqs.scala
@@ -244,9 +244,10 @@ object DemuxFastqs {
       |3. `M` identifies a unique molecular index read
       |4. `S` identifies a set of bases that should be skipped or ignored
       |
-      |The last `<number><operator>` pair may be specified using a `+` sign instead of number to denote "all remaining
-      |bases". This is useful if, e.g., fastqs have been trimmed and contain reads of varying length. Both reads must
-      |have template bases.  Any molecular identifiers will be concatenated using
+      |At most one `<number><operator>` pair in a read structure may use a `+` sign in place of the number to denote
+      |"all remaining bases", and it may appear at any position in the read structure.  This is useful if, e.g.,
+      |fastqs have been trimmed and contain reads of varying length. Both reads must have template bases.  Any
+      |molecular identifiers will be concatenated using
       |the `-` delimiter and placed in the given SAM record tag (`RX` by default).  Similarly, the sample barcode bases
       |from the given read will be placed in the `BC` tag.
       |

--- a/src/main/scala/com/fulcrumgenomics/fastq/DemuxFastqs.scala
+++ b/src/main/scala/com/fulcrumgenomics/fastq/DemuxFastqs.scala
@@ -245,11 +245,10 @@ object DemuxFastqs {
       |4. `S` identifies a set of bases that should be skipped or ignored
       |
       |At most one `<number><operator>` pair in a read structure may use a `+` sign in place of the number to denote
-      |"all remaining bases", and it may appear at any position in the read structure.  This is useful if, e.g.,
-      |fastqs have been trimmed and contain reads of varying length. Both reads must have template bases.  Any
-      |molecular identifiers will be concatenated using
-      |the `-` delimiter and placed in the given SAM record tag (`RX` by default).  Similarly, the sample barcode bases
-      |from the given read will be placed in the `BC` tag.
+      |"all remaining bases", and it may appear at any position in the read structure.  This is useful if, e.g., fastqs
+      |have been trimmed and contain reads of varying length. Both reads must have template bases.  Any molecular
+      |identifiers will be concatenated using the `-` delimiter and placed in the given SAM record tag (`RX` by default).
+      |Similarly, the sample barcode bases from the given read will be placed in the `BC` tag.
       |
       |Metadata about the samples should be given in either an Illumina Experiment Manager sample sheet or a metadata CSV
       |file.  Formats are described in detail below.

--- a/src/main/scala/com/fulcrumgenomics/fastq/FastqToBam.scala
+++ b/src/main/scala/com/fulcrumgenomics/fastq/FastqToBam.scala
@@ -55,10 +55,10 @@ import java.util
     |4. `C` identifies a cell barcode read
     |5. `S` identifies a set of bases that should be skipped or ignored
     |
-    |The last `<number><operator>` pair may be specified using a `+` sign instead of number to denote "all remaining
-    |bases". This is useful if, e.g., FASTQs have been trimmed and contain reads of varying length.  For example
-    |to convert a paired-end run with an index read and where the first 5 bases of R1 are a UMI and the second
-    |five bases are monotemplate you might specify:
+    |At most one `<number><operator>` pair in a read structure may use a `+` sign in place of the number to denote
+    |"all remaining bases", and it may appear at any position in the read structure.  This is useful if, e.g., FASTQs
+    |have been trimmed and contain reads of varying length.  For example to convert a paired-end run with an index
+    |read and where the first 5 bases of R1 are a UMI and the second five bases are monotemplate you might specify:
     |
     |```
     |--input r1.fq r2.fq i1.fq --read-structures 5M5S+T +T +B

--- a/src/main/scala/com/fulcrumgenomics/fastq/FastqToBam.scala
+++ b/src/main/scala/com/fulcrumgenomics/fastq/FastqToBam.scala
@@ -58,7 +58,8 @@ import java.util
     |At most one `<number><operator>` pair in a read structure may use a `+` sign in place of the number to denote
     |"all remaining bases", and it may appear at any position in the read structure.  This is useful if, e.g., FASTQs
     |have been trimmed and contain reads of varying length.  For example to convert a paired-end run with an index
-    |read and where the first 5 bases of R1 are a UMI and the second five bases are monotemplate you might specify:
+    |read and where the first 5 bases of R1 are a UMI and the next five bases should be skipped (e.g. because they
+    |are monotemplate) you might specify:
     |
     |```
     |--input r1.fq r2.fq i1.fq --read-structures 5M5S+T +T +B

--- a/src/main/scala/com/fulcrumgenomics/illumina/RunInfo.scala
+++ b/src/main/scala/com/fulcrumgenomics/illumina/RunInfo.scala
@@ -74,9 +74,9 @@ object RunInfo {
     val segments        = (xml \\ "RunInfo" \\ "Run" \\ "Reads" \\ "Read").map { read =>
       val isIndexedRead = (read \ "@IsIndexedRead").text.equals("Y")
       val numCycles     = (read \ "@NumCycles").text.toInt
-      ReadSegment(offset=0, length=Some(numCycles), kind=if (isIndexedRead) SegmentType.SampleBarcode else SegmentType.Template)
+      ReadSegment(length=Some(numCycles), kind=if (isIndexedRead) SegmentType.SampleBarcode else SegmentType.Template)
     }
-    val readStructure = ReadStructure(segments, resetOffsets=true)
+    val readStructure = ReadStructure(segments)
     val numLanes = (xml \\ "RunInfo" \\ "Run" \\ "FlowcellLayout" \ "@LaneCount").text.toInt
 
     RunInfo(

--- a/src/main/scala/com/fulcrumgenomics/umi/ExtractUmisFromBam.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/ExtractUmisFromBam.scala
@@ -59,9 +59,8 @@ import htsjdk.samtools.util._
     |it will lead to an BAM with inconsistent records.
     |
     |The read structure describes the structure of a given read as one or more read segments. A read segment describes
-    |a contiguous stretch of bases of the same type (ex. template bases) of some length and some offset from the start
-    |of the read.  Read structures are made up of `<number><operator>` pairs much like the CIGAR string in BAM files.
-    |Five kinds of operators are recognized:
+    |a contiguous stretch of bases of the same type (ex. template bases) of some length.  Read structures are made up
+    |of `<number><operator>` pairs much like the CIGAR string in BAM files.  Five kinds of operators are recognized:
     |
     |1. `T` identifies a template read
     |2. `B` identifies a sample barcode read
@@ -69,8 +68,12 @@ import htsjdk.samtools.util._
     |4. `C` identifies a cell barcode read
     |5. `S` identifies a set of bases that should be skipped or ignored
     |
-    |The last `<number><operator>` pair may be specified using a '+' sign instead of number to denote "all remaining
-    |bases". This is useful if, e.g., fastqs have been trimmed and contain reads of varying length.
+    |At most one `<number><operator>` pair may use a `+` sign in place of the number to denote "all remaining bases",
+    |and it may appear at any position in the read structure.  This is useful if, e.g., fastqs have been trimmed and
+    |contain reads of varying length.
+    |
+    |Note that when a clipping attribute is given via `--clipping-attribute`, every segment except possibly the last
+    |must have a fixed length.
     |
     |An example would be `10B3M7S100T` which describes 120 bases, with the first ten bases being a sample barcode,
     |bases 11-13 being a molecular index, bases 14-20 ignored, and bases 21-120 being template bases. See
@@ -254,19 +257,33 @@ object ExtractUmisFromBam {
   /**
     * Update the clipping information produced by Picard's MarkIlluminaAdapters to account for any non-template bases
     * that will be removed from the read.
+    *
+    * Only the last segment of the read structure may be indefinite-length; stripping non-template bases
+    * from past a non-terminal `+` would require knowing the read length, which is not a use case we support.
     */
   private[umi] def updateClippingInformation(record: SamRecord,
                                              clippingAttribute: Option[String],
                                              readStructure: ReadStructure): Unit = {
-    clippingAttribute.map(tag => (tag, record.get[Int](tag))) match {
+    clippingAttribute.flatMap(tag => record.get[Int](tag).map(pos => (tag, pos))) match {
       case None => ()
-      case Some((_, None)) => ()
-      case Some((tag, Some(clippingPosition))) =>
-        val newClippingPosition = readStructure.takeWhile(_.offset < clippingPosition).filter(_.kind == SegmentType.Template).map { t =>
-          if (t.length.exists(l => t.offset + l < clippingPosition)) t.length.get
-          else clippingPosition - t.offset
-        }.sum
-        record(tag) = newClippingPosition
+      case Some((tag, clippingPosition)) =>
+        require(
+          readStructure.dropRight(1).forall(_.hasFixedLength),
+          s"Clipping update requires fixed lengths for all segments except possibly the last; got $readStructure"
+        )
+        // Walk the segments in read order, summing lengths of non-template segments that fall before the
+        // clipping position. The new clipping position is the old one minus the number of bases stripped.
+        var stripped = 0
+        var offset   = 0
+        val iter     = readStructure.iterator
+        while (offset < clippingPosition && iter.hasNext) {
+          val seg    = iter.next()
+          val segLen = seg.length.getOrElse(clippingPosition - offset) // `+` is absorbent: only the last segment
+          val covered = math.min(segLen, clippingPosition - offset)
+          if (seg.kind != SegmentType.Template) stripped += covered
+          offset += segLen
+        }
+        record(tag) = clippingPosition - stripped
     }
   }
 }

--- a/src/main/scala/com/fulcrumgenomics/util/ReadStructure.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/ReadStructure.scala
@@ -24,7 +24,6 @@
 
 package com.fulcrumgenomics.util
 
-import com.fulcrumgenomics.FgBioDef._
 import com.fulcrumgenomics.util.ReadStructure.{SubReadWithQuals, SubReadWithoutQuals}
 
 import scala.collection.immutable
@@ -48,26 +47,29 @@ object ReadStructure {
   case class SubReadWithoutQuals(bases: String, segment: ReadSegment) extends SubRead
   case class SubReadWithQuals(bases: String, quals: String, segment: ReadSegment) extends SubRead
 
-  /** Creates a new ReadStructure, optionally resetting the offsets on each of the segments. */
-  def apply(segments: Seq[ReadSegment], resetOffsets: Boolean = false): ReadStructure = {
-    // Check that none but the last segment has an indefinite length
-    require(segments.dropRight(1).forall(_.hasFixedLength), s"Variable length ($AnyLengthChar) can only be used in the last segment: ${segments.mkString}")
-
-    val segs = if (!resetOffsets) segments else {
-      var off = 0
-      segments.map { s => yieldAndThen(s.copy(offset=off)) { off += s.length.getOrElse(0) } }
-    }
-
-    segments.filter(_.length.exists(_ <= 0)) match {
-      case Seq() => new ReadStructure(segs)
-      case _ => throw new IllegalArgumentException(s"Read structure contained zero length segments: ${segments.mkString}")
+  /** Creates a new ReadStructure from a sequence of segments. At most one segment may be the
+    * indefinite-length (`+`) segment, and it may appear at any position. */
+  def apply(segments: Seq[ReadSegment]): ReadStructure = {
+    require(segments.nonEmpty, "Can't create a read structure with zero segments.")
+    val indefiniteCount = segments.count(!_.hasFixedLength)
+    require(
+      indefiniteCount <= 1,
+      s"At most one segment may have indefinite length ($AnyLengthChar): ${segments.mkString}"
+    )
+    segments.find(_.length.exists(_ <= 0)) match {
+      case Some(bad) =>
+        throw new IllegalArgumentException(s"Read structure contained a zero or negative length segment: $bad in ${segments.mkString}")
+      case None =>
+        new ReadStructure(segments.toIndexedSeq)
     }
   }
 
-  /** Creates a read structure from a string */
+  /** Creates a read structure from its string form (e.g. `"8B+M10T"`), in which each segment is a
+    * length (either an integer or `+` for indefinite length) followed by a one-character segment-type
+    * code.  Whitespace is ignored. */
   def apply(readStructure: String): ReadStructure = {
     val tidied = readStructure.toUpperCase.filterNot(Character.isWhitespace)
-    ReadStructure(segments=segments(rs=tidied), resetOffsets=true)
+    ReadStructure(segments(rs=tidied))
   }
 
   /** Creates a sequence of read segments from a string. */
@@ -98,7 +100,7 @@ object ReadStructure {
       else {
         val code = rs.charAt(i)
         i += 1
-        try   { segs += ReadSegment(0, segLength, SegmentType(code)) }
+        try   { segs += ReadSegment(segLength, SegmentType(code)) }
         catch { case _: Exception => invalid("Read structure segment had unknown type", rs, parsePosition, i) }
       }
     }
@@ -122,25 +124,79 @@ object ReadStructure {
 }
 
 /**
-  * Describes the structure of a give read.  A read contains one or more read segments. A read segment describes
-  * a contiguous stretch of bases of the same type (ex. template bases) of some length and some offset from the start
-  * of the read.
+  * Describes the structure of a given read.  A read contains one or more read segments. A read segment
+  * describes a contiguous stretch of bases of the same type (e.g. template bases) and some length.
+  *
+  * At most one segment may be the indefinite-length (`+`) segment, meaning "whatever is left of the read".
+  * The `+` segment may appear at any position, not only at the end.
   *
   * @param segments the segments composing this read structure.
   */
-class ReadStructure private(val segments: Seq[ReadSegment]) extends immutable.Seq[ReadSegment] {
-  require(segments.nonEmpty, "Can't create a read structure with zero segments.")
+class ReadStructure private(val segments: IndexedSeq[ReadSegment]) extends immutable.Seq[ReadSegment] {
+  import ReadStructure.AnyLengthChar
 
-  /** The minimum length read that this read structure can process. */
-  private val minLength = segments.flatMap(_.length).sum
+  /** The index of the indefinite-length segment, if any. */
+  private val plusIndex: Option[Int] = segments.indexWhere(!_.hasFixedLength) match {
+    case -1 => None
+    case i  => Some(i)
+  }
+
+  /** Sum of lengths across all fixed-length segments. */
+  private val fixedLengthSum: Int = segments.iterator.flatMap(_.length).sum
+
+  /** Sum of fixed-length segment lengths strictly AFTER the `+` segment (zero when there is no `+`
+    * or the `+` is trailing). Used to resolve the end of the `+` segment at extract time. */
+  private val postPlusLen: Int = plusIndex match {
+    case Some(p) => segments.drop(p + 1).iterator.flatMap(_.length).sum
+    case None    => 0
+  }
+
+  /** Signed per-segment start offset.
+    *
+    *  - `>= 0` — offset from the start of the read. Used for segments before or at the `+`, and for
+    *    every segment when there is no `+`.
+    *  - `<  0` — distance from the end of the read, stored as a negative number. Used for segments
+    *    strictly after a non-terminal `+`. The actual start position in a read of length `L` is
+    *    `L + offset` (i.e. `L - (-offset)`).
+    */
+  private val offsets: IndexedSeq[Int] = {
+    val n   = segments.length
+    val out = Array.fill[Int](n)(0)
+
+    // Forward pass up to and including the `+` (or the whole vec if no `+`).
+    val forwardEnd = plusIndex.map(_ + 1).getOrElse(n)
+    var off        = 0
+    var i          = 0
+    while (i < forwardEnd) {
+      out(i) = off
+      off += segments(i).length.getOrElse(0)
+      i += 1
+    }
+
+    // Backward pass for segments strictly after the `+`, if any.
+    plusIndex.foreach { p =>
+      var distFromEnd = 0
+      var j           = n - 1
+      while (j > p) {
+        val len = segments(j).length.getOrElse(
+          throw new IllegalStateException(s"Post-$AnyLengthChar segment must have a fixed length; got ${segments(j)}")
+        )
+        distFromEnd += len
+        out(j)      = -distFromEnd
+        j          -= 1
+      }
+    }
+
+    out.toIndexedSeq
+  }
 
   /** Returns true if the ReadStructure has a fixed (i.e. non-variable) length. */
-  def hasFixedLength: Boolean = segments.last.hasFixedLength
+  def hasFixedLength: Boolean = plusIndex.isEmpty
 
-  /** Returns the fixed length if there is one. Throws an exception on segments without fixed lengths! */
+  /** Returns the fixed length if there is one. Throws an exception on structures with an indefinite segment! */
   def fixedLength: Int = {
-    require(hasFixedLength, s"fixedLength called on variable length segment: $this")
-    this.minLength
+    require(hasFixedLength, s"fixedLength called on variable length structure: $this")
+    fixedLengthSum
   }
 
   /** Length is defined as the number of segments (not bases!) in the read structure. */
@@ -153,23 +209,95 @@ class ReadStructure private(val segments: Seq[ReadSegment]) extends immutable.Se
   override def iterator: Iterator[ReadSegment] = segments.iterator
 
   /** Generates the String format of the ReadStructure that can be re-parsed. */
-  override def toString: String = segments.map(_.toString).mkString
+  override def toString: String = segments.iterator.map(_.toString).mkString
 
-  /** Generates a new ReadStucture that is the same as this one except that the last segment has undefined length. */
+  /** Generates a new ReadStructure that is the same as this one except that the last segment has undefined length.
+    * If the structure already has a `+` segment (in any position), it is returned unchanged, since it already
+    * handles reads of variable length. */
   def withVariableLastSegment: ReadStructure =
-    if (this.segments.last.hasFixedLength) new ReadStructure(segments.dropRight(1) :+ segments.last.copy(length=None)) else this
+    if (this.hasFixedLength) ReadStructure(segments.dropRight(1) :+ segments.last.copy(length = None)) else this
 
-  /** Splits the given bases into tuples with its associated read segment.  If strict is false then only return
-    * tuples for which we have bases in `bases`, otherwise throw an exception.
-    **/
-  def extract(bases: String): Seq[SubReadWithoutQuals] = segments.map(_.extract(bases))
+  /** Validates that a read of the given length can be extracted by this structure.
+    * For fixed-length structures we require an exact length match; silent truncation of trailing
+    * bases is almost always a bug (wrong structure, stray adapter, etc.), so we require the caller
+    * to either supply an exact-length read or convert the structure via [[withVariableLastSegment]]. */
+  private def validateReadLength(readLen: Int): Unit = {
+    if (plusIndex.isDefined) {
+      require(
+        readLen >= fixedLengthSum,
+        s"Read length $readLen is shorter than required $fixedLengthSum for read structure $this"
+      )
+    }
+    else {
+      require(
+        readLen == fixedLengthSum,
+        s"Read length $readLen does not match fixed read structure length $fixedLengthSum for $this"
+      )
+    }
+  }
 
-  /** Splits the given bases and qualities into triples with its associated read segment.  If strict is false then only
-    * return tuples for which we have bases in `bases`, otherwise throw an exception.
-    **/
-  def extract(bases: String, quals: String): Seq[SubReadWithQuals] = {
-    assert(bases.length == quals.length)
-    segments.map(s => s.extract(bases, quals))
+  /** Returns the `[start, end)` span within a read of length `readLen` that corresponds to the
+    * segment at index `i`. */
+  private def spanOf(i: Int, readLen: Int): (Int, Int) = {
+    if (plusIndex.contains(i)) {
+      // The indefinite-length segment: runs from its stored start offset to just before the post-`+` region.
+      (offsets(i), readLen - postPlusLen)
+    }
+    else {
+      val off   = offsets(i)
+      val start = if (off >= 0) off else readLen + off
+      (start, start + segments(i).length.get)
+    }
+  }
+
+  /** Extracts the bases corresponding to each read segment.  [[SegmentType.Skip]] segments are omitted
+    * from the returned sequence because callers almost always throw those bases away; use the two-argument
+    * overload with `includeSkips = true` to keep them. */
+  def extract(bases: String): Seq[SubReadWithoutQuals] = extract(bases, includeSkips = false)
+
+  /** Extracts the bases corresponding to each read segment.
+    *
+    * @param bases the raw read bases
+    * @param includeSkips whether to include [[SegmentType.Skip]] segments in the returned sequence
+    */
+  def extract(bases: String, includeSkips: Boolean): Seq[SubReadWithoutQuals] = {
+    validateReadLength(bases.length)
+    val readLen = bases.length
+    val builder = IndexedSeq.newBuilder[SubReadWithoutQuals]
+    var i       = 0
+    while (i < segments.length) {
+      val seg = segments(i)
+      if (includeSkips || seg.kind != SegmentType.Skip) {
+        val (start, end) = spanOf(i, readLen)
+        builder += SubReadWithoutQuals(bases.substring(start, end), seg)
+      }
+      i += 1
+    }
+    builder.result()
+  }
+
+  /** Extracts the bases and qualities corresponding to each read segment.
+    *
+    * @param bases the raw read bases
+    * @param quals the raw read qualities; must be the same length as `bases`
+    * @param includeSkips whether to include [[SegmentType.Skip]] segments in the returned sequence;
+    *                     defaults to `false` because callers almost always throw those bases away.
+    */
+  def extract(bases: String, quals: String, includeSkips: Boolean = false): Seq[SubReadWithQuals] = {
+    require(bases.length == quals.length, s"Bases and quals differ in length: ${bases.length} vs ${quals.length}")
+    validateReadLength(bases.length)
+    val readLen = bases.length
+    val builder = IndexedSeq.newBuilder[SubReadWithQuals]
+    var i       = 0
+    while (i < segments.length) {
+      val seg = segments(i)
+      if (includeSkips || seg.kind != SegmentType.Skip) {
+        val (start, end) = spanOf(i, readLen)
+        builder += SubReadWithQuals(bases.substring(start, end), quals.substring(start, end), seg)
+      }
+      i += 1
+    }
+    builder.result()
   }
 
   /** Returns just the segments of a given kind. */
@@ -205,53 +333,13 @@ object SegmentType {
   }
 }
 
-object ReadSegment {
-  val Types: Seq[Char] = Seq('T', 'B', 'M', 'C', 'S') // TODO: this is never used, can we delete it?
-
-  /** Creates a new ReadSegment with undefined length (i.e. length=0 or more). */
-  def apply(offset: Int, c: Char): ReadSegment = new ReadSegment(offset, None, kind=SegmentType(c))
-
-  /** Constructs a ReadSegment with a definite length using Char c to find the segment type. */
-  def apply(offset: Int, length: Int, c: Char): ReadSegment = new ReadSegment(offset=offset, length=Some(length), kind=SegmentType(c))
-}
-
 /**
   * Encapsulates all the information about a segment within a read structure. A segment can either
   * have a definite length, in which case length must be Some(Int), or an indefinite length (can be
-  * any length, 0 or more) in which case length must be None.
+  * any length, 0 or more) in which case length must be None.  The position of a segment's bases
+  * within a read is tracked by the enclosing [[ReadStructure]], not here.
   */
-case class ReadSegment (offset: Int, length: Option[Int], kind: SegmentType) {
-  /** Checks some requirements and then calculates the end position for the segment for the given read. */
-  private def calculateEnd(bases: String): Int = {
-    require(bases.length >= offset, s"Read ends before read segment starts: $this")
-    length.foreach(l => require(bases.length >= offset + l, s"Read ends before end of segment: $this"))
-
-    if (hasFixedLength) math.min(offset + fixedLength, bases.length)
-    else bases.length
-  }
-
-  /** Gets the bases associated with this read segment.  If strict is false then only return
-    * the sub-sequence for which we have bases in `bases`, otherwise throw an exception.
-    **/
-  private[util] def extract(bases: String): SubReadWithoutQuals = {
-    val end = calculateEnd(bases)
-    SubReadWithoutQuals(bases=bases.substring(offset, end), segment=resized(end))
-  }
-
-  /** Gets the bases and qualities associated with this read segment.  If strict is false then only return
-    * the sub-sequence for which we have bases in `bases`, otherwise throw an exception.
-    **/
-  private[util] def extract(bases: String, quals: String): SubReadWithQuals = {
-    require(bases.length == quals.length, s"Bases and quals differ in length: $bases $quals")
-    val end = calculateEnd(bases)
-    SubReadWithQuals(bases=bases.substring(offset, end), quals=quals.substring(offset, end), segment=resized(end))
-  }
-
-  private def resized(end: Int): ReadSegment = {
-    val newLength = end - offset
-    if (length.contains(newLength)) this else this.copy(length=Some(newLength))
-  }
-
+case class ReadSegment(length: Option[Int], kind: SegmentType) {
   /** Returns true if the read segment has a defined length. */
   def hasFixedLength: Boolean = this.length.nonEmpty
 
@@ -260,4 +348,9 @@ case class ReadSegment (offset: Int, length: Option[Int], kind: SegmentType) {
 
   /** Provides a string representation of this segment (ex. "23T" or "4M"). */
   override def toString: String = s"${length.getOrElse(ReadStructure.AnyLengthChar)}${kind.code}"
+}
+
+object ReadSegment {
+  /** Constructs a [[ReadSegment]] from a length and a segment type character. */
+  def apply(length: Int, c: Char): ReadSegment = ReadSegment(length = Some(length), kind = SegmentType(c))
 }

--- a/src/test/scala/com/fulcrumgenomics/umi/ExtractUmisFromBamTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/ExtractUmisFromBamTest.scala
@@ -427,5 +427,25 @@ class ExtractUmisFromBamTest extends UnitSpec with OptionValues {
     record("XT") = 80
     ExtractUmisFromBam.updateClippingInformation(record, Some("XT"), ReadStructure("75T10S15T"))
     record[Int]("XT") shouldBe 75
+
+    // molecular-barcode prefix that gets stripped: a clip past the 10M should shift down by 10
+    record("XT") = 50
+    ExtractUmisFromBam.updateClippingInformation(record, Some("XT"), ReadStructure("10M90T"))
+    record[Int]("XT") shouldBe 40
+
+    // clip position exactly on a segment boundary (end of the skip)
+    record("XT") = 30
+    ExtractUmisFromBam.updateClippingInformation(record, Some("XT"), ReadStructure("20T10S70T"))
+    record[Int]("XT") shouldBe 20
+
+    // clip position exactly on the next segment's start when that segment is a template
+    record("XT") = 20
+    ExtractUmisFromBam.updateClippingInformation(record, Some("XT"), ReadStructure("10M10T80T"))
+    record[Int]("XT") shouldBe 10
+
+    // multiple template segments with a mol barcode between them; clip lands in the second template
+    record("XT") = 40
+    ExtractUmisFromBam.updateClippingInformation(record, Some("XT"), ReadStructure("20T10M70T"))
+    record[Int]("XT") shouldBe 30
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/umi/ExtractUmisFromBamTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/ExtractUmisFromBamTest.scala
@@ -447,5 +447,17 @@ class ExtractUmisFromBamTest extends UnitSpec with OptionValues {
     record("XT") = 40
     ExtractUmisFromBam.updateClippingInformation(record, Some("XT"), ReadStructure("20T10M70T"))
     record[Int]("XT") shouldBe 30
+
+    // terminal `+` is the only positive `+` case allowed; clip should shift by the same 10 as `10M90T`
+    record("XT") = 50
+    ExtractUmisFromBam.updateClippingInformation(record, Some("XT"), ReadStructure("10M+T"))
+    record[Int]("XT") shouldBe 40
+
+    // a non-terminal `+` cannot be combined with a clipping attribute, since translating the clip
+    // position would require knowing the read length
+    record("XT") = 30
+    an[Exception] should be thrownBy {
+      ExtractUmisFromBam.updateClippingInformation(record, Some("XT"), ReadStructure("10M+M5T"))
+    }
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/util/ReadStructureTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/util/ReadStructureTest.scala
@@ -25,7 +25,6 @@
 package com.fulcrumgenomics.util
 
 import com.fulcrumgenomics.testing.UnitSpec
-import com.fulcrumgenomics.util.ReadStructure.SubReadWithQuals
 import com.fulcrumgenomics.util.SegmentType._
 import org.scalatest.OptionValues
 
@@ -34,31 +33,26 @@ import scala.util.Try
 class ReadStructureTest extends UnitSpec with OptionValues {
 
   private def compareReadStructures(actual: ReadStructure, expected: Seq[ReadSegment]) = {
-    // make sure the segments match
     actual shouldBe expected
-    // make sure the string representations are the same
     actual.toString shouldBe ReadStructure(expected).toString
   }
 
-  private def compareReadStructuresResetOffset(actual: Seq[ReadSegment], expected: ReadStructure) = {
-    val actualReadStructure = ReadStructure(actual, resetOffsets=true)
-    compareReadStructures(actualReadStructure, expected)
-  }
-
-  private def T(off: Int, len: Int) = ReadSegment(offset=off, length=Some(len), kind=SegmentType.Template)
-  private def B(off: Int, len: Int) = ReadSegment(offset=off, length=Some(len), kind=SegmentType.SampleBarcode)
-  private def M(off: Int, len: Int) = ReadSegment(offset=off, length=Some(len), kind=SegmentType.MolecularBarcode)
-  private def S(off: Int, len: Int) = ReadSegment(offset=off, length=Some(len), kind=SegmentType.Skip)
+  private def T(len: Int) = ReadSegment(length = Some(len), kind = Template)
+  private def B(len: Int) = ReadSegment(length = Some(len), kind = SampleBarcode)
+  private def M(len: Int) = ReadSegment(length = Some(len), kind = MolecularBarcode)
+  private def S(len: Int) = ReadSegment(length = Some(len), kind = Skip)
+  private val AnyT = ReadSegment(length = None, kind = Template)
+  private val AnyM = ReadSegment(length = None, kind = MolecularBarcode)
 
   "ReadStructure" should "be built from a string" in {
-    compareReadStructures(ReadStructure("1T"), Seq(T(0, 1)))
-    compareReadStructures(ReadStructure("1B"), Seq(B(0, 1)))
-    compareReadStructures(ReadStructure("1M"), Seq(M(0, 1)))
-    compareReadStructures(ReadStructure("1S"), Seq(S(0, 1)))
-    compareReadStructures(ReadStructure("101T"), Seq(T(0, 101)))
-    compareReadStructures(ReadStructure("5B101T"), Seq(B(0, 5), T(5, 101)))
-    compareReadStructures(ReadStructure("123456789T"), Seq(T(0, 123456789)))
-    compareReadStructures(ReadStructure("10T10B10B10S10M"), Seq(T(0, 10), B(10, 10), B(20, 10), S(30, 10), M(40, 10)))
+    compareReadStructures(ReadStructure("1T"), Seq(T(1)))
+    compareReadStructures(ReadStructure("1B"), Seq(B(1)))
+    compareReadStructures(ReadStructure("1M"), Seq(M(1)))
+    compareReadStructures(ReadStructure("1S"), Seq(S(1)))
+    compareReadStructures(ReadStructure("101T"), Seq(T(101)))
+    compareReadStructures(ReadStructure("5B101T"), Seq(B(5), T(101)))
+    compareReadStructures(ReadStructure("123456789T"), Seq(T(123456789)))
+    compareReadStructures(ReadStructure("10T10B10B10S10M"), Seq(T(10), B(10), B(10), S(10), M(10)))
   }
 
   it should "allow whitespace within the read structure and strip it" in {
@@ -66,26 +60,31 @@ class ReadStructureTest extends UnitSpec with OptionValues {
     ReadStructure(" 75T  8B   8B     75T  ").toString shouldBe "75T8B8B75T"
   }
 
-  it should "allow + only once and only for the last segment of the read" in {
-    import SegmentType._
-    ReadStructure("5M+T") shouldBe Seq(ReadSegment(0, Some(5), MolecularBarcode), ReadSegment(5, None, Template))
-    ReadStructure("+M")   shouldBe Seq(ReadSegment(0, None, MolecularBarcode))
+  it should "accept the + segment at any position, at most once" in {
+    ReadStructure("5M+T") shouldBe Seq(M(5), AnyT)
+    ReadStructure("+M")   shouldBe Seq(AnyM)
+    ReadStructure("+M70T") shouldBe Seq(AnyM, T(70))
+    ReadStructure("8B+M10T") shouldBe Seq(B(8), AnyM, T(10))
+    ReadStructure("10T8B+M10T") shouldBe Seq(T(10), B(8), AnyM, T(10))
+
     an[Exception] shouldBe thrownBy { ReadStructure("++M") }
     an[Exception] shouldBe thrownBy { ReadStructure("5M++T") }
     an[Exception] shouldBe thrownBy { ReadStructure("5M70+T") }
     an[Exception] shouldBe thrownBy { ReadStructure("+M+T") }
-    an[Exception] shouldBe thrownBy { ReadStructure("+M70T") }
+    an[Exception] shouldBe thrownBy { ReadStructure("5M+T+B") }
   }
 
-  it should "be built from segments while resetting their offset" in {
-    compareReadStructuresResetOffset(Seq(T(Int.MaxValue, 1)), ReadStructure("1T"))
-    compareReadStructuresResetOffset(Seq(B(Int.MaxValue, 1)), ReadStructure("1B"))
-    compareReadStructuresResetOffset(Seq(M(Int.MaxValue, 1)), ReadStructure("1M"))
-    compareReadStructuresResetOffset(Seq(S(Int.MaxValue, 1)), ReadStructure("1S"))
-    compareReadStructuresResetOffset(Seq(T(Int.MaxValue, 101)), ReadStructure("101T"))
-    compareReadStructuresResetOffset(Seq(B(Int.MaxValue, 5), T(5, 101)), ReadStructure("5B101T"))
-    compareReadStructuresResetOffset(Seq(T(Int.MaxValue, 123456789)), ReadStructure("123456789T"))
-    compareReadStructuresResetOffset(Seq(T(Int.MaxValue, 10), B(Int.MaxValue, 10), B(Int.MaxValue, 10), S(Int.MaxValue, 10), M(Int.MaxValue, 10)), ReadStructure("10T10B10B10S10M"))
+  it should "round-trip non-terminal + structures through toString" in {
+    Seq("8B+M10T", "+B10T", "10T8B+M10T", "5M+T", "+M", "+T").foreach { s =>
+      ReadStructure(s).toString shouldBe s
+    }
+  }
+
+  it should "be built from a sequence of segments" in {
+    ReadStructure(Seq(T(1))) shouldBe Seq(T(1))
+    ReadStructure(Seq(B(5), T(101))) shouldBe Seq(B(5), T(101))
+    ReadStructure(Seq(T(10), B(10), B(10), S(10), M(10))) shouldBe Seq(T(10), B(10), B(10), S(10), M(10))
+    ReadStructure(Seq(B(8), AnyM, T(10))) shouldBe Seq(B(8), AnyM, T(10))
   }
 
   it should "not be built from invalid structures" in {
@@ -97,12 +96,21 @@ class ReadStructureTest extends UnitSpec with OptionValues {
     Try { ReadStructure("23T2TT23T") }.failed.get.getMessage should include ("23T2T[T]23T")
   }
 
+  it should "reject segments with zero or negative length" in {
+    an[Exception] shouldBe thrownBy { ReadStructure(Seq(ReadSegment(length = Some(0), kind = Template))) }
+    an[Exception] shouldBe thrownBy { ReadStructure(Seq(ReadSegment(length = Some(-1), kind = Template))) }
+  }
+
+  it should "reject construction with multiple + segments via the segments constructor" in {
+    an[Exception] shouldBe thrownBy { ReadStructure(Seq(AnyM, AnyT)) }
+  }
+
   it should "collect segments of a single type" in {
     val rs = ReadStructure("10M9T8B7S10M9T8B7S")
-    rs.templateSegments         should contain theSameElementsInOrderAs Seq(T(10, 9), T(44, 9))
-    rs.molecularBarcodeSegments should contain theSameElementsInOrderAs Seq(M(0, 10), M(34, 10))
-    rs.sampleBarcodeSegments    should contain theSameElementsInOrderAs Seq(B(19, 8), B(53, 8))
-    rs.skipSegments             should contain theSameElementsInOrderAs Seq(S(27, 7), S(61, 7))
+    rs.templateSegments         should contain theSameElementsInOrderAs Seq(T(9), T(9))
+    rs.molecularBarcodeSegments should contain theSameElementsInOrderAs Seq(M(10), M(10))
+    rs.sampleBarcodeSegments    should contain theSameElementsInOrderAs Seq(B(8), B(8))
+    rs.skipSegments             should contain theSameElementsInOrderAs Seq(S(7), S(7))
   }
 
   "ReadStructure.withVariableLastSegment" should "convert the last segment to a variant length segment" in {
@@ -112,9 +120,31 @@ class ReadStructureTest extends UnitSpec with OptionValues {
     ReadStructure("5B+T").withVariableLastSegment.toString  shouldBe "5B+T"
   }
 
-  "ReadStructure.extract" should "get extract the bases for each segment" in {
+  it should "return itself unchanged when a non-terminal + segment is present" in {
+    // A non-terminal + already makes the structure variable-length; the result must not have two + segments.
+    ReadStructure("8B+M10T").withVariableLastSegment.toString  shouldBe "8B+M10T"
+    ReadStructure("+B10T").withVariableLastSegment.toString    shouldBe "+B10T"
+    ReadStructure("5T+M5B").withVariableLastSegment.toString   shouldBe "5T+M5B"
+  }
+
+  it should "correctly extract bases after withVariableLastSegment on a non-terminal + structure" in {
+    // Simulates the DemuxFastqs.variableReadStructures path: calling withVariableLastSegment on a
+    // structure that already has a non-terminal + must leave the structure unchanged so that extract
+    // still resolves spans correctly.
+    val rs        = ReadStructure("8B+M10T")
+    val converted = rs.withVariableLastSegment
+    converted.toString shouldBe "8B+M10T"  // must be identical — no extra + added
+    val bases = "BBBBBBBBUUUUUUUUUUUUTTTTTTTTTT"
+    val out   = converted.extract(bases)
+    out should have size 3
+    out(0).kind  shouldBe SampleBarcode;    out(0).bases shouldBe "BBBBBBBB"
+    out(1).kind  shouldBe MolecularBarcode; out(1).bases shouldBe "UUUUUUUUUUUU"
+    out(2).kind  shouldBe Template;         out(2).bases shouldBe "TTTTTTTTTT"
+  }
+
+  "ReadStructure.extract" should "extract the bases for each segment" in {
     val rs = ReadStructure("2T2B2M2C2S")
-    rs.extract("AACCGGNNTT").foreach { r =>
+    rs.extract("AACCGGNNTT", includeSkips = true).foreach { r =>
       r.kind match {
         case Template         => r.bases shouldBe "AA"
         case SampleBarcode    => r.bases shouldBe "CC"
@@ -126,8 +156,8 @@ class ReadStructureTest extends UnitSpec with OptionValues {
 
     an[Exception] should be thrownBy rs.extract("AAAAAAA")
 
-    // the last segment is truncated
-    rs.withVariableLastSegment.extract("AACCGGNNT").foreach { r =>
+    // trailing variable segment absorbs the short read's remaining base
+    rs.withVariableLastSegment.extract("AACCGGNNT", includeSkips = true).foreach { r =>
       r.kind match {
         case Template         => r.bases shouldBe "AA"
         case SampleBarcode    => r.bases shouldBe "CC"
@@ -136,8 +166,9 @@ class ReadStructureTest extends UnitSpec with OptionValues {
         case Skip             => r.bases shouldBe "T"
       }
     }
-    // the last segment is skipped
-    rs.withVariableLastSegment.extract("AACCGGNN").foreach { r =>
+    // trailing + can be zero-length: a read that ends exactly at the end of the fixed portion
+    // produces an empty bases string for the + segment (this pins the "0 or more" semantics for +).
+    rs.withVariableLastSegment.extract("AACCGGNN", includeSkips = true).foreach { r =>
       r.kind match {
         case Template         => r.bases shouldBe "AA"
         case SampleBarcode    => r.bases shouldBe "CC"
@@ -148,10 +179,23 @@ class ReadStructureTest extends UnitSpec with OptionValues {
     }
   }
 
+  it should "omit Skip segments from the result by default" in {
+    val rs  = ReadStructure("2T2B2M2C2S")
+    val out = rs.extract("AACCGGNNTT")
+    out.map(_.segment.kind) should contain noElementsOf Seq(Skip)
+    out.map(_.segment.kind) should contain theSameElementsInOrderAs Seq(Template, SampleBarcode, MolecularBarcode, CellBarcode)
+    rs.extract("AACCGGNNTT", "1122334455").map(_.segment.kind) should contain noElementsOf Seq(Skip)
+  }
 
-  "ReadStructure.extract(bases, quals)" should "get extract the bases and qualities for each segment" in {
+  it should "include Skip segments when includeSkips is true" in {
     val rs = ReadStructure("2T2B2M2C2S")
-    rs.extract("AACCGGNNTT", "1122334455").foreach { r =>
+    rs.extract("AACCGGNNTT", includeSkips = true).map(_.segment.kind).last shouldBe Skip
+    rs.extract("AACCGGNNTT", "1122334455", includeSkips = true).map(_.segment.kind).last shouldBe Skip
+  }
+
+  "ReadStructure.extract(bases, quals)" should "extract the bases and qualities for each segment" in {
+    val rs = ReadStructure("2T2B2M2C2S")
+    rs.extract("AACCGGNNTT", "1122334455", includeSkips = true).foreach { r =>
       r.kind match {
         case Template         => r.bases shouldBe "AA"; r.quals shouldBe "11"
         case SampleBarcode    => r.bases shouldBe "CC"; r.quals shouldBe "22"
@@ -162,8 +206,8 @@ class ReadStructureTest extends UnitSpec with OptionValues {
     }
     an[Exception] should be thrownBy rs.extract("AAAAAAA", "AAAAAAA")
 
-    // the last segment is truncated
-    rs.withVariableLastSegment.extract("AACCGGNNT", "112233445").foreach { r =>
+    // the last segment is truncated to match the read length
+    rs.withVariableLastSegment.extract("AACCGGNNT", "112233445", includeSkips = true).foreach { r =>
       r.kind match {
         case Template         => r.bases shouldBe "AA"; r.quals shouldBe "11"
         case SampleBarcode    => r.bases shouldBe "CC"; r.quals shouldBe "22"
@@ -172,8 +216,8 @@ class ReadStructureTest extends UnitSpec with OptionValues {
         case Skip             => r.bases shouldBe "T";  r.quals shouldBe "5"
       }
     }
-    // the last segment is skipped
-    rs.withVariableLastSegment.extract("AACCGGNN", "11223344").foreach { r =>
+    // the last segment is zero-length (pins 0-or-more semantics for +)
+    rs.withVariableLastSegment.extract("AACCGGNN", "11223344", includeSkips = true).foreach { r =>
       r.kind match {
         case Template         => r.bases shouldBe "AA"; r.quals shouldBe "11"
         case SampleBarcode    => r.bases shouldBe "CC"; r.quals shouldBe "22"
@@ -182,6 +226,75 @@ class ReadStructureTest extends UnitSpec with OptionValues {
         case Skip             => r.bases shouldBe ""  ; r.quals shouldBe ""
       }
     }
+  }
+
+  it should "require bases and quals to be the same length" in {
+    an[IllegalArgumentException] should be thrownBy ReadStructure("2T2B").extract("AACC", "111")
+    an[IllegalArgumentException] should be thrownBy ReadStructure("2T2B").extract("AACC", "11111")
+    an[IllegalArgumentException] should be thrownBy ReadStructure("+T").extract("AACC", "111")
+  }
+
+  it should "reject reads that are longer than a fixed-length structure" in {
+    val rs = ReadStructure("2T2B")
+    an[Exception] should be thrownBy rs.extract("AACCXX")
+    an[Exception] should be thrownBy rs.extract("AACCXX", "111111")
+  }
+
+  "ReadStructure.extract with non-terminal +" should "extract bases around a middle + segment" in {
+    val rs    = ReadStructure("8B+M10T")
+    val bases = "BBBBBBBBUUUUUUUUUUUUTTTTTTTTTT"
+    val quals = "!!!!!!!!@@@@@@@@@@@@##########"
+    bases.length shouldBe 30
+    val out = rs.extract(bases, quals)
+    out should have size 3
+    out(0).kind shouldBe SampleBarcode;    out(0).bases shouldBe "BBBBBBBB";     out(0).quals shouldBe "!!!!!!!!"
+    out(1).kind shouldBe MolecularBarcode; out(1).bases shouldBe "UUUUUUUUUUUU"; out(1).quals shouldBe "@@@@@@@@@@@@"
+    out(2).kind shouldBe Template;         out(2).bases shouldBe "TTTTTTTTTT";   out(2).quals shouldBe "##########"
+  }
+
+  it should "extract bases around a leading + segment" in {
+    val rs    = ReadStructure("+B10T")
+    val bases = "BBBBBTTTTTTTTTT"
+    val out   = rs.extract(bases)
+    out should have size 2
+    out(0).kind  shouldBe SampleBarcode; out(0).bases shouldBe "BBBBB"
+    out(1).kind  shouldBe Template;      out(1).bases shouldBe "TTTTTTTTTT"
+  }
+
+  it should "extract bases with fixed segments before and after the +" in {
+    val rs    = ReadStructure("10T8B+M10T")
+    val bases = "TTTTTTTTTTBBBBBBBBUUUUUUUUUUUUTTTTTTTTTT"
+    bases.length shouldBe 40
+    val out   = rs.extract(bases)
+    out.map(_.bases) shouldBe Seq("TTTTTTTTTT", "BBBBBBBB", "UUUUUUUUUUUU", "TTTTTTTTTT")
+  }
+
+  it should "handle a + segment with multiple fixed segments following it" in {
+    val rs    = ReadStructure("8B+M5T5S")
+    val bases = "BBBBBBBBUUUUUUUUUUUUTTTTTSSSSS"
+    bases.length shouldBe 30
+    val out   = rs.extract(bases, includeSkips = true)
+    out.map(_.bases) shouldBe Seq("BBBBBBBB", "UUUUUUUUUUUU", "TTTTT", "SSSSS")
+  }
+
+  it should "accept reads where the + segment has zero width" in {
+    val rs    = ReadStructure("8B+M10T")
+    val bases = "BBBBBBBBTTTTTTTTTT"
+    bases.length shouldBe 18
+    val out   = rs.extract(bases)
+    out.map(_.bases) shouldBe Seq("BBBBBBBB", "", "TTTTTTTTTT")
+  }
+
+  "ReadStructure.hasFixedLength / fixedLength" should "reflect whether a + segment is present" in {
+    val fixed    = ReadStructure("10T8B")
+    val variable = ReadStructure("10T+B")
+    val middle   = ReadStructure("8B+M10T")
+    fixed.hasFixedLength shouldBe true
+    fixed.fixedLength shouldBe 18
+    variable.hasFixedLength shouldBe false
+    middle.hasFixedLength shouldBe false
+    an[Exception] should be thrownBy variable.fixedLength
+    an[Exception] should be thrownBy middle.fixedLength
   }
 
   "ReadStructure.length" should "return the number of segments" in {
@@ -194,47 +307,36 @@ class ReadStructureTest extends UnitSpec with OptionValues {
     ReadStructure("123456789T").length shouldBe 1
     ReadStructure("10T10B10B10S10M").length shouldBe 5
     ReadStructure("10T10B10B10S10M10C").length shouldBe 6
+    ReadStructure("8B+M10T").length shouldBe 3
   }
 
   "ReadStructure.apply(idx: Int)" should "return the segment at the 0-based index" in {
-    ReadStructure("1T")(0) shouldBe T(0, 1)
-    ReadStructure("1B")(0) shouldBe B(0, 1)
-    ReadStructure("1M")(0) shouldBe M(0, 1)
-    ReadStructure("1S")(0) shouldBe S(0, 1)
-    ReadStructure("101T")(0) shouldBe T(0, 101)
+    ReadStructure("1T")(0) shouldBe T(1)
+    ReadStructure("1B")(0) shouldBe B(1)
+    ReadStructure("1M")(0) shouldBe M(1)
+    ReadStructure("1S")(0) shouldBe S(1)
+    ReadStructure("101T")(0) shouldBe T(101)
 
-    ReadStructure("5B101T")(0) shouldBe B(0, 5)
-    ReadStructure("5B101T")(1) shouldBe T(5, 101)
+    ReadStructure("5B101T")(0) shouldBe B(5)
+    ReadStructure("5B101T")(1) shouldBe T(101)
 
-    ReadStructure("123456789T")(0) shouldBe T(0, 123456789)
+    ReadStructure("123456789T")(0) shouldBe T(123456789)
 
-    ReadStructure("10T10B10B10S10M")(0) shouldBe T(0, 10)
-    ReadStructure("10T10B10B10S10M")(1) shouldBe B(10, 10)
-    ReadStructure("10T10B10B10S10M")(2) shouldBe B(20, 10)
-    ReadStructure("10T10B10B10S10M")(3) shouldBe S(30, 10)
-    ReadStructure("10T10B10B10S10M")(4) shouldBe M(40, 10)
+    ReadStructure("10T10B10B10S10M")(0) shouldBe T(10)
+    ReadStructure("10T10B10B10S10M")(1) shouldBe B(10)
+    ReadStructure("10T10B10B10S10M")(2) shouldBe B(10)
+    ReadStructure("10T10B10B10S10M")(3) shouldBe S(10)
+    ReadStructure("10T10B10B10S10M")(4) shouldBe M(10)
 
     an[Exception] should be thrownBy ReadStructure("101T")(1)
   }
 
-  "ReadSegment.apply(offset: Int, length: Int, ch: Char)" should "create a new ReadSegment" in {
-    ReadSegment(1, 2, 'T') shouldBe T(1, 2)
-    ReadSegment(1, 2, 'M') shouldBe M(1, 2)
-    ReadSegment(1, 2, 'S') shouldBe S(1, 2)
-    ReadSegment(1, 2, 'B') shouldBe B(1, 2)
-    an[Exception] should be thrownBy ReadSegment(1, 2, 'G')
-  }
-
-  "ReadSegment.extract(bases)" should "get extract the bases and qualities for a segment" in {
-    val molecularBarcodeSegment = ReadStructure("2T2B2M2S").segments(MolecularBarcode).head
-    molecularBarcodeSegment.extract("AACCGGTT").bases shouldBe "GG"
-  }
-
-  "ReadSegment.extract(bases, quals)" should "get extract the bases and qualities for a segment" in {
-    val molecularBarcodeSegment = ReadStructure("2T2B2M2S").segments(MolecularBarcode).head
-    molecularBarcodeSegment.extract("AACCGGTT", "11223344") match {
-      case SubReadWithQuals(bases, quals, _) =>  bases shouldBe "GG"; quals shouldBe "33"
-    }
+  "ReadSegment.apply(length, char)" should "create a new ReadSegment" in {
+    ReadSegment(2, 'T') shouldBe T(2)
+    ReadSegment(2, 'M') shouldBe M(2)
+    ReadSegment(2, 'S') shouldBe S(2)
+    ReadSegment(2, 'B') shouldBe B(2)
+    an[Exception] should be thrownBy ReadSegment(2, 'G')
   }
 
   "SegmentType.toString" should "return the String value of the segment code letter" in {


### PR DESCRIPTION
The `+` (indefinite-length) segment can now appear at any position within a read structure, not only the last, mirroring the Rust `read-structure` crate PR #14 on the Scala side. Extract resolves middle- and leading-+ structures by walking backward from the end of the read for post-+ segments.

Breaking API changes:
 - ReadSegment.offset removed; ReadStructure tracks offsets internally via a private signed array. Constructors now take (length, kind) instead of (offset, length, kind).
 - ReadStructure.apply(segments, resetOffsets) simplified to apply(segments); offsets are always computed.
 - Fixed-length structures reject over-long reads instead of silently truncating. Callers that may see variable-length input should route it through withVariableLastSegment.
 - extract gained an includeSkips: Boolean = false parameter; Skip segments are now omitted from extract results by default. All in-tree callers were already filtering by kind, so no behavior change for them.

ExtractUmisFromBam.updateClippingInformation now walks segments accumulating a running non-template-length sum before the clip position. It requires all but the last segment to be fixed-length, since translating a clip past a non-terminal + would need the read length.

The + segment still means zero-or-more bases here, deliberately differing from the Rust crate's one-or-more; DemuxFastqs relies on zero-or-more to handle short/trimmed reads via
withVariableLastSegment.