### PR TITLE
fix(util): make tie detection independent of value order and magnitude

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/util/MathUtil.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/MathUtil.scala
@@ -36,6 +36,34 @@ object MathUtil {
     */
   val epsilon: Double = 1.0 / Math.pow(2, 52)
 
+  /** The default number of ulps within which two values are treated as equal.
+    *
+    * [[epsilon]] is an *absolute* tolerance, and is only meaningful for values close to 1.0. Callers that compare
+    * accumulated log-probabilities work at magnitudes that grow with the size of the input: a value near -500 is
+    * routine, and there a single ulp is already ~5.7e-14, some 250x larger than [[epsilon]]. An absolute tolerance
+    * therefore silently stops matching anything as the magnitude grows. Comparing in ulps scales with the values
+    * being compared, so the same tolerance behaves consistently at any magnitude.
+    */
+  val maxUlps: Int = 4
+
+  /** The number of representable doubles between `a` and `b`, or `Long.MaxValue` when that is not meaningful.
+    *
+    * Values of opposite sign, and non-finite values that are not equal, are reported as maximally distant; the
+    * absolute [[epsilon]] comparison is what covers values straddling zero.
+    */
+  private def ulpsBetween(a: Double, b: Double): Long = {
+    if (a == b) 0L
+    else if (java.lang.Double.isNaN(a) || java.lang.Double.isNaN(b)) Long.MaxValue
+    else if (a.isInfinite || b.isInfinite) Long.MaxValue
+    else if ((a < 0) != (b < 0)) Long.MaxValue
+    else Math.abs(java.lang.Double.doubleToLongBits(a) - java.lang.Double.doubleToLongBits(b))
+  }
+
+  /** True if `a` and `b` are within either an absolute `epsilon` or `maxUlps` ulps of one another. */
+  private def approximatelyEqual(a: Double, b: Double, epsilon: Double, maxUlps: Int): Boolean = {
+    Math.abs(a - b) <= epsilon || ulpsBetween(a, b) <= maxUlps
+  }
+
   /** Calculates the arithmetic mean of an array of bytes. The computation is performed
     * in integer space and the result will therefore always round down.
     *
@@ -68,12 +96,18 @@ object MathUtil {
     * @param requireUniqueMinimum When false the earliest index at which the minimum value occurs is
     *                             reported. When true, if there are multiple indices with the minimum
     *                             value then -1 will be returned for the index.
-    * @param epsilon The epsilon for comparison of equality
+    * @param epsilon The absolute epsilon for comparison of equality; values within [[maxUlps]] ulps of one
+    *                another are also treated as equal
+    * @param maxUlps The number of ulps within which two values are treated as equal
     * @throws java.util.NoSuchElementException if either the input array is zero length or the array
     *                                contains only invalid values (NaN and possibly NegativeInfinity)
     */
-  def minWithIndex(ds: Array[Double], allowNegativeInfinity: Boolean=false, requireUniqueMinimum: Boolean=false, epsilon: Double = MathUtil.epsilon): (Double, Int) = {
+  def minWithIndex(ds: Array[Double], allowNegativeInfinity: Boolean=false, requireUniqueMinimum: Boolean=false, epsilon: Double = MathUtil.epsilon, maxUlps: Int = MathUtil.maxUlps): (Double, Int) = {
     if (ds.length == 0) throw new NoSuchElementException("Cannot find the min of a zero length array.")
+    def eligible(v: Double): Boolean = {
+      !java.lang.Double.isNaN(v) && (Double.NegativeInfinity != v || allowNegativeInfinity)
+    }
+
     var min      = Double.MaxValue
     var minIndex = -1
     var assigned = false
@@ -81,22 +115,37 @@ object MathUtil {
     var idx      = 0
     while (idx < len) {
       val v = ds(idx)
-      if (!java.lang.Double.isNaN(v) && (Double.NegativeInfinity != v || allowNegativeInfinity)) {
-        if (!assigned || v < min) {
-          min = v
-          minIndex = idx
-          assigned = true
-        }
-        else if (Math.abs(v - min) <= epsilon  && requireUniqueMinimum) {
-          minIndex = -1
-        }
+      if (eligible(v) && (!assigned || v < min)) {
+        min = v
+        minIndex = idx
+        assigned = true
       }
 
       idx += 1
     }
 
     if (!assigned) throw new NoSuchElementException("All values are NaNs or negative infinity.")
-    (min, minIndex)
+
+    // Ties are counted against the final minimum, not a running one: a near-tie is a property of the values, and
+    // comparing against a running minimum would only detect it when the tied value happens to appear later.
+    if (requireUniqueMinimum && countApproximatelyEqual(ds, min, epsilon, maxUlps, eligible) > 1) (min, -1)
+    else (min, minIndex)
+  }
+
+  /** Counts the eligible entries of `ds` that are approximately equal to `target`. */
+  private def countApproximatelyEqual(ds: Array[Double],
+                                      target: Double,
+                                      epsilon: Double,
+                                      maxUlps: Int,
+                                      eligible: Double => Boolean): Int = {
+    var count = 0
+    var idx   = 0
+    while (idx < ds.length) {
+      val v = ds(idx)
+      if (eligible(v) && approximatelyEqual(v, target, epsilon, maxUlps)) count += 1
+      idx += 1
+    }
+    count
   }
 
 
@@ -110,12 +159,16 @@ object MathUtil {
     * @param requireUniqueMaximum When false the earliest index at which the maximum value occurs is
     *                             reported. When true, if there are multiple indices with the maximum
     *                             value then -1 will be returned for the index.
-    * @param epsilon The epsilon for comparison of equality
+    * @param epsilon The absolute epsilon for comparison of equality; values within [[maxUlps]] ulps of one
+    *                another are also treated as equal
+    * @param maxUlps The number of ulps within which two values are treated as equal
     * @throws java.util.NoSuchElementException if either the input array is zero length or the array
     *                                contains only invalid values (NaN)
     */
-  def maxWithIndex(ds: Array[Double], requireUniqueMaximum: Boolean=false, epsilon: Double = MathUtil.epsilon): (Double,Int) = {
+  def maxWithIndex(ds: Array[Double], requireUniqueMaximum: Boolean=false, epsilon: Double = MathUtil.epsilon, maxUlps: Int = MathUtil.maxUlps): (Double,Int) = {
     if (ds.length == 0) throw new NoSuchElementException("Cannot find the max of a zero length array.")
+    def eligible(v: Double): Boolean = !java.lang.Double.isNaN(v)
+
     var max      =  Double.MinValue
     var maxIndex = -1
     var assigned = false
@@ -123,20 +176,19 @@ object MathUtil {
     var idx = 0
     while (idx < len) {
       val v = ds(idx)
-      if (!java.lang.Double.isNaN(v)) {
-        if (!assigned || v > max) {
-          max = v
-          maxIndex = idx
-          assigned = true
-        }
-        else if (Math.abs(v - max) <= epsilon && requireUniqueMaximum) {
-          maxIndex = -1
-        }
+      if (eligible(v) && (!assigned || v > max)) {
+        max = v
+        maxIndex = idx
+        assigned = true
       }
       idx += 1
     }
 
     if (!assigned) throw new NoSuchElementException("Array contained only NaNs.")
-    (max, maxIndex)
+
+    // Ties are counted against the final maximum, not a running one: a near-tie is a property of the values, and
+    // comparing against a running maximum would only detect it when the tied value happens to appear later.
+    if (requireUniqueMaximum && countApproximatelyEqual(ds, max, epsilon, maxUlps, eligible) > 1) (max, -1)
+    else (max, maxIndex)
   }
 }

--- a/src/main/scala/com/fulcrumgenomics/util/MathUtil.scala
+++ b/src/main/scala/com/fulcrumgenomics/util/MathUtil.scala
@@ -55,13 +55,45 @@ object MathUtil {
     if (a == b) 0L
     else if (java.lang.Double.isNaN(a) || java.lang.Double.isNaN(b)) Long.MaxValue
     else if (a.isInfinite || b.isInfinite) Long.MaxValue
-    else if ((a < 0) != (b < 0)) Long.MaxValue
-    else Math.abs(java.lang.Double.doubleToLongBits(a) - java.lang.Double.doubleToLongBits(b))
+    else {
+      val aBits = java.lang.Double.doubleToLongBits(a)
+      val bBits = java.lang.Double.doubleToLongBits(b)
+      // The sign of the *representation* is compared rather than the sign of the value: -0.0 is not `< 0`, but its
+      // representation is Long.MinValue, so treating it as non-negative would overflow the subtraction below.
+      // Representations that share a sign bit lie in the same half of the long range, so the subtraction is safe.
+      if ((aBits < 0) != (bBits < 0)) Long.MaxValue else Math.abs(aBits - bBits)
+    }
   }
 
   /** True if `a` and `b` are within either an absolute `epsilon` or `maxUlps` ulps of one another. */
   private def approximatelyEqual(a: Double, b: Double, epsilon: Double, maxUlps: Int): Boolean = {
     Math.abs(a - b) <= epsilon || ulpsBetween(a, b) <= maxUlps
+  }
+
+  /** True if more than one eligible entry of `ds` is approximately equal to `target`.
+    *
+    * `NaN`s are always ineligible, and `-Infinity` is ineligible unless `allowNegativeInfinity` is set, mirroring
+    * the entries that were candidates for the extremum in the first place. The scan stops as soon as a second
+    * match is seen; these functions sit on the consensus calling hot path, so neither the predicate nor the count
+    * is worth materialising.
+    */
+  private def hasApproximateTie(ds: Array[Double],
+                                target: Double,
+                                epsilon: Double,
+                                maxUlps: Int,
+                                allowNegativeInfinity: Boolean): Boolean = {
+    var seen = false
+    var idx  = 0
+    while (idx < ds.length) {
+      val v = ds(idx)
+      if (!java.lang.Double.isNaN(v) && (Double.NegativeInfinity != v || allowNegativeInfinity) &&
+          approximatelyEqual(v, target, epsilon, maxUlps)) {
+        if (seen) return true
+        seen = true
+      }
+      idx += 1
+    }
+    false
   }
 
   /** Calculates the arithmetic mean of an array of bytes. The computation is performed
@@ -104,10 +136,6 @@ object MathUtil {
     */
   def minWithIndex(ds: Array[Double], allowNegativeInfinity: Boolean=false, requireUniqueMinimum: Boolean=false, epsilon: Double = MathUtil.epsilon, maxUlps: Int = MathUtil.maxUlps): (Double, Int) = {
     if (ds.length == 0) throw new NoSuchElementException("Cannot find the min of a zero length array.")
-    def eligible(v: Double): Boolean = {
-      !java.lang.Double.isNaN(v) && (Double.NegativeInfinity != v || allowNegativeInfinity)
-    }
-
     var min      = Double.MaxValue
     var minIndex = -1
     var assigned = false
@@ -115,7 +143,8 @@ object MathUtil {
     var idx      = 0
     while (idx < len) {
       val v = ds(idx)
-      if (eligible(v) && (!assigned || v < min)) {
+      if (!java.lang.Double.isNaN(v) && (Double.NegativeInfinity != v || allowNegativeInfinity) &&
+          (!assigned || v < min)) {
         min = v
         minIndex = idx
         assigned = true
@@ -126,26 +155,10 @@ object MathUtil {
 
     if (!assigned) throw new NoSuchElementException("All values are NaNs or negative infinity.")
 
-    // Ties are counted against the final minimum, not a running one: a near-tie is a property of the values, and
+    // Ties are detected against the final minimum, not a running one: a near-tie is a property of the values, and
     // comparing against a running minimum would only detect it when the tied value happens to appear later.
-    if (requireUniqueMinimum && countApproximatelyEqual(ds, min, epsilon, maxUlps, eligible) > 1) (min, -1)
+    if (requireUniqueMinimum && hasApproximateTie(ds, min, epsilon, maxUlps, allowNegativeInfinity)) (min, -1)
     else (min, minIndex)
-  }
-
-  /** Counts the eligible entries of `ds` that are approximately equal to `target`. */
-  private def countApproximatelyEqual(ds: Array[Double],
-                                      target: Double,
-                                      epsilon: Double,
-                                      maxUlps: Int,
-                                      eligible: Double => Boolean): Int = {
-    var count = 0
-    var idx   = 0
-    while (idx < ds.length) {
-      val v = ds(idx)
-      if (eligible(v) && approximatelyEqual(v, target, epsilon, maxUlps)) count += 1
-      idx += 1
-    }
-    count
   }
 
 
@@ -167,8 +180,6 @@ object MathUtil {
     */
   def maxWithIndex(ds: Array[Double], requireUniqueMaximum: Boolean=false, epsilon: Double = MathUtil.epsilon, maxUlps: Int = MathUtil.maxUlps): (Double,Int) = {
     if (ds.length == 0) throw new NoSuchElementException("Cannot find the max of a zero length array.")
-    def eligible(v: Double): Boolean = !java.lang.Double.isNaN(v)
-
     var max      =  Double.MinValue
     var maxIndex = -1
     var assigned = false
@@ -176,7 +187,7 @@ object MathUtil {
     var idx = 0
     while (idx < len) {
       val v = ds(idx)
-      if (eligible(v) && (!assigned || v > max)) {
+      if (!java.lang.Double.isNaN(v) && (!assigned || v > max)) {
         max = v
         maxIndex = idx
         assigned = true
@@ -186,9 +197,10 @@ object MathUtil {
 
     if (!assigned) throw new NoSuchElementException("Array contained only NaNs.")
 
-    // Ties are counted against the final maximum, not a running one: a near-tie is a property of the values, and
+    // Ties are detected against the final maximum, not a running one: a near-tie is a property of the values, and
     // comparing against a running maximum would only detect it when the tied value happens to appear later.
-    if (requireUniqueMaximum && countApproximatelyEqual(ds, max, epsilon, maxUlps, eligible) > 1) (max, -1)
+    // Negative infinities are eligible here: unlike the minimum, they are never excluded from the maximum.
+    if (requireUniqueMaximum && hasApproximateTie(ds, max, epsilon, maxUlps, allowNegativeInfinity=true)) (max, -1)
     else (max, maxIndex)
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/util/MathUtilTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/util/MathUtilTest.scala
@@ -116,4 +116,51 @@ class MathUtilTest extends UnitSpec {
     // Custom epsilon: zero epsilon treats any different values as distinct
     maxWithIndex(Array(1.0, 20.0, 20.0 - smallDiff), requireUniqueMaximum=true, epsilon=0.0) shouldBe (20.0, 1)
   }
+
+  it should "detect a near-tie regardless of the order the values appear in" in {
+    // A near-tie is a property of the values, not of the order they happen to be stored in. Comparing each value
+    // against a *running* maximum only detects the tie when the tied value appears after the maximum.
+    val value  = 20.0
+    val oneUlp = Math.ulp(value)
+
+    maxWithIndex(Array(1.0, value, value - oneUlp), requireUniqueMaximum=true, epsilon=oneUlp) shouldBe (value, -1)
+    maxWithIndex(Array(1.0, value - oneUlp, value), requireUniqueMaximum=true, epsilon=oneUlp) shouldBe (value, -1)
+  }
+
+  it should "treat values a single ulp apart as tied at the magnitudes log-likelihoods occupy" in {
+    // The default epsilon is the ulp of 1.0. Consensus log-likelihoods are sums of log-probabilities and routinely
+    // sit near -500, where a single ulp is ~5.7e-14 -- roughly 250x larger than that epsilon -- so no two distinct
+    // values there could ever compare equal. A one-ulp separation is summation noise, not evidence.
+    Seq(-1.0, -10.0, -500.0, -5000.0).foreach { value =>
+      val oneUlp = Math.ulp(value)
+      withClue(s"value=$value ulp=$oneUlp: ") {
+        maxWithIndex(Array(value, value - oneUlp, -1e9, -1e9), requireUniqueMaximum=true) shouldBe (value, -1)
+      }
+    }
+  }
+
+  it should "still report a unique maximum when values are clearly separated at those magnitudes" in {
+    Seq(-1.0, -10.0, -500.0, -5000.0).foreach { value =>
+      withClue(s"value=$value: ") {
+        maxWithIndex(Array(value, value - 1.0, -1e9, -1e9), requireUniqueMaximum=true) shouldBe (value, 0)
+      }
+    }
+  }
+
+  it should "detect a near-tie regardless of order when finding the minimum" in {
+    val value  = 20.0
+    val oneUlp = Math.ulp(value)
+
+    minWithIndex(Array(100.0, value, value + oneUlp), requireUniqueMinimum=true, epsilon=oneUlp) shouldBe (value, -1)
+    minWithIndex(Array(100.0, value + oneUlp, value), requireUniqueMinimum=true, epsilon=oneUlp) shouldBe (value, -1)
+  }
+
+  it should "treat values a single ulp apart as tied when finding the minimum at large magnitudes" in {
+    Seq(1.0, 10.0, 500.0, 5000.0).foreach { value =>
+      val oneUlp = Math.ulp(value)
+      withClue(s"value=$value ulp=$oneUlp: ") {
+        minWithIndex(Array(value, value + oneUlp, 1e9, 1e9), requireUniqueMinimum=true) shouldBe (value, -1)
+      }
+    }
+  }
 }

--- a/src/test/scala/com/fulcrumgenomics/util/MathUtilTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/util/MathUtilTest.scala
@@ -147,6 +147,24 @@ class MathUtilTest extends UnitSpec {
     }
   }
 
+  it should "honour an explicit maxUlps" in {
+    val value  = -500.0
+    val oneUlp = Math.ulp(value)
+
+    // No ulps of tolerance: only exactly equal values tie, and the absolute epsilon is far too small to match here.
+    maxWithIndex(Array(value, value - oneUlp, -1e9, -1e9), requireUniqueMaximum=true, maxUlps=0) shouldBe (value, 0)
+
+    // A wider tolerance ties values several ulps apart.
+    maxWithIndex(Array(value, value - (oneUlp * 3), -1e9, -1e9), requireUniqueMaximum=true, maxUlps=8) shouldBe (value, -1)
+  }
+
+  it should "not treat negative zero as tied with a distant value of the opposite sign" in {
+    // -0.0 is not `< 0`, but its bit representation is Long.MinValue. Comparing the sign of the value rather than
+    // of the representation would put these in the same branch and overflow the ulp subtraction.
+    maxWithIndex(Array(1.0, -0.0), requireUniqueMaximum=true) shouldBe (1.0, 0)
+    minWithIndex(Array(-0.0, 1.0), requireUniqueMinimum=true) shouldBe (-0.0, 0)
+  }
+
   it should "detect a near-tie regardless of order when finding the minimum" in {
     val value  = 20.0
     val oneUlp = Math.ulp(value)


### PR DESCRIPTION
## Problem

`MathUtil.maxWithIndex` and `minWithIndex` support a `requireUniqueMaximum` / `requireUniqueMinimum` mode that reports `-1` when the extremum is tied. That tie detection has two defects, and together they mean it effectively never fires for the one production caller that relies on it.

**1. It depends on the order the values are stored in.** Each value was compared against a *running* extremum, so a near-tie was only detected when the tied value happened to appear *after* the extremum. For values arriving in ascending order every comparison took the `v > max` branch and no tie was ever recorded. Concretely, with `epsilon` set to one ulp of `20.0`, the same two values report `-1` in one order and index `1` in the other.

**2. It uses an absolute epsilon that is meaningless at the magnitudes it is applied to.** `MathUtil.epsilon` is `1.0 / 2^52`, the ulp of `1.0`. `ConsensusCaller` applies this to accumulated log-likelihoods, which are sums of log-probabilities and routinely sit near `-500`. A single ulp there is already ~5.7e-14, roughly 250x larger than the epsilon, so no two *distinct* doubles at that magnitude can ever compare equal. Only exactly-equal values were ever detected as ties.

The practical effect is that positions whose bases are mathematically tied, but whose accumulated sums differ by a ulp or two purely from summation order, were called as a definite base chosen by floating-point noise instead of being reported as a no-call.

## Fix

Two changes, applied to both functions:

- Tie detection now runs as a **second pass against the final extremum** rather than a running one. A near-tie is a property of the values, not of their position in the array.
- A **ulp tolerance is checked alongside the existing absolute epsilon** (`abs(a - b) <= epsilon || ulpsBetween(a, b) <= maxUlps`, default 4 ulps).

The ulp check is deliberately additive rather than a replacement. Callers pass explicit epsilons today (`0.01`, `1.0`, `0.0`), and rescaling `epsilon` relative to magnitude would silently change their meaning — for example the existing assertion that `20.0` and `19.98` are *not* tied at `epsilon=0.01` would have flipped. OR-ing in a ulp comparison preserves every existing explicit-epsilon behaviour while fixing the magnitudes where an absolute tolerance is useless.

`minWithIndex` had the identical defect and is fixed the same way. Its only current caller does not set `requireUniqueMinimum`, so nothing in production changes there today, but leaving a known-broken twin behind seemed worse than the slightly wider diff.

## Behaviour change to be aware of

Two things change for callers that set `requireUnique*`:

1. Genuinely near-tied extrema are now reported as ties (`-1`). For `ConsensusCaller` this means such positions become no-calls rather than an arbitrary base. This is the behaviour the `requireUniqueMaximum=true` flag was always asking for.
2. An array of all `-Infinity` now reports a tie instead of index `0`. Previously `Math.abs(-Inf - -Inf)` is `NaN` and `NaN <= epsilon` is false, so a position with no evidence for any base was silently called as an `A`.

`ConsensusCaller.scala` is the only production call site that sets `requireUniqueMaximum=true`, so the blast radius is limited to consensus base calling. `FishersExactTest` and `NumericTypes` both call these functions without the flag, which leaves the tie branch dead for them.

I have not measured the change on fgbio's own consensus output. For a sense of scale, a Rust port of this same algorithm (fgumi) that carried both defects verbatim shows 212 of 1,000,000 consensus records changing, each by exactly one base, all in the direction of base to `N`, with a near-uniform split across A/C/G/T. Of those, 186 already carried the minimum quality `Q2` in the old output — the old code already knew the position was maximally uncertain and emitted a concrete base anyway.

## Testing

Written test-first: five new tests were added and the four that demonstrate the defects were confirmed failing against the current implementation before any change was made. The fifth is a guard that clearly-separated values at those same magnitudes still resolve to a unique extremum, so the fix cannot simply be over-reporting ties.

- New tests: near-tie detection is order independent (max and min), one-ulp separation ties at magnitudes from `-1` to `-5000` (max and min), and the clear-separation guard.
- All 11 pre-existing `MathUtilTest` assertions pass unchanged, including every explicit-epsilon case.
- Full suite: **1609 tests, 122 suites, 0 failures**, including `ConsensusCallerTest`, `VanillaUmiConsensusCallerTest`, `DuplexConsensusCallerTest`, `CallMolecularConsensusReadsTest` and `CallDuplexConsensusReadsTest`.

Worth noting for reviewers: the existing test suite passes both before and after, which is itself informative — the near-tie cases this fixes were not covered. The existing epsilon tests only exercise custom, comparatively large epsilons (`0.01`, `1.0`) at magnitude ~20, where `epsilon` is far larger than a ulp, and the one near-tie case is written in the value order that happens to work. The default epsilon was never tested at any realistic magnitude.
