### PR TITLE
fix(umi): exclude unmapped reads from consensus calling

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/ConsensusCallingIterator.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/ConsensusCallingIterator.scala
@@ -53,9 +53,13 @@ class ConsensusCallingIterator[ConsensusRead <: SimpleRead](sourceIterator: Iter
   private var collectedStats: Boolean = false
 
   protected val iter: Iterator[SamRecord] = {
+    // Only mapped reads may contribute to a consensus.  An unmapped read has no cigar, and an empty cigar is a prefix
+    // of every cigar, so `filterToMostCommonAlignment` would match it against whichever alignment group it was tested
+    // against first rather than rejecting it as a minority alignment.  Note that the mapped end of a half-mapped pair
+    // is still used; only the unmapped end is dropped.
     val filteredIterator = sourceIterator
       .filterNot (r => r.secondary || r.supplementary)
-      .filter(r => r.mapped || (r.paired && r.mateMapped))
+      .filter(r => r.mapped)
 
     // Wrap our input iterator in a progress logging iterator if we have a progress logger
     val progressIterator = progress match {

--- a/src/test/scala/com/fulcrumgenomics/umi/CallCodecConsensusReadsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/CallCodecConsensusReadsTest.scala
@@ -126,4 +126,27 @@ class CallCodecConsensusReadsTest extends UnitSpec with OptionValues {
       metric.value.toString.toInt shouldBe 2
     }
   }
+
+  it should "not use either end of a half-mapped pair when calling a consensus" in {
+    val builder = new SamBuilder(readLength=30, sort=Some(SamOrder.TemplateCoordinate))
+    val attrs   = Map(("RX", "ACC-TGA"), ("MI", "hi"))
+    builder.addPair(name="mapped1", start1=100, start2=100, bases1="AC" * 15, bases2="AC" * 15, attrs=attrs)
+    builder.addPair(name="mapped2", start1=100, start2=100, bases1="AC" * 15, bases2="AC" * 15, attrs=attrs)
+    // A template whose R2 is unmapped is not a primary FR pair, so neither end may contribute to the consensus.
+    builder.addPair(name="halfmapped", start1=100, start2=100, bases1="AC" * 15, bases2="GT" * 15, unmapped2=true, attrs=attrs)
+
+    val out = makeTempFile("codec.", ".bam")
+    val rej = makeTempFile("rejects.", ".bam")
+    new CallCodecConsensusReads(input=builder.toTempFile(), output=out, readGroupId="ZZ", rejects=Some(rej)).execute()
+
+    val recs = readBamRecs(out)
+    recs should have size 1
+
+    // Only the two fully mapped templates contribute to each single-strand consensus.
+    recs.head[Int](ConsensusTags.PerRead.AbRawReadCount) shouldBe 2
+    recs.head[Int](ConsensusTags.PerRead.BaRawReadCount) shouldBe 2
+
+    // Every rejected record belongs to the half-mapped template.
+    readBamRecs(rej).foreach { rec => rec.name shouldBe "halfmapped" }
+  }
 }

--- a/src/test/scala/com/fulcrumgenomics/umi/CallDuplexConsensusReadsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/CallDuplexConsensusReadsTest.scala
@@ -132,4 +132,31 @@ class CallDuplexConsensusReadsTest extends UnitSpec {
       }
     }
   }
+
+  it should "not use the unmapped end of a half-mapped pair when calling a single-strand consensus" in {
+    val builder = new SamBuilder(readLength=10, sort=Some(SamOrder.TemplateCoordinate))
+    // Three AB templates, the third of which has an unmapped R2 carrying different bases to the mapped R2s.
+    builder.addPair(name="ab1", start1=100, start2=100, attrs=Map(MI -> "1/A"), bases1="AAAAAAAAAA", bases2="AAAAAAAAAA")
+    builder.addPair(name="ab2", start1=100, start2=100, attrs=Map(MI -> "1/A"), bases1="AAAAAAAAAA", bases2="AAAAAAAAAA")
+    builder.addPair(name="ab3", start1=100, start2=100, attrs=Map(MI -> "1/A"), bases1="AAAAAAAAAA", bases2="CCCCCCCCCC", unmapped2=true)
+    // Two fully mapped BA templates.
+    builder.addPair(name="ba1", start1=100, start2=100, strand1=Minus, strand2=Plus, attrs=Map(MI -> "1/B"), bases1="AAAAAAAAAA", bases2="AAAAAAAAAA")
+    builder.addPair(name="ba2", start1=100, start2=100, strand1=Minus, strand2=Plus, attrs=Map(MI -> "1/B"), bases1="AAAAAAAAAA", bases2="AAAAAAAAAA")
+
+    val out = makeTempFile("duplex.", ".bam")
+    new CallDuplexConsensusReads(input=builder.toTempFile(), output=out, readGroupId="ZZ").execute()
+
+    val recs = readBamRecs(out)
+    recs should have size 2
+    val r1 = recs.find(_.firstOfPair).value
+    val r2 = recs.find(_.secondOfPair).value
+
+    // The AB-R1s are all mapped, so all three contribute to the AB single-strand consensus for R1.
+    r1[Int](ConsensusTags.PerRead.AbRawReadCount) shouldBe 3
+    r1[Int](ConsensusTags.PerRead.BaRawReadCount) shouldBe 2
+
+    // Only the two mapped AB-R2s may contribute to the AB single-strand consensus for R2; the unmapped one must not.
+    r2[Int](ConsensusTags.PerRead.AbRawReadCount) shouldBe 2
+    r2[Int](ConsensusTags.PerRead.BaRawReadCount) shouldBe 2
+  }
 }

--- a/src/test/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReadsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReadsTest.scala
@@ -110,4 +110,54 @@ class CallMolecularConsensusReadsTest extends UnitSpec {
       rec[String](specialCellTag) shouldBe "AB"
     }
   }
+
+  /** Builds a tag family of three read pairs at the same coordinates, two with both ends mapped and one whose R2 is
+    * unmapped.
+    *
+    * The two mapped R2s carry `G`s while the unmapped R2 carries `T`s, so the consensus R2 shows which reads
+    * contributed to it.  R2s are placed on the negative strand by [[SamBuilder]], so `toSourceRead` reverse
+    * complements them and a consensus built from the mapped R2s alone reads as `C`s. */
+  private def halfMappedFamily(rlen: Int): SamBuilder = {
+    val builder = new SamBuilder(baseQuality=30, readLength=rlen, readGroupId=Some("ABC"), sort=Some(SamOrder.TemplateCoordinate))
+    val attrs   = Map(DefaultTag -> "GATTACA:1")
+    builder.addPair(name="mapped:1",     start1=100, start2=300, bases1="A"*rlen, bases2="G"*rlen, attrs=attrs)
+    builder.addPair(name="mapped:2",     start1=100, start2=300, bases1="A"*rlen, bases2="G"*rlen, attrs=attrs)
+    builder.addPair(name="halfmapped:3", start1=100, start2=300, bases1="A"*rlen, bases2="T"*rlen, unmapped2=true, attrs=attrs)
+    builder
+  }
+
+  Seq(2, 3).foreach { maxReads =>
+    it should f"cap R1 at max-reads and build R2 from the mapped reads only with --max-reads=$maxReads" in {
+      val rlen    = 100
+      val output  = newBam
+      val rejects = newBam
+
+      new CallMolecularConsensusReads(
+        input       = halfMappedFamily(rlen).toTempFile(),
+        output      = output,
+        minReads    = 1,
+        maxReads    = Some(maxReads),
+        rejects     = Some(rejects),
+        readGroupId = "ABC"
+      ).execute()
+
+      // Exactly one consensus read pair is produced.
+      val records = readBamRecs(output)
+      records.size shouldBe 2
+      val r1 = records.find(_.firstOfPair).value
+      val r2 = records.find(_.secondOfPair).value
+
+      // All three R1s are mapped and eligible, so R1 is capped at max-reads.
+      r1[Int](ConsensusTags.PerRead.RawReadCount) shouldBe math.min(3, maxReads)
+      r1.basesString shouldBe "A" * rlen
+
+      // Only the two mapped R2s may contribute, whether or not the cap binds.  The unmapped R2's `C`s must not reach
+      // the consensus, and it must not be counted towards the consensus depth.
+      r2[Int](ConsensusTags.PerRead.RawReadCount) shouldBe 2
+      r2.basesString shouldBe "C" * rlen
+
+      // The unmapped R2 must not have been used, whether it was rejected by the caller or filtered before reaching it.
+      readBamRecs(rejects).foreach { rec => rec.name shouldBe "halfmapped:3" }
+    }
+  }
 }


### PR DESCRIPTION
## Problem

Unmapped reads reach the consensus callers and contribute bases and depth to consensus reads, with no alignment support.

`GroupReadsByUmi` keeps a read whose mate is mapped, and `ConsensusCallingIterator` applies the same predicate, so the unmapped end of a half-mapped pair survives into consensus calling. An unmapped read has an empty cigar, and `Cigar.isPrefixOf` returns `true` for an empty left hand side — the loop never executes:

```scala
def isPrefixOf(that: Cigar): Boolean = {
  if (that.elems.size < this.elems.size) false
  else {
    val lastIndex = this.elems.size - 1   // -1 for an empty cigar
    ...                                   // while (isPrefix && i <= lastIndex) never runs
```

So in `filterToMostCommonAlignment` an empty cigar matches *every* alignment group instead of forming one of its own, and the read is retained rather than rejected as a minority alignment. Whether it is retained at all depends on where it lands in that method's length-descending sort: if it sorts first it seeds a group nothing can join and is rejected, and if it sorts later it joins the winning group. An unmapped read gets no mate-overlap trimming, so it is frequently the longest read in its group — the outcome flips on a read-length tiebreak.

Observed on `main`, for a tag family of three read pairs where one pair has an unmapped R2:

| Tool | Symptom |
|---|---|
| `CallMolecularConsensusReads` | `--max-reads 3` reports `cD=3` for R2 when only two reads are eligible. `--max-reads 2` retains the unmapped read in preference to a mapped one, and every base of the R2 consensus no-calls. |
| `CallDuplexConsensusReads` | Reports `aD=3` for the AB single-strand consensus of R2 when only two AB-R2s are mapped. |
| `CallCodecConsensusReads` | Unaffected — `isPrimaryFrPair` rejects a template with an unmapped end as `NotPrimaryFrPair` before the R1/R2 split. |

## Fix

Require `r.mapped` in `ConsensusCallingIterator` instead of `r.mapped || (r.paired && r.mateMapped)`.

All three tools construct this iterator (`CallMolecularConsensusReads.scala:188`, `CallDuplexConsensusReads.scala:164`, `CallCodecConsensusReads.scala:151`), so the change covers every one of them structurally rather than relying on each caller to filter.

This restores the intent of #948. That PR widened the predicate to stop discarding the *mapped* end of a half-mapped pair, after #940 had dropped both ends. That end is still kept — it satisfies `r.mapped` on its own. Only the unmapped end, admitted as a side effect of how the predicate was widened, is now dropped.

### Why not `subGroupRecords`

Returning a fourth "unmapped" group was considered and rejected: `CodecConsensusCaller` extends `DuplexConsensusCaller` but never calls `subGroupRecords`, doing its own split at `CodecConsensusCaller.scala:196-197`, so a fourth element would miss the CODEC path entirely. It would also widen a protected 3-tuple across three call sites, two of which already discard the fragments slot as `(_, abR1s, abR2s)`.

## Tests

Written first, watched failing, then fixed — the two commits are `test:` then `fix:` in that order, so the first is red by design. Happy to squash if you would rather not carry a red commit.

Each of the three tools gets a regression test over the same family shape, so none can regress independently:

- `CallMolecularConsensusReadsTest` — two cases, `--max-reads` 2 and 3, asserting R1 is capped at max-reads, that R2's depth is 2, and that R2's bases are those of the mapped reads. The bases assertion is what catches the `--max-reads 2` case, where `cD` alone looks correct.
- `CallDuplexConsensusReadsTest` — asserts `aD`/`bD` on both ends, with R1's `aD=3` as a positive control that mapped reads are unaffected.
- `CallCodecConsensusReadsTest` — passes before and after; a guard against losing the `NotPrimaryFrPair` protection.

Before: 3 failures (2 molecular, 1 duplex), codec green. After: full suite 1608 tests, 0 failures.

## Deliberately not addressed

**The root cause in `filterToMostCommonAlignment` is untouched.** An empty cigar is still a prefix of every cigar. This PR makes that unreachable from the three consensus tools; any future path producing an empty cigar would hit it again. Fixing the grouping loop itself has a wider blast radius and wants its own change.

**Accounting.** Dropped reads are filtered before the caller sees them, so they are not counted in `raw_reads_considered` and do not reach `--rejects` — the same treatment secondary and supplementary reads already get here. Routing them through `rejectRecords` with a dedicated `RejectionReason` means touching the `usedByVanilla`/`usedByDuplex`/`usedByCodec` tables, which is the same shape of work as the `raw_reads_used` gap tracked in #1167. The codec and molecular tests assert only that every rejected record belongs to the half-mapped template, so they hold under either choice.

**Duplex has a second, separate exposure** not covered here: `areAllSameStrand` (`DuplexConsensusCaller.scala:260`) reads `negativeStrand` off an unmapped record, which can falsely reject an entire AB+BA molecule as `PotentialCollision`. This PR removes unmapped reads before that check, so it is no longer reachable from the tool, but the method remains unguarded.
