### PR TITLE
fix(umi): account for unmapped reads rejected from consensus calling

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/ConsensusCallingIterator.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/ConsensusCallingIterator.scala
@@ -53,13 +53,12 @@ class ConsensusCallingIterator[ConsensusRead <: SimpleRead](sourceIterator: Iter
   private var collectedStats: Boolean = false
 
   protected val iter: Iterator[SamRecord] = {
-    // Only mapped reads may contribute to a consensus.  An unmapped read has no cigar, and an empty cigar is a prefix
-    // of every cigar, so `filterToMostCommonAlignment` would match it against whichever alignment group it was tested
-    // against first rather than rejecting it as a minority alignment.  Note that the mapped end of a half-mapped pair
-    // is still used; only the unmapped end is dropped.
+    // Templates with no mapped read at all are dropped here; the unmapped end of a half-mapped pair is passed through
+    // to the caller, which rejects it as `RejectionReason.Unmapped` so that it is counted and written to the rejects
+    // output rather than silently discarded.
     val filteredIterator = sourceIterator
       .filterNot (r => r.secondary || r.supplementary)
-      .filter(r => r.mapped)
+      .filter(r => r.mapped || (r.paired && r.mateMapped))
 
     // Wrap our input iterator in a progress logging iterator if we have a progress logger
     val progressIterator = progress match {

--- a/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
@@ -86,6 +86,7 @@ object UmiConsensusCaller {
     case object HighDuplexDisagreement   extends _RejectionReason("high_duplex_disagreement",    "Too many errors between top/bottoms strands", false, false, true)
     case object ClipOverlapFailed        extends _RejectionReason("clip_overlap_failed",         "See https://github.com/fulcrumgenomics/fgbio/issues/1090", false, false, true)
     case object NotPrimaryFrPair         extends _RejectionReason("not_primary_fr_pair",         "Template did not have a single primary FR pair of reads", false, false, true)
+    case object Unmapped                 extends _RejectionReason("unmapped",                    "Read is unmapped", true, true, true)
   }
 
   /** Metric class for outputting consensus calling statistics. */
@@ -351,10 +352,18 @@ trait UmiConsensusCaller[ConsensusRead <: SimpleRead] {
     */
   final def consensusReadsFromSamRecords(recs: Seq[SamRecord]): Seq[SamRecord] = {
     this._totalReads += recs.size
+
+    // Unmapped reads cannot contribute to a consensus: they have no cigar, and an empty cigar is a prefix of every
+    // cigar, so `filterToMostCommonAlignment` would match one against whichever alignment group it was tested against
+    // first rather than rejecting it.  Rejecting here rather than filtering upstream keeps them visible in the rejects
+    // output and in the rejection counts.  The mapped end of a half-mapped pair is unaffected.
+    val (mapped, unmapped) = recs.partition(_.mapped)
+    if (unmapped.nonEmpty) rejectRecords(unmapped, RejectionReason.Unmapped)
+
     // Ensure that mate cigar is set on all read pairs.  This is needed when using
     // `clipper.numBasesExtendingPastMate` subsequently
-    updateMateCigars(recs)
-    val result = consensusSamRecordsFromSamRecords(recs)
+    updateMateCigars(mapped)
+    val result = consensusSamRecordsFromSamRecords(mapped)
     this._consensusReadsConstructed += result.size
     result
   }

--- a/src/test/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReadsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/CallMolecularConsensusReadsTest.scala
@@ -27,6 +27,8 @@ package com.fulcrumgenomics.umi
 
 import com.fulcrumgenomics.bam.api.SamOrder
 import com.fulcrumgenomics.testing.{SamBuilder, UnitSpec}
+import com.fulcrumgenomics.umi.UmiConsensusCaller.{ConsensusKvMetric, RejectionReason}
+import com.fulcrumgenomics.util.Metric
 import com.fulcrumgenomics.umi.VanillaUmiConsensusCallerOptions._
 
 /**
@@ -131,6 +133,7 @@ class CallMolecularConsensusReadsTest extends UnitSpec {
       val rlen    = 100
       val output  = newBam
       val rejects = newBam
+      val stats   = makeTempFile("call_molecular_consensus_reads_test.", ".txt")
 
       new CallMolecularConsensusReads(
         input       = halfMappedFamily(rlen).toTempFile(),
@@ -138,6 +141,7 @@ class CallMolecularConsensusReadsTest extends UnitSpec {
         minReads    = 1,
         maxReads    = Some(maxReads),
         rejects     = Some(rejects),
+        stats       = Some(stats),
         readGroupId = "ABC"
       ).execute()
 
@@ -156,8 +160,14 @@ class CallMolecularConsensusReadsTest extends UnitSpec {
       r2[Int](ConsensusTags.PerRead.RawReadCount) shouldBe 2
       r2.basesString shouldBe "C" * rlen
 
-      // The unmapped R2 must not have been used, whether it was rejected by the caller or filtered before reaching it.
-      readBamRecs(rejects).foreach { rec => rec.name shouldBe "halfmapped:3" }
+      // The unmapped R2 must not have been used, and must be accounted for rather than vanishing:
+      // it is written to the rejects BAM and counted under its own rejection reason.
+      val rejected = readBamRecs(rejects)
+      rejected.map(rec => (rec.name, rec.secondOfPair)) should contain theSameElementsAs Seq(("halfmapped:3", true))
+
+      val metrics = Metric.read[ConsensusKvMetric](stats).map(m => m.key -> m.value.toString).toMap
+      metrics(s"raw_reads_rejected_for_${RejectionReason.Unmapped.code}") shouldBe "1"
+      metrics("raw_reads_considered") shouldBe "6"
     }
   }
 }


### PR DESCRIPTION
**Stacked on #1168** — base is `nh_test-consensus-cap-half-mapped-pair`, so review that one first. The diff here is the third commit only.

## Problem

#1168 stopped unmapped reads contributing to consensus reads by dropping them in `ConsensusCallingIterator`'s pre-group filter. That fixed the defect but made the reads invisible: they were never counted in `raw_reads_considered`, carried no rejection reason, and never reached `--rejects`.

A read that disappears between input and output with nothing in the metrics to explain it is hard to tell apart from a bug. It also sits awkwardly next to every other way a read can be excluded from a consensus, all of which are counted and emitted.

## Fix

Move the decision from the iterator into `UmiConsensusCaller.consensusReadsFromSamRecords` — the `final` method every caller funnels through — and reject via a new `RejectionReason.Unmapped`:

```scala
val (mapped, unmapped) = recs.partition(_.mapped)
if (unmapped.nonEmpty) rejectRecords(unmapped, RejectionReason.Unmapped)
```

Structural coverage of all three tools is preserved, and because the rejection now happens on the caller, the counts aggregate through `addStatistics` exactly as every other reason does — including under `--threads > 1`, where each thread has its own caller via `emptyClone()`.

The iterator's predicate returns to `mapped || (paired && mateMapped)`. Templates with no mapped read at all are still dropped there, unchanged; only the unmapped end of a half-mapped pair now flows through to be rejected explicitly.

The reason is marked as used by all three callers (`usedByVanilla`/`usedByDuplex`/`usedByCodec` all true), so `raw_reads_rejected_for_unmapped` is initialised to zero and appears in every stats file rather than materialising only when it fires.

## Behaviour

For input containing half-mapped pairs, relative to #1168:

- `raw_reads_considered` counts the unmapped read again, as it did before #1168
- `raw_reads_rejected_for_unmapped` is a new key in the stats output
- the unmapped read appears in `--rejects`, tagged with the `rr` rejection-reason tag like any other rejected record

No change to which reads contribute to a consensus — #1168 settled that, and its tests still pin it.

## Tests

`CallMolecularConsensusReadsTest`'s two cases are tightened from a permissive check to exact assertions: the precise rejects content, the new `raw_reads_rejected_for_unmapped` count, and `raw_reads_considered`. The permissive form was deliberate in #1168 so it would hold under either accounting choice; now that the choice is made, it pins it.

Full suite: 1608 tests, 0 failures.

## Note on fgumi parity

I originally raised this as an fgbio-vs-fgumi asymmetry. That framing was not quite right and is worth stating plainly: fgumi's default path *also* drops unmapped reads silently, in `consensus_pregroup_keep_raw`, which is a plain record filter that records nothing. Its `RejectionReason::Unmapped` fires only on the `--allow-unmapped` path.

So this change is not restoring parity — it puts fgbio ahead, and the equivalent accounting on the fgumi default path (fulcrumgenomics/fgumi#737) is now the gap. Worth doing there too, but it does not belong in that PR either.
