### PR TITLE
fix(umi): AnnotateBamWithUmis should not fail on UMIs without BAM records

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/AnnotateBamWithUmis.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/AnnotateBamWithUmis.scala
@@ -54,7 +54,8 @@ import com.fulcrumgenomics.util.{ProgressLogger, ReadStructure, SegmentType}
     |sorted in the same order as the BAM file.
     |
     |At the end of execution, reports how many records were processed and how many were
-    |missing UMIs. If any read from the BAM file did not have a matching UMI read in the
+    |missing UMIs.  All records are written to the output, whether or not a UMI was found.
+    |If any read from the BAM file did not have a matching UMI read in the
     |FASTQ file, the program will exit with a non-zero exit status.  The `--fail-fast` option
     |may be specified to cause the program to terminate the first time it finds a records
     |without a matching UMI.
@@ -65,7 +66,7 @@ import com.fulcrumgenomics.util.{ProgressLogger, ReadStructure, SegmentType}
     |files assuming they are in the same order.  More precisely, the UMI fastq file will be
     |traversed first, reading in the next set of BAM reads with same read name as the
     |UMI's read name.  Those BAM reads will be annotated.  If no BAM reads exist for the UMI,
-    |no logging or error will be reported.
+    |the UMI is skipped and counted, but is not an error.
   """,
   group = ClpGroups.SamOrBam)
 class AnnotateBamWithUmis(
@@ -93,10 +94,14 @@ class AnnotateBamWithUmis(
     else Seq.tabulate(fastq.length)(_ => readStructure.head)
   }
 
+  /** The number of BAM records with no UMI in the FASTQ(s); an error. */
   private var missingUmis: Long = 0
 
+  /** The number of UMIs skipped for having no BAM records; `--sorted` only, and not an error. */
+  private var skippedUmis: Long = 0
+
   /** Updates the count of missing UMI records, and throws an exception if fail-fast is true. */
-  private def logMissingUmi(readName: String): Unit = {
+  private def countMissingUmi(readName: String): Unit = {
     missingUmis += 1
     if (failFast) fail("Record '" + readName + "' in BAM file not found in FASTQ file.")
   }
@@ -124,11 +129,11 @@ class AnnotateBamWithUmis(
       val fastqIter = FastqSource.zipped(sources=fqSources)
       val samIter   = in.iterator.bufferBetter
 
-      while (samIter.hasNext) {
-        if (fastqIter.isEmpty) fail(s"No more FASTQ records but more SAM records. Next SAM record: ${samIter.next().name}")
+      while (samIter.hasNext && fastqIter.hasNext) {
         val fqRecs  = fastqIter.next()
         val records = samIter.takeWhile(_.name == fqRecs.head.name).toIndexedSeq
-        if (records.isEmpty) logMissingUmi(fqRecs.head.name) else {
+        if (records.isEmpty) skippedUmis += 1
+        else {
           val umis = fqRecs.zip(structures).flatMap { case (rec, structure) =>
             extractUmis(rec=rec, structure=structure)
           }
@@ -141,9 +146,10 @@ class AnnotateBamWithUmis(
         }
       }
       fqSources.foreach(_.close())
-      // Log any BAM records that were not annotated
+      // Any remaining BAM records have no UMI; write them out un-annotated
       samIter.foreach { rec =>
-        logMissingUmi(rec.name)
+        countMissingUmi(rec.name)
+        out += rec
         progress.record(rec)
       }
     } else {
@@ -161,7 +167,7 @@ class AnnotateBamWithUmis(
           case Some(umis) =>
             rec(attribute) = umis.map(_.bases).mkString("-")
             qualAttribute.foreach(qtag => rec(qtag) = umis.map(_.quals).mkString(" "))
-          case None       => logMissingUmi(name)
+          case None       => countMissingUmi(name)
         }
         out += rec
         progress.record(rec)
@@ -171,6 +177,7 @@ class AnnotateBamWithUmis(
     // Finish up
     out.close()
     logger.info(s"Processed ${progress.getCount} records with $missingUmis missing UMIs.")
-    if (missingUmis > 0) fail(exit=missingUmis.toInt)
+    if (skippedUmis > 0) logger.info(s"Skipped $skippedUmis UMIs with no corresponding records.")
+    if (missingUmis > 0) fail(s"Found $missingUmis BAM record(s) with no UMI in the FASTQ(s).")
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/umi/AnnotateBamWithUmisTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/AnnotateBamWithUmisTest.scala
@@ -24,9 +24,11 @@
  */
 package com.fulcrumgenomics.umi
 
+import com.fulcrumgenomics.FgBioDef.PathToFastq
 import com.fulcrumgenomics.bam.api.SamSource
 import com.fulcrumgenomics.cmdline.FgBioMain.FailureException
 import com.fulcrumgenomics.commons.io.PathUtil
+import com.fulcrumgenomics.fastq.{FastqRecord, FastqSource, FastqWriter}
 import com.fulcrumgenomics.testing.UnitSpec
 import com.fulcrumgenomics.util.{Io, ReadStructure}
 
@@ -40,6 +42,25 @@ class AnnotateBamWithUmisTest extends UnitSpec {
   private val fq      = dir.resolve("annotate_umis.fastq")
   private val umiTag  = "RX"
   private val qualTag = "QX"
+
+  /** The number of records in the input SAM. */
+  private val numSamRecords: Long = readBamRecs(sam).length.toLong
+
+  /** The UMIs in the input FASTQ, in the same order as the input SAM. */
+  private val umis: IndexedSeq[FastqRecord] = FastqSource(fq).toIndexedSeq
+
+  /** A UMI whose read name is not in the input SAM. */
+  private val extraUmi = FastqRecord(name="not_a_flowcell:1:1101:10003:3200", bases="GATCTTGG",
+    quals="-,86,,;:", comment=Some("2:N:0:19"), readNumber=Some(2))
+
+  /** Writes the given UMIs to a FASTQ. */
+  private def writeUmis(recs: IterableOnce[FastqRecord]): PathToFastq = {
+    val path   = makeTempFile("umis.", ".fq")
+    val writer = FastqWriter(path)
+    recs.iterator.foreach(writer.write)
+    writer.close()
+    path
+  }
 
   "AnnotateBamWithUmis" should "successfully add UMIs to a BAM" in {
     val out = makeTempFile("with_umis.", ".bam")
@@ -87,12 +108,12 @@ class AnnotateBamWithUmisTest extends UnitSpec {
     an[FailureException] shouldBe thrownBy { annotator.execute() }
   }
 
-  it should "fail if one or more reads doesn't have a UMI when the fastq is sorted" in {
-    val out     = makeTempFile("with_umis.", ".bam")
-    val shortFq = makeTempFile(s"missing_umis.", ".fq.gz")
-    Io.writeLines(shortFq, Io.readLines(fq).toSeq.dropRight(8))
+  it should "fail but still output all records if one or more reads doesn't have a UMI when the fastq is sorted" in {
+    val out       = makeTempFile("with_umis.", ".bam")
+    val shortFq   = writeUmis(umis.dropRight(2))
     val annotator = new AnnotateBamWithUmis(input=sam, fastq=Seq(shortFq), output=out, attribute=umiTag, sorted=true)
     an[FailureException] shouldBe thrownBy { annotator.execute() }
+    readBamRecs(out) should have size numSamRecords
   }
 
   it should "not fail if there are extra reads in the fastq not in the bam" in {
@@ -107,16 +128,42 @@ class AnnotateBamWithUmisTest extends UnitSpec {
     })
   }
 
-  it should "not fail if there are extra reads in the fastq not in the bam when the fastq is sorted" in {
-    val out      = makeTempFile("with_umis.", ".bam")
-    val longFq   = makeTempFile(s"extra_umis.", ".fq.gz")
-    val lines    = Io.readLines(fq) ++ Seq("@not_a_flowcell:1:1101:10060:3200/2 2:N:0:19","GATCTTGG","+","-,86,,;:")
-    Io.writeLines(longFq, lines)
+  it should "not fail if there are extra reads at the end of the fastq not in the bam when the fastq is sorted" in {
+    val out       = makeTempFile("with_umis.", ".bam")
+    val longFq    = writeUmis(umis :+ extraUmi)
     val annotator = new AnnotateBamWithUmis(input=sam, fastq=Seq(longFq), output=out, attribute=umiTag, sorted=true)
     annotator.execute()
-    SamSource(out).foreach(rec => {
-      rec[String](umiTag) shouldBe rec.basesString.substring(0,8)
-    })
+    val recs = readBamRecs(out)
+    recs should have size numSamRecords
+    recs.foreach(rec => rec[String](umiTag) shouldBe rec.basesString.substring(0,8))
+  }
+
+  it should "not fail if there are extra reads in the middle of the fastq when the fastq is sorted" in {
+    val out       = makeTempFile("with_umis.", ".bam")
+    val longFq    = writeUmis(umis.patch(1, Seq(extraUmi), 0))
+    val annotator = new AnnotateBamWithUmis(input=sam, fastq=Seq(longFq), output=out, attribute=umiTag, sorted=true)
+    annotator.execute()
+    val recs = readBamRecs(out)
+    recs should have size numSamRecords
+    recs.foreach(rec => rec[String](umiTag) shouldBe rec.basesString.substring(0,8))
+  }
+
+  it should "not fail fast if there are extra reads in the fastq not in the bam when the fastq is sorted" in {
+    val out       = makeTempFile("with_umis.", ".bam")
+    val longFq    = writeUmis(umis.patch(1, Seq(extraUmi), 0))
+    val annotator = new AnnotateBamWithUmis(input=sam, fastq=Seq(longFq), output=out, attribute=umiTag, sorted=true, failFast=true)
+    annotator.execute()
+    readBamRecs(out) should have size numSamRecords
+  }
+
+  it should "fail fast on the first read without a UMI" in {
+    Seq(true, false).foreach { sorted =>
+      val out       = makeTempFile("with_umis.", ".bam")
+      val shortFq   = writeUmis(umis.dropRight(2))
+      val annotator = new AnnotateBamWithUmis(input=sam, fastq=Seq(shortFq), output=out, attribute=umiTag, sorted=sorted, failFast=true)
+      val ex        = intercept[FailureException] { annotator.execute() }
+      ex.message.value should include ("not found in FASTQ file")
+    }
   }
 
   it should "successfully add UMIs to a BAM with a given read structure" in {
@@ -198,13 +245,19 @@ class AnnotateBamWithUmisTest extends UnitSpec {
     an[FailureException] shouldBe thrownBy { annotator.execute() }
   }
 
-  it should "fail to add UMIs to a BAM with multiple FASTQs with extra lines and corresponding read structures when sorted is true" in {
+  it should "add UMIs to a BAM with multiple FASTQs with extra UMIs and corresponding read structures when sorted is true" in {
     val out = makeTempFile("with_umis.", ".bam")
-    val longFq = makeTempFile(s"extra_umis.", ".fq.gz")
-    Io.writeLines(longFq, Io.readLines(fq))
-    Io.writeLines(longFq, Seq("@not_a_flowcell:1:1101:10060:3200/2 2:N:0:19","GATCTTGG","+","-,86,,;:"))
+    val longFq = writeUmis(umis.patch(1, Seq(extraUmi), 0))
     val annotator = new AnnotateBamWithUmis(input=sam, fastq=Seq(longFq, longFq), readStructure=Seq(ReadStructure("2M4B+M"), ReadStructure("1B+M")), output=out, attribute=umiTag, sorted=true)
-    an[FailureException] shouldBe thrownBy { annotator.execute() }
+    annotator.execute()
+    val recs = readBamRecs(out)
+    recs should have size numSamRecords
+    recs.foreach { rec =>
+      val first  = rec.basesString.substring(0,2) // read one: [2M]4B+M
+      val second = rec.basesString.substring(6,8) // read one: 2M4B[+M]
+      val third  = rec.basesString.substring(1,8) // read two: 1B[+M]
+      rec[String](umiTag) shouldBe s"${first}-${second}-${third}"
+    }
   }
 
   it should "successfully add UMIs to a BAM using all bases from more than 3 FASTQs with a single read structure" in {


### PR DESCRIPTION
Fixes #1170.

With `--sorted`, a UMI in the FASTQ that has no corresponding BAM records was counted as a *missing UMI* and caused a non-zero exit with `Execution failed!`, even though the output BAM was complete and correctly annotated. This is the ordinary case when an upstream tool discards read pairs, and it contradicts the tool's own documentation: *"If no BAM reads exist for the UMI, no logging or error will be reported."*

The two conditions were sharing one counter, so the log message was also backwards — it reported "missing UMIs" when what was actually missing was *reads*. They are now tracked separately:

- **A UMI with no BAM records** is skipped, counted, and reported (`Skipped N UMIs with no corresponding records.`), and is not an error. This also correctly scopes `--fail-fast`, which is documented for BAM records without a matching UMI.
- **A BAM record with no UMI** remains counted, logged, and a non-zero exit.

This also changes `--fail-fast`: it no longer triggers on a UMI without BAM records, and in sorted mode it now names the read it failed on. Previously the sorted path could not report that condition at all — it died with `No more FASTQ records but more SAM records` instead. `--fail-fast` had no test coverage anywhere in the repo; it is now tested in both modes.

## History

This is a reintroduced regression, not a new bug. #735 fixed it in Oct 2021 (`records.nonEmpty`) and added the documentation sentence above; #657 rewrote the `--sorted` block for multi-FASTQ support two months later and restored `records.isEmpty` → `logMissingUmi`, reverting the fix while keeping its documentation. #735's fix therefore never appeared in a release: 1.4.0 predates it and 1.5.0 postdates the revert. The `while (samIter.hasNext)` guard added by #1055 covers extra FASTQ records only at the *end* of the file, so records in the middle — the reported case — still failed.

## Two related fixes

- **Output truncation.** A BAM record absent from the middle of the FASTQ consumed the remainder of the FASTQ looking for a match, then failed with `No more FASTQ records but more SAM records` *before* `out.close()`, leaving a zero-record output BAM. Remaining BAM records are now written out un-annotated before failing, matching the un-sorted path, which has always written records that had no UMI. The trailing `samIter.foreach` that was meant to do this was unreachable and never wrote records; it is now reachable and does.
- **Exit code and diagnostics.** `fail(exit=missingUmis.toInt)` exited **0** whenever the count was a multiple of 256 — logging `Execution failed!` while reporting success — and overflowed past 2^31. Failures now go through `fail(message)`, which takes exit 1 from `FailureException`'s default and prints the reason inside the fatal block, instead of leaving `Execution failed!` with no explanation.

Note that with equality-only name matching (`--sorted` promises identical order, not lexicographic sort) a BAM record missing from the middle of the FASTQ still costs the UMIs of every record after it. That remains a loud, counted failure with a complete output BAM, rather than a silent truncation.

## Tests

The tests for extra FASTQ records deserve their own note, since they are why the revert went unnoticed for four years.

- From #735 until #1047 they never called `annotator.execute()` — they constructed the tool, then iterated the empty temp file `makeTempFile` had created, which yields zero records without throwing. They passed unconditionally, which is how #657 reverted the fix with CI green. #1047 spotted this and commented the `--sorted` one out with `// TODO: write a test that actually tests this behavior.`; #1055 re-enabled it.
- Once re-enabled, the extra FASTQ record was appended to the **end** of the file, exactly the case the `hasNext` guard short-circuits before reaching it. Nothing covered a record mid-FASTQ.
- The multi-FASTQ "extra lines" test called `Io.writeLines` twice, and the second call overwrote the first — so the FASTQ held only the extra record, and the test passed for a reason unrelated to its name.

Added or repaired:

- extra UMI **mid-FASTQ**, single- and multi-FASTQ (both previously failed; the multi-FASTQ one is the repaired overwrite test, now asserting success)
- all records are written whether or not they were annotated, guarding the truncation bug (previously produced 0 of 10 records)
- record counts asserted alongside tag values, so a silently empty output BAM can no longer pass

Also folded into this change: the new missing-UMI test was byte-for-byte the existing `"fail if one or more reads doesn't have a UMI when the fastq is sorted"` test plus one assertion, so the two are now one test; FASTQ fixtures are built from `FastqRecord` via `FastqWriter` rather than raw lines, so record boundaries are no longer magic line counts (`grouped(4)`, `dropRight(8)`); reads-back use the existing `UnitSpec.readBamRecs`; and `numSamRecords` is derived from the fixture rather than hardcoded.

One failure assertion was deliberately dropped: the multi-FASTQ "extra lines" test called `Io.writeLines` twice and the second call overwrote the first, so its FASTQ held only the non-matching extra record — it asserted failure on "FASTQ far shorter than BAM", not on extra lines as its name claimed. That scenario stays covered by the multiple-truncated-FASTQs test; the repaired test now asserts the success its name always described.

Each new test was confirmed to fail against the unfixed code, both before and after that refactor. Full suite passes: 1614 tests.


