### PR TITLE
fix(bam): clip past the mate's end using query, not reference, distances

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/bam/SamRecordClipper.scala
+++ b/src/main/scala/com/fulcrumgenomics/bam/SamRecordClipper.scala
@@ -324,27 +324,150 @@ class SamRecordClipper(val mode: ClippingMode, val autoClipAttributes: Boolean) 
     }
   }
 
-  /** Returns the number of bases extending past the mate end for FR pairs including any soft-clipped bases, zero otherwise.
+  /** Returns the number of query bases at the 3' end of a record that extend past the 3' end of its mate, for FR pairs,
+    * and zero otherwise.
+    *
+    * The two reads of an FR pair sequence the same insert from opposite ends, so beyond the last reference position
+    * that both alignments cover they must have sequenced the same number of insert bases.  Any query bases a record has
+    * beyond that count are read-through past the end of the insert (i.e. into the adapter).  Both counts are taken in
+    * _query_ space so that an indel near the end of either alignment does not skew the comparison; the shared reference
+    * position is used only as the landmark from which to count.
+    *
+    * Soft-clipped bases are counted, since they are query bases that may still belong to the insert.  Hard-clipped
+    * bases are not, since they are not present in the record.
+    *
+    * When the two alignments share no reference position there is no landmark to count from, and the count falls back
+    * to `numBasesExtendingPastDisjointMate` below.
     *
     * @param rec the record to examine
-    * @param mateUnSoftClippedStart the smallest mapped genomic coordinate considering *ONLY* soft-clipping
-    * @param mateUnSoftClippedEnd the largest mapped genomic coordinate considering *ONLY* soft-clipping
+    * @param mateStart the alignment start of the mate
+    * @param mateCigar the alignment cigar of the mate
+    * @return the number of query bases to clip from the 3' end of the record (in sequencing order)
     */
-  def numBasesExtendingPastMate(rec: SamRecord, mateUnSoftClippedStart: Int, mateUnSoftClippedEnd: Int): Int = {
-    if (!rec.isFrPair) 0 else rec.positiveStrand match {
-      case true if rec.end >= mateUnSoftClippedEnd =>
-        // positive strand record is aligned to/past the mate alignment end: count any bases aligned/soft-clipped after
-        Math.max(0, rec.length - rec.readPosAtRefPos(pos=mateUnSoftClippedEnd, returnLastBaseIfDeleted=false))
-      case true =>
-        // positive strand record alignment ends before the mate alignment end: remove any excess soft-clipped reads
-        Math.max(0, rec.cigar.trailingSoftClippedBases - (mateUnSoftClippedEnd - rec.end))
-      case false if rec.start > mateUnSoftClippedStart =>
-        // negative strand record alignment starts after the mate alignment start: remove any excess soft-clipped reads
-        Math.max(0, rec.cigar.leadingSoftClippedBases - (rec.start - mateUnSoftClippedStart))
-      case false =>
-        // negative strand record alignment starts at or before the mate start: count up to and including one base before
-        Math.max(0, rec.readPosAtRefPos(pos=mateUnSoftClippedStart, returnLastBaseIfDeleted=false) - 1)
+  def numBasesExtendingPastMate(rec: SamRecord, mateStart: Int, mateCigar: Cigar): Int = {
+    if (!rec.isFrPair) 0 else {
+      val mateEnd      = mateStart + mateCigar.lengthOnTarget - 1
+      val overlapStart = Math.max(rec.start, mateStart)
+      val overlapEnd   = Math.min(rec.end, mateEnd)
+      if (overlapEnd < overlapStart) numBasesExtendingPastDisjointMate(rec, mateStart, mateCigar, mateEnd)
+      else if (rec.positiveStrand) {
+        // The 3' end of a positive strand record is its right-hand end, so count from the last shared position.
+        val recBases  = numQueryBasesAfter(start=rec.start, cigar=rec.cigar, refPos=overlapEnd)
+        val mateBases = numQueryBasesAfter(start=mateStart, cigar=mateCigar, refPos=overlapEnd)
+        Math.max(0, recBases - mateBases)
+      }
+      else {
+        // The 3' end of a negative strand record is its left-hand end, so count from the first shared position.
+        val recBases  = numQueryBasesBefore(start=rec.start, cigar=rec.cigar, refPos=overlapStart)
+        val mateBases = numQueryBasesBefore(start=mateStart, cigar=mateCigar, refPos=overlapStart)
+        Math.max(0, recBases - mateBases)
+      }
     }
+  }
+
+  /** Returns the number of query bases at the 3' end of a record that extend past the 3' end of its mate, when the two
+    * alignments cover no reference position in common.
+    *
+    * With no shared position there is no landmark to count query bases from, so the record's own soft-clipped tail is
+    * projected into reference space at one query base per reference base and compared against the mate's
+    * un-soft-clipped far end — the estimate this function has applied since #842.  Two reads can absolutely have read
+    * through into each other's adapter here: both alignments lie within the insert, so a short insert read from both
+    * ends leaves them disjoint whenever each alignment stops short of the other's, which soft clipping at a variant or
+    * a mis-called base is enough to produce.  The extrapolation is exact whenever the region between the two
+    * alignments is ungapped, and it is continuous with the query-space count above, which reduces to exactly this
+    * expression as the shared span shrinks to a single reference position.
+    *
+    * The reference/query conflation that the query-space count exists to avoid cannot bite here: neither alignment
+    * places a base between the two, so neither can place an indel between them either.  An indel in the sample that
+    * falls in that gap is invisible to both reads and shifts the estimate by its own length, in either direction; the
+    * result is capped by the record's soft clipping regardless, so no aligned base is ever removed on the strength of
+    * it.
+    *
+    * A record whose 3' end points away from its mate — a positive strand record lying entirely to the right of its
+    * mate, or a negative strand record entirely to its left — describes an outward-facing template rather than
+    * read-through, and nothing is clipped.
+    *
+    * @param rec the record to examine
+    * @param mateStart the alignment start of the mate
+    * @param mateCigar the alignment cigar of the mate
+    * @param mateEnd the alignment end of the mate, which the only caller has already computed
+    * @return the number of query bases to clip from the 3' end of the record (in sequencing order)
+    */
+  private def numBasesExtendingPastDisjointMate(rec: SamRecord, mateStart: Int, mateCigar: Cigar, mateEnd: Int): Int = {
+    if (rec.positiveStrand && rec.end < mateStart) {
+      val mateUnSoftClippedEnd = mateEnd + mateCigar.trailingSoftClippedBases
+      Math.max(0, rec.cigar.trailingSoftClippedBases - (mateUnSoftClippedEnd - rec.end))
+    }
+    else if (rec.negativeStrand && rec.start > mateEnd) {
+      val mateUnSoftClippedStart = mateStart - mateCigar.leadingSoftClippedBases
+      Math.max(0, rec.cigar.leadingSoftClippedBases - (rec.start - mateUnSoftClippedStart))
+    }
+    else 0
+  }
+
+  /** Returns the number of query bases in an alignment that lie to the right of the given reference position.
+    *
+    * Inserted and soft-clipped bases are counted when they follow the last query base at or before the given position.
+    * If the position falls within a deletion or skipped region then no query base is at the position, and every query
+    * base after the gap is counted.  Hard-clipped bases are never counted since they are not present in the record.
+    *
+    * @param start the alignment start of the alignment
+    * @param cigar the cigar of the alignment
+    * @param refPos the reference position, which must fall within the aligned span of the alignment
+    */
+  private def numQueryBasesAfter(start: Int, cigar: Cigar, refPos: Int): Int = {
+    require(start <= refPos && refPos <= start + cigar.lengthOnTarget - 1,
+      s"Reference position $refPos is outside the aligned span of $cigar at $start.")
+    var numAtOrBefore = 0
+    var refCur        = start
+    var done          = false
+    val iter          = cigar.iterator
+    while (!done && iter.hasNext) {
+      val elem = iter.next()
+      if (elem.operator.consumesReferenceBases()) {
+        val refLast = refCur + elem.length - 1
+        if (refLast <= refPos) { numAtOrBefore += elem.lengthOnQuery; refCur = refLast + 1 }
+        else { // the position falls within this element; count only the query bases up to and including it
+          if (elem.operator.consumesReadBases()) numAtOrBefore += refPos - refCur + 1
+          done = true
+        }
+      }
+      else if (refCur > refPos) done = true // the element lies to the right of the position
+      else numAtOrBefore += elem.lengthOnQuery
+    }
+    cigar.lengthOnQuery - numAtOrBefore
+  }
+
+  /** Returns the number of query bases in an alignment that lie to the left of the given reference position.
+    *
+    * Inserted and soft-clipped bases are counted when they precede the first query base at or after the given position.
+    * If the position falls within a deletion or skipped region then no query base is at the position, and every query
+    * base before the gap is counted.  Hard-clipped bases are never counted since they are not present in the record.
+    *
+    * @param start the alignment start of the alignment
+    * @param cigar the cigar of the alignment
+    * @param refPos the reference position, which must fall within the aligned span of the alignment
+    */
+  private def numQueryBasesBefore(start: Int, cigar: Cigar, refPos: Int): Int = {
+    require(start <= refPos && refPos <= start + cigar.lengthOnTarget - 1,
+      s"Reference position $refPos is outside the aligned span of $cigar at $start.")
+    var numBefore = 0
+    var refCur    = start
+    var done      = false
+    val iter      = cigar.iterator
+    while (!done && iter.hasNext) {
+      val elem = iter.next()
+      if (elem.operator.consumesReferenceBases()) {
+        val refLast = refCur + elem.length - 1
+        if (refLast < refPos) { numBefore += elem.lengthOnQuery; refCur = refLast + 1 }
+        else { // the position falls within this element; count only the query bases strictly before it
+          if (elem.operator.consumesReadBases()) numBefore += refPos - refCur
+          done = true
+        }
+      }
+      else numBefore += elem.lengthOnQuery // refCur is always <= refPos here, so the element lies to the left
+    }
+    numBefore
   }
 
   /** Clips the reads in FR read pairs whose alignments extend beyond the far end of their mate's alignment.
@@ -354,43 +477,29 @@ class SamRecordClipper(val mode: ClippingMode, val autoClipAttributes: Boolean) 
     * @return the additional number of bases clipped (3' end in sequencing order) for the read and mate respectively
     */
   def clipExtendingPastMateEnds(rec: SamRecord, mate: SamRecord): (Int, Int) = {
-    if (rec.isFrPair) {
-      val basesClipped1 = clipExtendingPastMateEnd(
-        rec                    = rec,
-        mateUnSoftClippedStart = mate.unSoftClippedStart,
-        mateUnSoftClippedEnd   = mate.unSoftClippedEnd,
-      )
-      val basesClipped2 = clipExtendingPastMateEnd(
-        rec                    = mate,
-        mateUnSoftClippedStart = rec.unSoftClippedStart,
-        mateUnSoftClippedEnd   = rec.unSoftClippedEnd,
-      )
-      (basesClipped1, basesClipped2)
-    }
+    if (!rec.isFrPair) (0, 0)
     else {
-      (0, 0)
+      // NB: both amounts must be computed before either read is clipped, otherwise the second read is compared against
+      // an alignment that has already been shortened (or, if the first read was clipped away entirely, un-mapped).
+      val numBases1 = numBasesExtendingPastMate(rec=rec, mateStart=mate.start, mateCigar=mate.cigar)
+      val numBases2 = numBasesExtendingPastMate(rec=mate, mateStart=rec.start, mateCigar=rec.cigar)
+      (clipExtendingPastMateEnd(rec, numBases1), clipExtendingPastMateEnd(mate, numBases2))
     }
   }
 
-  /** Clips the read in FR read pairs whose alignments extend beyond the far end of their mate's alignment.
+  /** Clips the given number of query bases from the 3' end of a read.
     *
     * @param rec the record to clip
-    * @param mateUnSoftClippedStart the smallest mapped genomic coordinate considering *ONLY* soft-clipping
-    * @param mateUnSoftClippedEnd the largest mapped genomic coordinate considering *ONLY* soft-clipping
+    * @param numBases the number of query bases present in the record to clip from its 3' end
     * @return the additional number of bases clipped (3' end in sequencing order)
     */
-  private def clipExtendingPastMateEnd(rec: SamRecord, mateUnSoftClippedStart: Int, mateUnSoftClippedEnd: Int): Int = {
-    if (!rec.isFrPair) 0 // do not overlap, don't clip
-    else {
-      val totalClippedBases = numBasesExtendingPastMate(
-        rec                    = rec,
-        mateUnSoftClippedStart = mateUnSoftClippedStart,
-        mateUnSoftClippedEnd   = mateUnSoftClippedEnd,
-      )
-      if (totalClippedBases == 0) 0 else {
-       if (rec.positiveStrand) this.clipEndOfRead(rec, totalClippedBases)
-       else this.clipStartOfRead(rec, totalClippedBases)
-      }
+  private def clipExtendingPastMateEnd(rec: SamRecord, numBases: Int): Int = {
+    if (numBases <= 0) 0 else {
+      // NB: clip3PrimeEndOfRead takes the total clipping desired _including_ any existing clipping, while numBases
+      // counts only bases present in the record, so any existing hard-clipping at that end must be added back in.
+      val cigar                = rec.cigar
+      val existingHardClipping = if (rec.negativeStrand) cigar.leadingHardClippedBases else cigar.trailingHardClippedBases
+      this.clip3PrimeEndOfRead(rec, numBases + existingHardClipping)
     }
   }
 

--- a/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/UmiConsensusCaller.scala
@@ -292,12 +292,11 @@ trait UmiConsensusCaller[ConsensusRead <: SimpleRead] {
       var index = if (!rec.isFrPair) trimToLength - 1 else {
         // Get the number of mapped bases to clip that maps beyond the mate's end, including any soft-clipped bases. Use
         // that to compute where in the read to keep.
-        val mateUnSoftClippedStart = rec.mateUnSoftClippedStart.getOrElse(throw new IllegalArgumentException(f"Mate cigar (MC SAM tag) needed for read: ${rec.name}"))
-        val mateUnSoftClippedEnd   = rec.mateUnSoftClippedEnd.getOrElse(throw new IllegalArgumentException(f"Mate cigar (MC SAM tag) needed for read: ${rec.name}"))
+        val mateCigar = rec.mateCigar.getOrElse(throw new IllegalArgumentException(f"Mate cigar (MC SAM tag) needed for read: ${rec.name}"))
         val clipPosition = rec.length - this.clipper.numBasesExtendingPastMate(
-          rec                    = rec,
-          mateUnSoftClippedStart = mateUnSoftClippedStart,
-          mateUnSoftClippedEnd   = mateUnSoftClippedEnd,
+          rec       = rec,
+          mateStart = rec.mateStart,
+          mateCigar = mateCigar,
         )
         min(clipPosition, trimToLength) - 1
       }

--- a/src/test/scala/com/fulcrumgenomics/bam/SamRecordClipperTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/SamRecordClipperTest.scala
@@ -878,6 +878,78 @@ class SamRecordClipperTest extends UnitSpec with OptionValues {
     mate.cigar.toString shouldBe "40M20I40M"
   }
 
+  // The last reference position shared by the two reads is 149.  The record has 50 query bases after it (aligned) and
+  // the mate has 10 (soft-clipped), so 40 bases are removed from the record.  Symmetrically, the first shared
+  // reference position is 100, before which the record has no query bases and the mate has 40, so 40 bases are removed
+  // from the mate.  There are no indels here, so this is the control case that must be unaffected by the fix for
+  // https://github.com/fulcrumgenomics/fgbio/issues/1090.
+  it should "clip back to the mate's soft-clipped end when neither read contains an indel" in {
+    val (rec, mate) = pair(100, "100M", Plus, 60, "90M10S", Minus)
+    clipper(Soft).clipExtendingPastMateEnds(rec=rec, mate=mate) shouldBe (40, 40)
+    rec.start shouldBe 100
+    rec.cigar.toString shouldBe "60M40S"
+    mate.start shouldBe 100
+    mate.cigar.toString shouldBe "40S50M10S"
+  }
+
+  // Regression test for https://github.com/fulcrumgenomics/fgbio/issues/1090.  The mate's un-soft-clipped end
+  // (223 + 2 = 225) is a reference position built by adding a query distance (the mate's trailing soft-clipping) to a
+  // reference position, and it happens to land inside the record's deletion.  The reads share reference positions
+  // through 223; after it the record has four query bases and the mate has two, so only two bases may be clipped.
+  it should "clip using query distances when a deletion falls at the mate's un-soft-clipped end" in {
+    val (rec, mate) = pair(101, "2S124M1D3M", Plus, 100, "3S124M2S", Minus)
+    clipper(Soft).clipExtendingPastMateEnds(rec=rec, mate=mate) shouldBe (2, 0)
+    rec.mapped shouldBe true
+    rec.start shouldBe 101
+    rec.cigar.toString shouldBe "2S124M1D1M2S"
+    mate.mapped shouldBe true
+    mate.start shouldBe 100
+    mate.cigar.toString shouldBe "3S124M2S"
+  }
+
+  // A second regression test for https://github.com/fulcrumgenomics/fgbio/issues/1090 that pins the knock-on effect on
+  // the mate: over-clipping the record un-maps it, and the mate is then compared against an un-mapped record and so is
+  // left unclipped.  Both reads must be clipped here, and the amount clipped from each must not depend on the other
+  // read having been clipped first.
+  it should "clip the mate even when the record's deletion falls at the mate's un-soft-clipped end" in {
+    val (rec, mate) = pair(101, "2S124M1D3M", Plus, 97, "115M14S", Minus)
+    clipper(Soft).clipExtendingPastMateEnds(rec=rec, mate=mate) shouldBe (2, 2)
+    rec.mapped shouldBe true
+    rec.start shouldBe 101
+    rec.cigar.toString shouldBe "2S124M1D1M2S"
+    mate.mapped shouldBe true
+    mate.start shouldBe 99
+    mate.cigar.toString shouldBe "2S113M14S"
+  }
+
+  // The example from https://github.com/fulcrumgenomics/fgbio/issues/1090.  The reads share reference positions
+  // through 169; after it the record has 80 query bases (10 inserted, 23 aligned and 47 soft-clipped) and the mate has
+  // 30 (all soft-clipped), so 50 bases are removed from the record.  Comparing reference distances instead under-clips
+  // here, since the insertion makes the record's alignment end 10 reference bases short of where its query bases reach.
+  it should "clip using query distances when the record contains an insertion before the mate's end" in {
+    val (rec, mate) = pair(100, "70M10I23M47S", Plus, 100, "50S70M30S", Minus)
+    clipper(Hard).clipExtendingPastMateEnds(rec=rec, mate=mate) shouldBe (3, 0) // 3 aligned bases clipped from the record
+    rec.start shouldBe 100
+    rec.cigar.toString shouldBe "70M10I20M50H"
+    mate.start shouldBe 100
+    mate.cigar.toString shouldBe "50H70M30S"
+  }
+
+  // Bases already hard-clipped from the 3' end are not present in the record, so they must not be counted towards the
+  // clipping that is applied, otherwise the requested clipping is silently absorbed by the existing hard-clipping.
+  it should "clip past the mate's end when the read has already been hard-clipped at its 3' end" in {
+    val (rec, mate) = pair(100, "100M", Plus, 60, "90M10S", Minus)
+    clipper(Hard).clip3PrimeEndOfRead(rec, 10) shouldBe 10
+    clipper(Hard).clip3PrimeEndOfRead(mate, 10) shouldBe 10
+    rec.cigar.toString shouldBe "90M10H"
+    mate.cigar.toString shouldBe "10H80M10S"
+    clipper(Hard).clipExtendingPastMateEnds(rec=rec, mate=mate) shouldBe (30, 30)
+    rec.start shouldBe 100
+    rec.cigar.toString shouldBe "60M40H"
+    mate.start shouldBe 100
+    mate.cigar.toString shouldBe "40H50M10S"
+  }
+
   "SamRecordClipper.numBasesExtendingPastMate" should "return zero when reads do not extend past the end or are not FR pairs" in {
     val builder = new SamBuilder()
     val Seq(r1, r2) = builder.addPair(start1=100, start2=200, cigar1="20S80M", cigar2="10S90M")
@@ -892,13 +964,8 @@ class SamRecordClipperTest extends UnitSpec with OptionValues {
 
   /** Convenience method for testing numBasesExtendingPastMate */
   def numBasesExtendingPastMate(clipper: SamRecordClipper, rec: SamRecord): Int = {
-    val mateUnSoftClippedStart = rec.mateUnSoftClippedStart.getOrElse(throw new IllegalStateException(f"Mate cigar (MC SAM tag) needed for read: ${rec.name}"))
-    val mateUnSoftClippedEnd   = rec.mateUnSoftClippedEnd.getOrElse(throw new IllegalStateException(f"Mate cigar (MC SAM tag) needed for read: ${rec.name}"))
-    clipper.numBasesExtendingPastMate(
-      rec                    = rec,
-      mateUnSoftClippedStart = mateUnSoftClippedStart,
-      mateUnSoftClippedEnd   = mateUnSoftClippedEnd,
-    )
+    val mateCigar = rec.mateCigar.getOrElse(throw new IllegalStateException(f"Mate cigar (MC SAM tag) needed for read: ${rec.name}"))
+    clipper.numBasesExtendingPastMate(rec=rec, mateStart=rec.mateStart, mateCigar=mateCigar)
   }
 
   it should "return a return a positive value when reads extend past its mate" in {
@@ -932,5 +999,62 @@ class SamRecordClipperTest extends UnitSpec with OptionValues {
     val Seq(r9, r10) = builder.addPair(start1=100, start2=100, cigar1="30S70M", cigar2="50S50M")
     numBasesExtendingPastMate(clipper(Soft), r9) shouldBe 20
     numBasesExtendingPastMate(clipper(Soft), r10) shouldBe 20
+  }
+
+  it should "count query bases, not reference bases, when an indel is present near the end of an alignment" in {
+    val builder = new SamBuilder(readLength=129)
+
+    // The reads share reference positions through 223, after which r1 has four query bases (the last base of its 124M
+    // at 224 and the three bases of its trailing 3M at 226-228; the deleted position 225 contributes no query base)
+    // and r2 has two (its trailing 2S).  The first shared reference position is 101, before which r1 has two query
+    // bases (its leading 2S) and r2 has four (its leading 3S plus the base at 100).
+    val Seq(r1, r2) = builder.addPair(start1=101, start2=100, cigar1="2S124M1D3M", cigar2="3S124M2S")
+    numBasesExtendingPastMate(clipper(Soft), r1) shouldBe 2
+    numBasesExtendingPastMate(clipper(Soft), r2) shouldBe 2
+
+    // The reads share reference positions through 169, after which r3 has 80 query bases (10 inserted, 23 aligned and
+    // 47 soft-clipped) and r4 has 30 (all soft-clipped).  The first shared reference position is 100, before which r3
+    // has no query bases and r4 has 50.
+    val builder2    = new SamBuilder(readLength=150)
+    val Seq(r3, r4) = builder2.addPair(start1=100, start2=100, cigar1="70M10I23M47S", cigar2="50S70M30S")
+    numBasesExtendingPastMate(clipper(Soft), r3) shouldBe 50
+    numBasesExtendingPastMate(clipper(Soft), r4) shouldBe 50
+  }
+
+  // Both alignments lie within the insert, so a pair that reads through into the adapter can still leave them
+  // disjoint: here each 100 base read aligns only its first 20 bases and soft-clips the rest, over an insert of 39
+  // reference bases.  With the mate at 1019 the two alignments share exactly one reference position, 1019, past which
+  // the record has all 80 of its soft-clipped bases and the mate has 19, so 61 bases of read-through are clipped from
+  // each.  Moving the mate one base to the right removes that shared position, and the answer must not jump: the
+  // insert is one base longer, so one fewer base of each read is read-through.  Comparing the record's soft-clipped
+  // extent against the mate's un-soft-clipped end is what carries the count across that boundary, and no indel can lie
+  // between two alignments that place no bases between them.
+  it should "clip the read-through of a pair whose alignments share no reference position" in {
+    val Seq(r1, r2) = new SamBuilder(readLength=100).addPair(start1=1000, start2=1019, cigar1="20M80S", cigar2="80S20M")
+    numBasesExtendingPastMate(clipper(Soft), r1) shouldBe 61
+    numBasesExtendingPastMate(clipper(Soft), r2) shouldBe 61
+
+    val Seq(r3, r4) = new SamBuilder(readLength=100).addPair(start1=1000, start2=1020, cigar1="20M80S", cigar2="80S20M")
+    numBasesExtendingPastMate(clipper(Soft), r3) shouldBe 60
+    numBasesExtendingPastMate(clipper(Soft), r4) shouldBe 60
+
+    // The count is bounded by the record's own soft clipping, so applying it takes no aligned base: hard-clipping
+    // shows exactly which bases go, where soft-clipping them again would be invisible.
+    clipper(Hard).clipExtendingPastMateEnds(rec=r3, mate=r4) shouldBe (0, 0) // No aligned bases clipped
+    r3.start shouldBe 1000
+    r3.cigar.toString shouldBe "20M20S60H"
+    r4.start shouldBe 1020
+    r4.cigar.toString shouldBe "60H20S20M"
+  }
+
+  // The mate's alignment is supplied by the caller — from the MC tag in practice — and is never cross-checked against
+  // what the record's own flags say about the pair, so a record can be classified as one end of an FR pair while the
+  // mate alignment in hand lies entirely to its left.  Its 3' end then points away from that mate, which describes an
+  // outward-facing template rather than read-through, and nothing may be clipped: there is no estimate to make, and
+  // the record's aligned bases are not the ones to spend on a geometry this function cannot verify.
+  it should "not clip a record lying entirely past the mate alignment it is given" in {
+    val (rec, _) = pair(301, "15M", Plus, 300, "10M5S", Minus)
+    rec.isFrPair shouldBe true
+    clipper(Soft).numBasesExtendingPastMate(rec=rec, mateStart=101, mateCigar=Cigar("10M5S")) shouldBe 0
   }
 }


### PR DESCRIPTION
Fixes #1090.

`SamRecordClipper`'s "clip past the far end of the mate" functions mixed reference-space and query-space distances. `numBasesExtendingPastMate` took the mate's *un-soft-clipped* end — a reference coordinate produced by adding the mate's trailing soft-clip *length* (a query distance) to its alignment end — and then converted that coordinate back into a query offset on the record with `readPosAtRefPos`. With no indels the two spaces coincide and the answer is right; with an indel near either end of either alignment they diverge, and the read is over- or under-clipped.

Two concrete failure modes, both reachable in duplex consensus calling of libraries with adapter read-through:

- **Over-clipping.** If the synthesized coordinate lands inside a deletion in the record, `readPosAtRefPos(..., returnLastBaseIfDeleted=false)` returns `0`, so the computed clip becomes the record's entire length and the record is un-mapped outright. Worse, the mate was then clipped against the just-un-mapped record and so was left unclipped, which can take out a whole template.
- **Under-clipping.** If the record has an insertion before that coordinate, its alignment end falls short of where its query bases reach, so the record keeps bases past the end of the insert (the example in the issue).

## What changed

`numBasesExtendingPastMate` now works entirely in query space, using a shared reference position only as a landmark, as described in the issue:

1. Find the reference positions covered by both alignments.
2. Count how many query bases each read has beyond the relevant end of that shared span — the last shared position for a positive-strand record (its 3' end is on the right), the first shared position for a negative-strand record.
3. Both reads sequenced the same insert, so they must have the same number of query bases beyond that landmark. The excess is what is clipped.

### When the two alignments share no reference position

There is no landmark to count from, so this case keeps the estimate `numBasesExtendingPastMate` has applied since #842: project the record's soft-clipped tail into reference space at one query base per reference base and compare it against the mate's un-soft-clipped far end.

Answering `0` here — which an earlier revision of this PR did — is wrong, and the reason is worth stating, because "no overlap means no read-through" is the intuitive reading and it is false. Both alignments lie *within* the insert, so a pair that read through into the adapter can still leave them disjoint: it happens whenever each alignment stops short of the other's, which soft clipping at a variant or a mis-called base is enough to produce. Concretely, two 100 base reads over a 39 base insert, aligned `20M80S` at 1000 and `80S20M` at 1019, share exactly one reference position and give up 61 bases each. Move the mate one base right and they share none — the insert is one base longer, so the answer must be 60, not 0. The extrapolation is the analytic continuation of the query-space count, which reduces to exactly that expression as the shared span shrinks to a single position.

It is also safe against the defect this PR fixes. Neither alignment places a base between the two, so neither can place an indel between them, and the reference/query conflation cannot arise. An indel in the *sample* that falls in the gap is invisible to both reads and shifts the estimate by its own length in either direction, but the result is capped by the record's own soft clipping, so no aligned base is ever removed on the strength of it. #842 added this branch for exactly this reason: without it, "the `numBasesExtendingPastMate` function always returned 0 [...] generally resulting in reads now failing when they used to pass" in `FilterConsensusReads`.

A record whose 3' end points *away* from a mate it does not overlap is a different case and is not clipped at all — that describes an outward-facing template rather than read-through. The mate's alignment is supplied by the caller, so it can contradict what the record's own flags say about the pair, and measuring such a record against the landscape like any other would count every one of its query bases as past the mate and take its aligned ones.

### Counting

Counting is done by walking the cigar directly rather than by calling `readPosAtRefPos`, which makes the deletion case explicit instead of relying on the `returnLastBaseIfDeleted` flag: a position inside a deletion has no query base, and every query base past the gap is counted. Soft-clipped bases still count as insert bases, preserving the less-aggressive behavior introduced in #1026; hard-clipped bases do not, since they are not present in the record.

Two smaller correctness fixes in the same functions, both needed to make the above land correctly:

- `clipExtendingPastMateEnds` now computes both clipping amounts *before* clipping either read. Previously the mate was measured against an alignment the first call had already shortened (or un-mapped), which made the result order-dependent.
- Existing hard-clipping at the 3' end is now added back in when calling `clipEndOfRead` / `clipStartOfRead`, which take the *total* clipping desired including what is already there. Without this, requested clipping is silently absorbed by pre-existing hard-clipping — reachable in `ClipBam`, which applies fixed 3' clipping before this step. This mirrors what `clipOverlappingReads` already does.

## API change

`numBasesExtendingPastMate` now takes the mate's alignment start and cigar instead of its un-soft-clipped start and end. The old parameters cannot express the mate's indel structure, which the query-space count requires. Both in-tree callers already have the mate's cigar available (`UmiConsensusCaller` via the `MC` tag, which it already ensures is set).

## Notes

The `ClipOverlapFailed` branch in `CodecConsensusCaller` carries a `// TODO remove this branch once SamRecordClipper has been updated` comment referring to this bug. It is left in place: `computeConsensusLength` has its own reference/query-space assumptions and can still return a length shorter than one of the consensus reads, so the branch has not been proven dead. Removing it is a separate change.

## Tests

All new tests fail on `main` and pass here, except where noted:

- `clip back to the mate's soft-clipped end when neither read contains an indel` — control; passes before and after, pins that the indel-free path (including soft-clip-aware trimming from #1026) is unchanged.
- `clip using query distances when a deletion falls at the mate's un-soft-clipped end` — the over-clipping case. Was `(127, 0)` with the record un-mapped; now `(2, 0)`.
- `clip the mate even when the record's deletion falls at the mate's un-soft-clipped end` — pins the knock-on effect on the mate. Was `(127, 0)` with the mate untouched; now `(2, 2)`.
- `clip using query distances when the record contains an insertion before the mate's end` — the example from the issue, which produces exactly the `70M10I20M50H` the issue asks for. Was `(0, 0)`.
- `clip past the mate's end when the read has already been hard-clipped at its 3' end` — pins the hard-clipping fix. Was `(20, 20)`; now `(30, 30)`.
- `count query bases, not reference bases, when an indel is present near the end of an alignment` — unit coverage of `numBasesExtendingPastMate` itself for both the deletion and insertion cases.
- `clip the read-through of a pair whose alignments share no reference position` — the continuity pair above (61 with one shared position, 60 with none), on both strands, plus a hard-clip assertion pinning that neither record loses an aligned base. Passes before and after; it fails against a version of this PR that answers 0 when the alignments are disjoint.
- `not clip a record lying entirely past the mate alignment it is given` — the outward-facing guard.

All existing `SamRecordClipper` tests are unchanged and still pass.

## Verification beyond the unit tests

The new counts were checked out-of-tree against an independent oracle built from htsjdk's per-base `getReferencePositionAtReadPosition` — a different code path from the cigar walk — over a randomized sweep of cigars:

- 3,911 random FR pairs (1,995 of them containing an indel): `numBasesExtendingPastMate` matched the oracle on every one.
- 3,925 random indel-free FR pairs: matched the **pre-fix** formula exactly, confirming the change is a no-op when neither alignment has an indel near the relevant end.
- 2,863 overlapping FR pairs, in both soft- and hard-clip mode: neither read is ever un-mapped, at least the computed excess is clipped from each 3' end, and a second pass clips nothing further.
- Across 29,246 indel-bearing evaluations the pre-fix formula disagreed with the fix 1,338 times (4.6%), by a mean of 6.7 query bases and a maximum of 92 (an entire read). 92 of those were whole-read over-clips — cases where the old code returned a clip at least as long as the read and would therefore have un-mapped it.

A second sweep, over a set of 20,000 randomly generated FR pairs (100 base reads, leading and trailing soft clips 0-80, mate offsets −160 to +260, half carrying an indel) that deliberately spans overlapping, touching and **disjoint** geometries rather than only overlapping ones:

- 40,000 evaluations, both strands. **662 differ from the pre-fix formula, and every one of them is on a pair carrying an indel** — all 9,210 indel-free evaluations are unchanged. The largest disagreement is 99 bases, a whole-read over-clip the pre-fix formula produced from a deletion at the synthesized boundary.
- The same 20,000 pairs were run against [fulcrumgenomics/fgumi#759](https://github.com/fulcrumgenomics/fgumi/pull/759), an independent rework of the same arithmetic in a different language, with **zero disagreements**.

That second sweep is what caught the disjoint case. The earlier randomized sweep above generated only overlapping pairs, so it could not see it: an intermediate revision of this PR answered 0 for disjoint pairs, which differed from the pre-fix formula on 28 indel-free evaluations in the new set.

One pre-existing behavior worth noting, unchanged here: `clip()` never splits an insertion, so if the clip boundary falls inside one the whole insertion is clipped. The applied clipping can therefore exceed the computed excess by up to (insertion length − 1).

