### PR TITLE
fix(umi): measure the CODEC overlap as the intersection of the two alignments

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/CodecConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CodecConsensusCaller.scala
@@ -208,9 +208,15 @@ class CodecConsensusCaller(readNamePrefix: String,
           if (longestR1Alignment.positiveStrand) (longestR1Alignment, longestR2Alignment)
           else (longestR2Alignment, longestR1Alignment)
 
-        // Calculate the overlapping region in reference space; this calculation only works because we
-        // can assert from checks above that we have an FR pair that sequences towards each other.
-        val (overlapStart, overlapEnd) = (longestNegAln.start, longestPosAln.end)
+        // Calculate the overlapping region in reference space, which is the intersection of the aligned
+        // spans of the two alignments.  The checks above assert that we have an FR pair that sequences
+        // towards each other, but that does not stop the two alignments from dovetailing (each ending
+        // past the far end of the other), so the intersection must be taken rather than assumed to run
+        // from the negative strand alignment's start to the positive strand alignment's end.  Reference
+        // positions outside the intersection are aligned over by at most one of the two reads, so
+        // neither the phase check nor the consensus length below can be evaluated there.
+        val overlapStart  = Math.max(longestPosAln.start, longestNegAln.start)
+        val overlapEnd    = Math.min(longestPosAln.end, longestNegAln.end)
         val overlapLength = overlapEnd - overlapStart + 1
 
         // If the overlap isn't long enough then reject the records and return no consensus reads
@@ -238,7 +244,7 @@ class CodecConsensusCaller(readNamePrefix: String,
           if (longestR1Alignment.negativeStrand) r1Consensus.revcomp() else r2Consensus.revcomp()
 
           // Calculate the length of the consensus
-          computeConsensusLength(longestPosAln, longestNegAln) match {
+          computeConsensusLength(longestPosAln, longestNegAln, overlapEnd) match {
             case -1 =>
               rejectRecords((r1s.view ++ r2s.view).flatMap(_.sam), RejectionReason.IndelErrorBetweenStrands)
               Nil
@@ -281,13 +287,16 @@ class CodecConsensusCaller(readNamePrefix: String,
   }
 
   /**
-    * Computes the length of the consensus read that should be generated. The provided positive and
-    * negative strand alignments _must_ overlap.
+    * Computes the length of the consensus read that should be generated.
     *
     * Returns -1 if the length couldn't be computed because the overlap of the reads ends on an indel.
+    *
+    * @param pos the positive strand alignment
+    * @param neg the negative strand alignment
+    * @param refOverlapEnd the last reference position that both alignments are aligned over; both
+    *                      alignments _must_ span it
     */
-  private def computeConsensusLength(pos: SamRecord, neg: SamRecord): Int = {
-    val refOverlapEnd = pos.end
+  private def computeConsensusLength(pos: SamRecord, neg: SamRecord, refOverlapEnd: Int): Int = {
     val posReadPos = pos.readPosAtRefPos(refOverlapEnd, returnLastBaseIfDeleted=false)
     val negReadPos = neg.readPosAtRefPos(refOverlapEnd, returnLastBaseIfDeleted=false)
     if (posReadPos == 0 || negReadPos == 0) -1 else {

--- a/src/test/scala/com/fulcrumgenomics/umi/CodecConsensusCallerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/CodecConsensusCallerTest.scala
@@ -179,6 +179,57 @@ class CodecConsensusCallerTest extends UnitSpec with OptionValues {
     cons.head[String](ConsensusTags.UmiBases) shouldBe "ACC-TGA"
   }
 
+  it should "make a consensus from a dovetailed pair whose alignments have no indels" in {
+    // Both reads sequenced the same 40 base insert, but the aligner soft-clipped a different end of
+    // each, so each alignment extends past the far end of the other: R2 starts before R1 starts _and_
+    // R1 ends after R2 ends. There is no indel in either cigar, so nothing about this pair is out of
+    // phase; the two alignments simply overlap over a narrower region (111-130, 20 bases) than the
+    // 40 base span that runs from R2's start to R1's end.
+    val insert = RefBases.substring(100, 140)
+    def dovetailedPair: Seq[SamRecord] = new SamBuilder(readLength=insert.length, baseQuality=35).addPair(
+      contig=0, start1=111, start2=101, cigar1="10S30M", cigar2="30M10S",
+      bases1=insert, bases2=insert, attrs=Map(("RX", "ACC-TGA"), ("MI", "hi"))
+    )
+    val cons = new CodecConsensusCaller(readNamePrefix="codec", minReadsPerStrand=1, minDuplexLength=1)
+      .consensusReadsFromSamRecords(dovetailedPair)
+
+    cons should have length 1
+    cons.head.length shouldBe insert.length
+    cons.head.basesString shouldBe insert
+    cons.head[String](ConsensusTags.UmiBases) shouldBe "ACC-TGA"
+
+    // The duplex region is gated on the 20 reference bases the two alignments share, not on the wider
+    // span they jointly cover.
+    new CodecConsensusCaller(readNamePrefix="codec", minReadsPerStrand=1, minDuplexLength=20)
+      .consensusReadsFromSamRecords(dovetailedPair) should have length 1
+
+    new CodecConsensusCaller(readNamePrefix="codec", minReadsPerStrand=1, minDuplexLength=21)
+      .consensusReadsFromSamRecords(dovetailedPair) shouldBe Seq()
+  }
+
+  it should "make a consensus when one strand's alignment runs through a deletion past the other's aligned end" in {
+    // Both reads sequenced the same 127 base insert plus two bases of read-through, which the clipper
+    // removes. The positive strand alignment runs through a single base deletion that sits beyond the
+    // aligned end of the negative strand alignment, which soft-clipped its last two bases instead. The
+    // two alignments therefore agree exactly everywhere they are both aligned, and the deletion is not
+    // evidence that the strands disagree.
+    val posBases = RefBases.substring(98, 224) + RefBases.substring(225, 228)
+    val negBases = RefBases.substring(96, 224) + RefBases.substring(225, 226)
+    val expected = RefBases.substring(98, 224) + RefBases.substring(225, 226)
+    val builder  = new SamBuilder(readLength=posBases.length, baseQuality=35)
+    val caller   = new CodecConsensusCaller(readNamePrefix="codec", minReadsPerStrand=1, minDuplexLength=1)
+    val raw      = builder.addPair(
+      contig=0, start1=101, start2=100, cigar1="2S124M1D3M", cigar2="3S124M2S",
+      bases1=posBases, bases2=negBases, attrs=Map(("RX", "ACC-TGA"), ("MI", "hi"))
+    )
+    val cons = caller.consensusReadsFromSamRecords(raw)
+
+    cons should have length 1
+    cons.head.length shouldBe expected.length
+    cons.head.basesString shouldBe expected
+    cons.head[String](ConsensusTags.UmiBases) shouldBe "ACC-TGA"
+  }
+
   it should "emit the consensus in the orientation of R1" in {
     val builder = new SamBuilder(readLength=30, baseQuality=35)
     val caller  = new CodecConsensusCaller(readNamePrefix="codec", minReadsPerStrand=1, minDuplexLength=1)
@@ -291,6 +342,22 @@ class CodecConsensusCallerTest extends UnitSpec with OptionValues {
 
     new CodecConsensusCaller(readNamePrefix="codec", minReadsPerStrand=1, minDuplexLength=1)
       .consensusReadsFromSamRecords(raw) shouldBe Seq()
+  }
+
+  it should "not emit a consensus when the alignments disagree by an indel inside their overlap" in {
+    // The deletion sits strictly inside the region both alignments are aligned over, so the two strands
+    // genuinely disagree about how many query bases span it and the reads cannot be brought into phase.
+    val builder = new SamBuilder(readLength=60, baseQuality=35)
+    val raw = builder.addPair(
+      contig=0, start1=101, start2=103, cigar1="60M", cigar2="30M2D30M", attrs=Map(("RX", "ACC-TGA"), ("MI", "hi"))
+    ).tapEach(setReadSequence)
+
+    new CodecConsensusCaller(readNamePrefix="codec", minReadsPerStrand=1, minDuplexLength=1)
+      .consensusReadsFromSamRecords(raw) shouldBe Seq()
+    raw.foreach { rec =>
+      rec[String](UmiConsensusCaller.RejectReasonTag) shouldBe
+        UmiConsensusCaller.RejectionReason.IndelErrorBetweenStrands.code
+    }
   }
 
   it should "not emit a consensus when there are a lot of disagreements between strands of the duplex" in {


### PR DESCRIPTION
Fixes #1173.

**Stacked on #1172** — the base of this branch is `nh_fix-clip-past-mate-query-space`, so the diff to review is the single commit `fix(umi): measure the CODEC overlap as the intersection of the two alignments`. Both defects are independent (each of the two tests added here fails on `main` too), but they meet on the same read pair, so it is easier to reason about them in order.

`CodecConsensusCaller` took the region over which R1 and R2 overlap to run from the negative strand alignment's start to the positive strand alignment's end:

```scala
val (overlapStart, overlapEnd) = (longestNegAln.start, longestPosAln.end)
```

That equals the intersection of the two aligned spans only when one alignment is contained within the span of the other. An FR pair sequences its two reads towards each other, which is what the old comment appealed to, but that does not stop the two alignments from dovetailing — each ending past the far end of the other — and for such a pair the region above includes reference positions that only one of the two reads is aligned over.

`readPosAtRefPos` returns 0 at a position outside an alignment, so the phase check compared a real query offset at one end of the region against a zero at the other and concluded the strands were out of phase. Every dovetailed pair was rejected as `IndelErrorBetweenStrands` — including pairs whose cigars contain no indel at all, which is the first test added here. `computeConsensusLength` measured at `pos.end` for the same reason and returned `-1` whenever the negative strand alignment stopped short of it.

The fix takes the intersection explicitly and measures the consensus length at its end, which is the last reference position both alignments span. For every pair whose positive strand alignment starts and ends at or before the negative strand alignment's, the two formulas agree, so nothing changes outside the dovetailed case — the five existing positive tests and the two existing negative indel tests are unmoved.

### Tests

- **A dovetailed pair with no indels.** Two reads over the same 40 base insert, `10S30M` at 111 and `30M10S` at 101, so R2 starts before R1 starts and R1 ends after R2 ends. Rejected as `IndelErrorBetweenStrands` before; now emits the 40 base consensus. The test also pins the `--min-duplex-length` boundary at the 20 shared reference bases rather than the 40 base joint span.
- **A terminal deletion beyond the other strand's aligned end.** `2S124M1D3M` at 101 against `3S124M2S` at 100 over a shared 127 base insert plus read-through. After clipping the two reads are identical and in register, and the deletion is at a position only the positive strand read is aligned over. Now emits the 127 base consensus.
- **Control: a deletion strictly inside the overlap still rejects.** `60M` at 101 against `30M2D30M` at 103. Asserts the reject-reason tag is `indel_error_between_strands` rather than just an empty result, so the control fails if the pair is dropped for some other reason.

### CI

CI cannot pass on this repo right now: every job fails at Checkout with `This repository exceeded its LFS budget` before any Scala compiles. Unrelated to this change and not fixable from a PR — it needs an org admin to raise the budget. Verified locally instead: the full suite is green (1623 tests, 0 failures).
