### PR TITLE
refactor(umi): replace redundant isPrimaryFrPair with SamRecord.isFrPair (htsjdk 5.0.0)

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/umi/CodecConsensusCaller.scala
+++ b/src/main/scala/com/fulcrumgenomics/umi/CodecConsensusCaller.scala
@@ -32,7 +32,6 @@ import com.fulcrumgenomics.umi.UmiConsensusCaller.{ConsensusKvMetric, ReadType, 
 import com.fulcrumgenomics.util.NumericTypes.PhredScore
 import com.fulcrumgenomics.util.Sequences
 import htsjdk.samtools.SAMTag
-import htsjdk.samtools.SamPairUtil.PairOrientation
 
 import scala.collection.mutable
 
@@ -174,11 +173,10 @@ class CodecConsensusCaller(readNamePrefix: String,
     }
     else {
       // Group the primary alignments by read name and retain only templates that form a single
-      // primary FR pair. The FR check is performed at the pair level (via `isPrimaryFrPair`)
-      // because htsjdk's per-record `SamPairUtil.getPairOrientation` historically disagreed
-      // between mates on dovetail pairs whose aligned ends coincided, which previously caused a
-      // `scala.MatchError` on a singleton read-name bucket here. See
-      // https://github.com/samtools/htsjdk/pull/1771 for the upstream fix (htsjdk 5.0.0+).
+      // FR pair. `SamRecord.isFrPair` is symmetric between mates on dovetail pairs whose aligned
+      // ends coincide as of htsjdk 5.0.0, which fixed the per-record `SamPairUtil.getPairOrientation`
+      // asymmetry (samtools/htsjdk#1771), so it is evaluated on `a` directly here. The `case _`
+      // arm keeps a singleton read-name bucket from raising a `scala.MatchError`.
       // Template order is preserved from BAM-iteration order (not hash order) so that downstream
       // `maxBy` tie-breaks on `cigar.lengthOnTarget` are stable across JVMs.
       // TODO: handle chimeric reads or reads with one unmapped etc.
@@ -186,7 +184,7 @@ class CodecConsensusCaller(readNamePrefix: String,
         pairs.filterNot(r => r.secondary || r.supplementary)
       )
       val (frPairs, nonFrPairs) = primaryPairs.partition {
-        case (_, Seq(a, b)) => CodecConsensusCaller.isPrimaryFrPair(a, b)
+        case (_, Seq(a, _)) => a.isFrPair
         case _              => false
       }
       rejectRecords(nonFrPairs.flatMap(_._2), RejectionReason.NotPrimaryFrPair)
@@ -409,26 +407,5 @@ object CodecConsensusCaller {
     val byName = mutable.LinkedHashMap.empty[String, mutable.ArrayBuffer[SamRecord]]
     records.foreach { rec => byName.getOrElseUpdate(rec.name, mutable.ArrayBuffer.empty) += rec }
     byName.iterator.map { case (name, recs) => (name, recs.toSeq) }.toSeq
-  }
-
-  /** Returns true if the two records form an FR pair, computing the answer symmetrically in
-    * its arguments. After validating that both records are mapped to the same contig on
-    * opposite strands, delegates to htsjdk's `SamPairUtil.getPairOrientation` evaluated on
-    * the reverse-strand record: that branch derives both 5' positions from CIGARs
-    * (`mate.alignmentStart` vs `record.alignmentEnd`) and is independent of MC/TLEN, so the
-    * answer is consistent regardless of which record of the pair this is called with. See
-    * https://github.com/samtools/htsjdk/pull/1771 (htsjdk 5.0.0+) for the underlying
-    * per-record asymmetry this avoids; once we no longer need to support older htsjdk
-    * versions for this caller, this helper can be replaced with `SamRecord.isFrPair`.
-    */
-  private[umi] def isPrimaryFrPair(a: SamRecord, b: SamRecord): Boolean = {
-    if (!a.mapped || !b.mapped) false
-    else if (!a.mateMapped || !b.mateMapped) false
-    else if (a.refIndex != b.refIndex) false
-    else if (a.positiveStrand == b.positiveStrand) false
-    else {
-      val rev = if (a.positiveStrand) b else a
-      rev.pairOrientation == PairOrientation.FR
-    }
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/bam/api/SamRecordTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/bam/api/SamRecordTest.scala
@@ -57,6 +57,15 @@ class SamRecordTest extends UnitSpec with OptionValues {
     builder.addPair(start1=100, start2=200, strand1=Plus, strand2=Minus).forall(_.isFrPair)  shouldBe true
   }
 
+  it should "return true symmetrically on a dovetail FR pair whose aligned ends coincide" in {
+    // htsjdk 5.0.0 (samtools/htsjdk#1771) fixed the per-record getPairOrientation asymmetry, so
+    // isFrPair now agrees for both mates of a dovetail pair. Before 5.0.0 the forward read, whose
+    // branch derived the mate 5' position from TLEN, reported non-FR here.
+    val builder = new SamBuilder(readLength=129, baseQuality=20)
+    builder.addPair(contig=0, start1=96, start2=49, cigar1="68S53M8S", cigar2="28S48M53S")
+      .forall(_.isFrPair) shouldBe true
+  }
+
   "SamRecord.cigar" should "always return the latest/correct cigar, when when SAMRecord methods are used" in {
     val builder = new SamBuilder(readLength=50)
     val rec = builder.addFrag(start=10, cigar="50M").get

--- a/src/test/scala/com/fulcrumgenomics/umi/CodecConsensusCallerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/umi/CodecConsensusCallerTest.scala
@@ -353,57 +353,6 @@ class CodecConsensusCallerTest extends UnitSpec with OptionValues {
   }
 
   //////////////////////////////////////////////////////////////////////////////
-  // Tests for isPrimaryFrPair
-  //////////////////////////////////////////////////////////////////////////////
-
-  "CodecConsensusCaller.isPrimaryFrPair" should "classify a dovetail FR pair as FR regardless of argument order" in {
-    val builder = new SamBuilder(readLength=129, baseQuality=35)
-    val pair = builder.addPair(
-      contig=0, start1=96, start2=49, cigar1="68S53M8S", cigar2="28S48M53S"
-    ).tapEach(setReadSequence)
-    val r1 = pair.head
-    val r2 = pair.last
-    CodecConsensusCaller.isPrimaryFrPair(r1, r2) shouldBe true
-    CodecConsensusCaller.isPrimaryFrPair(r2, r1) shouldBe true
-  }
-
-  it should "classify a typical FR pair as FR" in {
-    val builder = new SamBuilder(readLength=30, baseQuality=35)
-    val Seq(r1, r2) = builder.addPair(contig=0, start1=10, start2=50).toSeq
-    CodecConsensusCaller.isPrimaryFrPair(r1, r2) shouldBe true
-  }
-
-  it should "classify an RF pair as not FR" in {
-    val builder = new SamBuilder(readLength=30, baseQuality=35)
-    val Seq(r1, r2) = builder.addPair(
-      contig=0, start1=50, start2=100, strand1=Minus, strand2=Plus
-    ).toSeq
-    CodecConsensusCaller.isPrimaryFrPair(r1, r2) shouldBe false
-  }
-
-  it should "reject cross-chromosomal pairs" in {
-    val builder = new SamBuilder(readLength=30, baseQuality=35)
-    val Seq(r1, r2) = builder.addPair(contig=0, start1=10, start2=50).toSeq
-    r1.refIndex = 0
-    r2.refIndex = 1
-    CodecConsensusCaller.isPrimaryFrPair(r1, r2) shouldBe false
-  }
-
-  it should "reject a pair with one mate unmapped" in {
-    val builder = new SamBuilder(readLength=30, baseQuality=35)
-    val Seq(r1, r2) = builder.addPair(contig=0, start1=10, start2=10, unmapped2=true).toSeq
-    CodecConsensusCaller.isPrimaryFrPair(r1, r2) shouldBe false
-  }
-
-  it should "reject a tandem pair" in {
-    val builder = new SamBuilder(readLength=30, baseQuality=35)
-    val Seq(r1, r2) = builder.addPair(
-      contig=0, start1=10, start2=50, strand1=Plus, strand2=Plus
-    ).toSeq
-    CodecConsensusCaller.isPrimaryFrPair(r1, r2) shouldBe false
-  }
-
-  //////////////////////////////////////////////////////////////////////////////
   // Tests for quality masking
   //////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Closes #1178.

`CodecConsensusCaller.isPrimaryFrPair` was added to work around htsjdk's pre-5.0.0 per-record `SamPairUtil.getPairOrientation` asymmetry on dovetail FR pairs whose aligned ends coincide — it evaluated orientation on the reverse-strand record, a CIGAR-derived branch that is consistent regardless of which mate it is called with. Its own doc comment noted it "can be replaced with `SamRecord.isFrPair`" once we no longer support older htsjdk.

We now depend on **htsjdk 5.0.0** (`build.sbt`), which includes samtools/htsjdk#1771, so per-record `SamRecord.isFrPair` is symmetric-correct on dovetails and the helper is redundant.

## Changes

- `CodecConsensusCaller.scala`: replace the pair-level predicate at the primary-pair `partition` with `a.isFrPair`; delete the private `isPrimaryFrPair` helper and its now-unused `PairOrientation` import; update the surrounding comment. The `case _ => false` arm (singleton read-name bucket `MatchError` guard) is retained.
- Tests: remove the `CodecConsensusCaller.isPrimaryFrPair` unit block (its typical-FR / RF / cross-chromosomal / one-mate-unmapped / tandem cases are already covered by `SamRecordTest.isFrPair`), and add its unique dovetail case to `SamRecordTest` as a `SamRecord.isFrPair` symmetric-on-dovetail assertion. The end-to-end `CodecConsensusCallerTest` dovetail test ("not throw on an FR dovetail pair whose aligned ends coincide") is unchanged and still passes.

No behavior change on htsjdk 5.0.0. Verified: `CodecConsensusCallerTest` and `SamRecordTest` green (including the dovetail cases).
